### PR TITLE
fix(incus): use exact cloud-config header

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,3 +5,5 @@ exclude_paths:
   - .ansible/
   - collections/
   - .pre-commit-config.yaml
+  - deploy/incus/profiles/rhel9.yml
+  - deploy/incus/profiles/rhel10.yml

--- a/.yamllint
+++ b/.yamllint
@@ -1,6 +1,10 @@
 ---
 extends: default
 
+ignore: |
+  deploy/incus/profiles/rhel9.yml
+  deploy/incus/profiles/rhel10.yml
+
 rules:
   line-length:
     max: 120

--- a/deploy/incus/profiles/rhel10.yml
+++ b/deploy/incus/profiles/rhel10.yml
@@ -1,4 +1,4 @@
-# cloud-config
+#cloud-config
 # yamllint disable rule:document-start
 hostname: __HOSTNAME__
 fqdn: __FQDN__

--- a/deploy/incus/profiles/rhel9.yml
+++ b/deploy/incus/profiles/rhel9.yml
@@ -1,4 +1,4 @@
-# cloud-config
+#cloud-config
 # yamllint disable rule:document-start
 hostname: __HOSTNAME__
 fqdn: __FQDN__


### PR DESCRIPTION
## Summary
- use the exact #cloud-config header required by cloud-init NoCloud user-data
- keep lint exceptions scoped to the two Incus cloud-init payload files

## Tests
- pre-commit hooks via ee-wunder-devtools-ubi9