### PR TITLE
fix(aap): run installer with native async polling

### DIFF
--- a/roles/aap_deploy/README.md
+++ b/roles/aap_deploy/README.md
@@ -34,6 +34,10 @@ Key variables:
 - `aap_deploy_setup_prepare_process_template`
 - `aap_deploy_setup_install_force`
 - `aap_deploy_bundle_dir` (path containing `/bundle`)
+- `aap_deploy_installer_runner` (`native` or `vendor`, default: `native`)
+- `aap_deploy_installer_async_timeout`
+- `aap_deploy_installer_async_retries`
+- `aap_deploy_installer_async_delay`
 - `aap_deploy_installer_log_dir`
 - `aap_deploy_installer_diagnostics_enabled`
 - `aap_deploy_installer_diagnostics_log_tail_lines`
@@ -85,15 +89,17 @@ Key variables:
 - `aap_deploy_growth_automationmetrics_host`
 - `aap_deploy_enterprise_automationmetrics_hosts`
 
-Vendor-driven installer behavior:
+Installer behavior:
 - Role performs an early existing-install detection (marker and runtime containers).
 - Marker-based skip is runtime-validated by default to avoid stale marker false positives.
 - When detected, host prep, bundle handling, inventory rendering, and installer execution are skipped.
 - Verification still runs (when enabled).
 - Role expects a controller-side bundle path and copies it to the managed host.
 - Role prepares the setup workspace and renders installer inventory via `infra.aap_utilities.aap_setup_prepare`.
-- Role runs the containerized installer via `infra.aap_utilities.aap_setup_install`.
-- Role writes the vendor installer Ansible log below `aap_deploy_installer_log_dir`.
+- By default, role runs the prepared containerized installer command directly
+  with controlled async status polling. Set `aap_deploy_installer_runner:
+  vendor` to use `infra.aap_utilities.aap_setup_install` for compatibility.
+- Role writes the installer Ansible log below `aap_deploy_installer_log_dir`.
 - On installer failure, role prints redacted diagnostics before returning failure.
 - Default bundle dir is `bundle` (relative to the extracted setup directory).
 

--- a/roles/aap_deploy/defaults/main.yml
+++ b/roles/aap_deploy/defaults/main.yml
@@ -95,7 +95,13 @@ aap_deploy_setup_prepare_process_template: true
 aap_deploy_setup_install_force: true
 aap_deploy_setup_install_extra_vars: {}
 aap_deploy_setup_install_extra_vars_files: []
+aap_deploy_installer_runner: native
+aap_deploy_installer_async_timeout: 14400
+aap_deploy_installer_async_retries: 720
+aap_deploy_installer_async_delay: 20
 aap_deploy_installer_log_dir: "{{ aap_deploy_install_dir }}/logs"
+aap_deploy_installer_extra_vars_path: >-
+  {{ aap_setup_prep_setup_dir | default(aap_deploy_setup_dir, true) }}/aap_deploy_extra_vars.yml
 aap_deploy_installer_diagnostics_enabled: true
 aap_deploy_installer_diagnostics_log_tail_lines: 180
 

--- a/roles/aap_deploy/tasks/40_install.yml
+++ b/roles/aap_deploy/tasks/40_install.yml
@@ -31,8 +31,107 @@
     group: "{{ aap_deploy_install_user }}"
     mode: '0750'
 
+- name: Validate installer runner
+  ansible.builtin.assert:
+    that:
+      - aap_deploy_installer_runner in ['native', 'vendor']
+    fail_msg: >-
+      Unsupported aap_deploy_installer_runner={{ aap_deploy_installer_runner }}.
+      Supported values are native and vendor.
+    quiet: true
+
 - name: Run AAP containerized installer with diagnostics
   block:
+    - name: Write native installer ansible.cfg
+      ansible.builtin.copy:
+        dest: "{{ aap_setup_prep_setup_dir }}/ansible.cfg"
+        owner: "{{ aap_deploy_install_user }}"
+        group: "{{ aap_deploy_install_user }}"
+        mode: '0644'
+        content: |
+          [defaults]
+          collections_path = ./collections
+          inventory = ./inventory
+          log_path = {{ aap_deploy_installer_log_dir }}/aap_install.log
+      when: aap_deploy_installer_runner == 'native'
+
+    - name: Write native installer extra vars file
+      ansible.builtin.copy:
+        dest: "{{ aap_deploy_installer_extra_vars_path }}"
+        owner: "{{ aap_deploy_install_user }}"
+        group: "{{ aap_deploy_install_user }}"
+        mode: '0600'
+        content: "{{ aap_deploy_setup_install_extra_vars | to_nice_yaml }}"
+      when:
+        - aap_deploy_installer_runner == 'native'
+        - (aap_deploy_setup_install_extra_vars | length) > 0
+
+    - name: Copy native installer extra vars files to workspace
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: "{{ aap_setup_prep_setup_dir }}/{{ item | basename }}"
+        owner: "{{ aap_deploy_install_user }}"
+        group: "{{ aap_deploy_install_user }}"
+        mode: '0600'
+      loop: "{{ aap_deploy_setup_install_extra_vars_files }}"
+      register: aap_deploy_installer_extra_vars_files_copied
+      when:
+        - aap_deploy_installer_runner == 'native'
+        - (aap_deploy_setup_install_extra_vars_files | length) > 0
+
+    - name: Build native installer command
+      ansible.builtin.set_fact:
+        aap_deploy_installer_command: >-
+          ansible-playbook -i inventory ansible.containerized_installer.install
+          {% if (aap_deploy_setup_install_extra_vars | length) > 0 %}
+          -e @{{ aap_deploy_installer_extra_vars_path | quote }}
+          {% endif %}
+          {% for extra_vars_file in (aap_deploy_installer_extra_vars_files_copied.results | default([])) %}
+          -e @{{ extra_vars_file.dest | quote }}
+          {% endfor %}
+      when: aap_deploy_installer_runner == 'native'
+
+    - name: Start native AAP containerized installer
+      ansible.builtin.command:
+        cmd: "{{ aap_deploy_installer_command }}"
+        chdir: "{{ aap_setup_prep_setup_dir }}"
+      async: "{{ aap_deploy_installer_async_timeout | int }}"
+      poll: 0
+      become: true
+      become_user: "{{ aap_deploy_install_user }}"
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ aap_deploy_install_user_uid }}"
+        DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ aap_deploy_install_user_uid }}/bus"
+      register: aap_deploy_installer_async_job
+      changed_when: false
+      when: aap_deploy_installer_runner == 'native'
+
+    - name: Wait for native AAP containerized installer
+      ansible.builtin.async_status:
+        jid: "{{ aap_deploy_installer_async_job.ansible_job_id }}"
+      become: true
+      become_user: "{{ aap_deploy_install_user }}"
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ aap_deploy_install_user_uid }}"
+        DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ aap_deploy_install_user_uid }}/bus"
+      register: aap_deploy_installer_async_status
+      until: aap_deploy_installer_async_status.finished | bool
+      retries: "{{ aap_deploy_installer_async_retries | int }}"
+      delay: "{{ aap_deploy_installer_async_delay | int }}"
+      when: aap_deploy_installer_runner == 'native'
+
+    - name: Fail when native installer exited non-zero
+      ansible.builtin.fail:
+        msg: |-
+          Native AAP containerized installer exited with rc={{ aap_deploy_installer_async_status.rc }}.
+          stdout:
+          {{ aap_deploy_installer_async_status.stdout | default('') | trim }}
+          stderr:
+          {{ aap_deploy_installer_async_status.stderr | default('') | trim }}
+      when:
+        - aap_deploy_installer_runner == 'native'
+        - (aap_deploy_installer_async_status.rc | default(0) | int) != 0
+
     - name: Run AAP containerized installer via vendor role  # noqa var-naming[no-role-prefix]
       ansible.builtin.include_role:
         name: infra.aap_utilities.aap_setup_install
@@ -58,6 +157,7 @@
         ah_validate_certs: "{{ aap_validate_certs | bool }}"
         eda_validate_certs: "{{ aap_validate_certs | bool }}"
         gateway_validate_certs: "{{ aap_validate_certs | bool }}"
+      when: aap_deploy_installer_runner == 'vendor'
   rescue:
     - name: Collect AAP installer failure diagnostics
       ansible.builtin.include_tasks: 45_installer_diagnostics.yml


### PR DESCRIPTION
## Summary
- add native AAP containerized installer runner with explicit async status polling
- keep vendor runner as opt-in compatibility mode
- document the new installer runner controls

## Validation
- scripts/devtools-yamllint.sh roles/aap_deploy/defaults/main.yml roles/aap_deploy/tasks/40_install.yml
- scripts/devtools-ansible-lint.sh
- commit hook: yamllint, ansible-lint, non-heavy molecule, collection smoke, galaxy verify