### PR TITLE
fix(aap): add installer diagnostics

### DIFF
--- a/roles/aap_deploy/README.md
+++ b/roles/aap_deploy/README.md
@@ -11,7 +11,8 @@ bundle mode.
   For ephemeral Incus VMs, keep the base image unregistered and run
   `playbooks/rhel_prepare.yml` before this role. That playbook composes
   `lit.rhel.rhsm`, `lit.rhel.repos`, and `lit.rhel.virtual_guest`.
-- `ansible-core`, `python3`, and `podman` on target host (managed by host prep if enabled).
+- `ansible-core`, `git`, `podman`, `rsync`, `tar`, and `unzip` on target host
+  (managed by host prep if enabled).
 - `infra.aap_utilities` collection installed in the execution environment.
 - A local AAP containerized setup bundle on the control node for real installer runs.
 - Enough local storage for bundle copy and extraction. Red Hat documents a minimum 60 GB
@@ -33,6 +34,9 @@ Key variables:
 - `aap_deploy_setup_prepare_process_template`
 - `aap_deploy_setup_install_force`
 - `aap_deploy_bundle_dir` (path containing `/bundle`)
+- `aap_deploy_installer_log_dir`
+- `aap_deploy_installer_diagnostics_enabled`
+- `aap_deploy_installer_diagnostics_log_tail_lines`
 - `aap_deploy_redis_mode` (`standalone` or `cluster`)
 - `aap_deploy_redis_hosts` (required when `aap_deploy_redis_mode=cluster`, at least 6 hosts)
 - `aap_deploy_growth_automationmetrics_host`
@@ -89,6 +93,8 @@ Vendor-driven installer behavior:
 - Role expects a controller-side bundle path and copies it to the managed host.
 - Role prepares the setup workspace and renders installer inventory via `infra.aap_utilities.aap_setup_prepare`.
 - Role runs the containerized installer via `infra.aap_utilities.aap_setup_install`.
+- Role writes the vendor installer Ansible log below `aap_deploy_installer_log_dir`.
+- On installer failure, role prints redacted diagnostics before returning failure.
 - Default bundle dir is `bundle` (relative to the extracted setup directory).
 
 ## Automation metrics service
@@ -163,7 +169,8 @@ RHEL 10 host prep:
   `ansible_distribution_major_version`, so RHEL 10 resolves to
   `rhel-10-for-<arch>-baseos-rpms` and `rhel-10-for-<arch>-appstream-rpms`.
 - Red Hat documents `ansible-core` from RHEL AppStream for installation on RHEL 10.
-  Host prep installs `ansible-core`, `python3`, and `podman`.
+  Host prep installs the packages required by the wrapper role and the upstream
+  `infra.aap_utilities.aap_setup_prepare` role.
 
 Satellite or baseline-managed repositories:
 

--- a/roles/aap_deploy/defaults/main.yml
+++ b/roles/aap_deploy/defaults/main.yml
@@ -95,6 +95,9 @@ aap_deploy_setup_prepare_process_template: true
 aap_deploy_setup_install_force: true
 aap_deploy_setup_install_extra_vars: {}
 aap_deploy_setup_install_extra_vars_files: []
+aap_deploy_installer_log_dir: "{{ aap_deploy_install_dir }}/logs"
+aap_deploy_installer_diagnostics_enabled: true
+aap_deploy_installer_diagnostics_log_tail_lines: 180
 
 # Effective installer admin passwords are resolved by shared role `aap`
 # from inventory inputs (`aap_*_admin_password_input`).

--- a/roles/aap_deploy/tasks/40_install.yml
+++ b/roles/aap_deploy/tasks/40_install.yml
@@ -23,30 +23,51 @@
     quiet: true
   no_log: "{{ aap_admin_passwords_no_log | default(true) }}"
 
-- name: Run AAP containerized installer via vendor role  # noqa var-naming[no-role-prefix]
-  ansible.builtin.include_role:
-    name: infra.aap_utilities.aap_setup_install
-    apply:
-      become: true
-      become_user: "{{ aap_deploy_install_user }}"
-      environment:
-        XDG_RUNTIME_DIR: "/run/user/{{ aap_deploy_install_user_uid }}"
-        DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ aap_deploy_install_user_uid }}/bus"
-  vars:
-    aap_setup_down_version: "{{ aap_deploy_setup_download_version }}"
-    aap_setup_containerized: "{{ aap_deploy_setup_download_containerized }}"
-    aap_setup_inst_containerized: "{{ aap_deploy_setup_download_containerized }}"
-    aap_setup_inst_setup_dir: "{{ aap_setup_prep_setup_dir }}"
-    aap_setup_prep_inv_nodes: "{{ aap_deploy_setup_prep_inv_nodes }}"
-    aap_setup_prep_inv_vars: "{{ aap_deploy_setup_prep_inv_vars }}"
-    aap_setup_prep_inv_secrets: "{{ aap_deploy_setup_prep_inv_secrets }}"
-    aap_setup_inst_force: "{{ aap_deploy_setup_install_force }}"
-    aap_setup_inst_extra_vars: "{{ aap_deploy_setup_install_extra_vars }}"
-    aap_setup_inst_extra_vars_files: "{{ aap_deploy_setup_install_extra_vars_files }}"
-    controller_validate_certs: "{{ aap_validate_certs | bool }}"
-    ah_validate_certs: "{{ aap_validate_certs | bool }}"
-    eda_validate_certs: "{{ aap_validate_certs | bool }}"
-    gateway_validate_certs: "{{ aap_validate_certs | bool }}"
+- name: Ensure installer log directory exists
+  ansible.builtin.file:
+    path: "{{ aap_deploy_installer_log_dir }}"
+    state: directory
+    owner: "{{ aap_deploy_install_user }}"
+    group: "{{ aap_deploy_install_user }}"
+    mode: '0750'
+
+- name: Run AAP containerized installer with diagnostics
+  block:
+    - name: Run AAP containerized installer via vendor role  # noqa var-naming[no-role-prefix]
+      ansible.builtin.include_role:
+        name: infra.aap_utilities.aap_setup_install
+        apply:
+          become: true
+          become_user: "{{ aap_deploy_install_user }}"
+          environment:
+            XDG_RUNTIME_DIR: "/run/user/{{ aap_deploy_install_user_uid }}"
+            DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ aap_deploy_install_user_uid }}/bus"
+      vars:
+        aap_setup_down_version: "{{ aap_deploy_setup_download_version }}"
+        aap_setup_containerized: "{{ aap_deploy_setup_download_containerized }}"
+        aap_setup_inst_containerized: "{{ aap_deploy_setup_download_containerized }}"
+        aap_setup_inst_setup_dir: "{{ aap_setup_prep_setup_dir }}"
+        aap_setup_inst_log_dir: "{{ aap_deploy_installer_log_dir }}"
+        aap_setup_prep_inv_nodes: "{{ aap_deploy_setup_prep_inv_nodes }}"
+        aap_setup_prep_inv_vars: "{{ aap_deploy_setup_prep_inv_vars }}"
+        aap_setup_prep_inv_secrets: "{{ aap_deploy_setup_prep_inv_secrets }}"
+        aap_setup_inst_force: "{{ aap_deploy_setup_install_force }}"
+        aap_setup_inst_extra_vars: "{{ aap_deploy_setup_install_extra_vars }}"
+        aap_setup_inst_extra_vars_files: "{{ aap_deploy_setup_install_extra_vars_files }}"
+        controller_validate_certs: "{{ aap_validate_certs | bool }}"
+        ah_validate_certs: "{{ aap_validate_certs | bool }}"
+        eda_validate_certs: "{{ aap_validate_certs | bool }}"
+        gateway_validate_certs: "{{ aap_validate_certs | bool }}"
+  rescue:
+    - name: Collect AAP installer failure diagnostics
+      ansible.builtin.include_tasks: 45_installer_diagnostics.yml
+      when: aap_deploy_installer_diagnostics_enabled | bool
+
+    - name: Fail after AAP installer diagnostics
+      ansible.builtin.fail:
+        msg: >-
+          AAP containerized installer failed. Review the redacted diagnostics
+          above and the installer log directory {{ aap_deploy_installer_log_dir }}.
 
 - name: Write installation marker
   ansible.builtin.copy:

--- a/roles/aap_deploy/tasks/45_installer_diagnostics.yml
+++ b/roles/aap_deploy/tasks/45_installer_diagnostics.yml
@@ -1,0 +1,94 @@
+---
+- name: Report installer diagnostic context
+  ansible.builtin.debug:
+    msg:
+      - "setup_dir={{ aap_setup_prep_setup_dir | default(aap_deploy_setup_dir, true) }}"
+      - "log_dir={{ aap_deploy_installer_log_dir }}"
+      - "install_user={{ aap_deploy_install_user }}"
+
+- name: Collect filesystem capacity
+  ansible.builtin.command:
+    cmd: df -hT {{ aap_deploy_install_dir | quote }} /tmp
+  register: aap_deploy_diag_df
+  changed_when: false
+  failed_when: false
+
+- name: Show filesystem capacity
+  ansible.builtin.debug:
+    var: aap_deploy_diag_df.stdout_lines
+
+- name: Collect failed user services  # noqa command-instead-of-module
+  ansible.builtin.command:
+    cmd: systemctl --user --failed --no-pager
+  become: true
+  become_user: "{{ aap_deploy_install_user }}"
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ aap_deploy_install_user_uid }}"
+    DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ aap_deploy_install_user_uid }}/bus"
+  register: aap_deploy_diag_failed_units
+  changed_when: false
+  failed_when: false
+
+- name: Show failed user services
+  ansible.builtin.debug:
+    var: aap_deploy_diag_failed_units.stdout_lines
+
+- name: Collect rootless podman containers
+  ansible.builtin.command:
+    cmd: podman ps -a --format json
+  become: true
+  become_user: "{{ aap_deploy_install_user }}"
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ aap_deploy_install_user_uid }}"
+    DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ aap_deploy_install_user_uid }}/bus"
+  register: aap_deploy_diag_podman
+  changed_when: false
+  failed_when: false
+
+- name: Show rootless podman containers
+  ansible.builtin.debug:
+    var: aap_deploy_diag_podman.stdout_lines
+
+- name: Find recent installer log files
+  ansible.builtin.find:
+    paths:
+      - "{{ aap_deploy_installer_log_dir }}"
+      - "{{ aap_setup_prep_setup_dir | default(aap_deploy_setup_dir, true) }}"
+    patterns:
+      - "*.log"
+      - "*.out"
+      - "*.err"
+    file_type: file
+    recurse: true
+    age: -6h
+  register: aap_deploy_diag_logs
+  failed_when: false
+
+- name: Show discovered installer log files
+  ansible.builtin.debug:
+    msg: "{{ aap_deploy_diag_logs.files | default([]) | map(attribute='path') | list }}"
+
+- name: Show redacted installer log tails
+  ansible.builtin.shell: |
+    set -o pipefail
+    tail -n {{ aap_deploy_installer_diagnostics_log_tail_lines | int }} {{ item.path | quote }} \
+      | sed -E 's/((password|passwd|token|secret|key)[[:alnum:]_ -]*[=:][[:space:]]*)[^[:space:]"]+/\1[REDACTED]/Ig'
+  args:
+    executable: /bin/bash
+  loop: "{{ aap_deploy_diag_logs.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path }}"
+  register: aap_deploy_diag_log_tails
+  changed_when: false
+  failed_when: false
+  when: aap_deploy_diag_logs.files | default([]) | length > 0
+
+- name: Print redacted installer log tails
+  ansible.builtin.debug:
+    msg: "{{ item.stdout_lines }}"
+  loop: "{{ aap_deploy_diag_log_tails.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item.path | default('unknown') }}"
+  when:
+    - aap_deploy_diag_log_tails is defined
+    - item.stdout_lines | default([]) | length > 0

--- a/roles/aap_deploy/vars/RedHat-10.yml
+++ b/roles/aap_deploy/vars/RedHat-10.yml
@@ -6,4 +6,8 @@ aap_deploy_required_repos_default:
 aap_deploy_base_required_packages_default:
   - acl
   - ansible-core
+  - git
   - podman
+  - rsync
+  - tar
+  - unzip

--- a/roles/aap_deploy/vars/RedHat-9.yml
+++ b/roles/aap_deploy/vars/RedHat-9.yml
@@ -6,4 +6,8 @@ aap_deploy_required_repos_default:
 aap_deploy_base_required_packages_default:
   - acl
   - ansible-core
+  - git
   - podman
+  - rsync
+  - tar
+  - unzip


### PR DESCRIPTION
## Summary
- install vendor-required AAP prep packages during host prep
- write vendor installer logs to the AAP log directory
- print redacted diagnostics when the containerized installer fails

## Validation
- yamllint via devtools
- ansible-lint via devtools
- collection smoke via devtools
- galaxy verify via devtools
- molecule light hook passed in commit hook