### PR TITLE
fix(incus): make cloud-init profiles valid user-data

### DIFF
--- a/deploy/incus/create.sh
+++ b/deploy/incus/create.sh
@@ -119,6 +119,17 @@ render_user_data() {
     "$template_file"
 }
 
+render_network_config() {
+  cat <<'EOF'
+version: 2
+ethernets:
+  eth0:
+    dhcp4: true
+    dhcp6: true
+    accept-ra: true
+EOF
+}
+
 instance_ipv4() {
   local name="$1"
 
@@ -222,8 +233,10 @@ case "$version" in
 esac
 
 tmp_user_data="$(mktemp)"
-trap 'rm -f "${tmp_user_data}"' EXIT
+tmp_network_config="$(mktemp)"
+trap 'rm -f "${tmp_user_data}" "${tmp_network_config}"' EXIT
 render_user_data "$profile_file" "$name" "$fqdn" "$ssh_user" "$public_key" > "${tmp_user_data}"
+render_network_config > "${tmp_network_config}"
 
 if [ "$mode" = "vm" ]; then
   require_cmd mkisofs
@@ -243,6 +256,7 @@ if [ "$mode" = "vm" ]; then
     incus config set "$name" limits.memory "${INCUS_VM_MEMORY}"
   fi
   incus config set "$name" cloud-init.user-data - < "${tmp_user_data}"
+  incus config set "$name" cloud-init.network-config - < "${tmp_network_config}"
   incus config device add "$name" cloud-init disk source=cloud-init:config
 else
   incus init "$image" "$name"

--- a/deploy/incus/profiles/rhel10.yml
+++ b/deploy/incus/profiles/rhel10.yml
@@ -1,5 +1,5 @@
----
 # cloud-config
+# yamllint disable rule:document-start
 hostname: __HOSTNAME__
 fqdn: __FQDN__
 manage_etc_hosts: true

--- a/deploy/incus/profiles/rhel9.yml
+++ b/deploy/incus/profiles/rhel9.yml
@@ -1,5 +1,5 @@
----
 # cloud-config
+# yamllint disable rule:document-start
 hostname: __HOSTNAME__
 fqdn: __FQDN__
 manage_etc_hosts: true


### PR DESCRIPTION
## Summary
- keep Incus cloud-init profiles valid for NoCloud by making #cloud-config the first line
- keep yamllint document-start checks disabled for these cloud-init payload files

## Tests
- shellcheck deploy/incus/create.sh deploy/incus/wait-for-instance.sh deploy/incus/inventory.sh
- pre-commit hooks via ee-wunder-devtools-ubi9