### PR TITLE
feat(aap): support external installer polling

### DIFF
--- a/roles/aap_deploy/README.md
+++ b/roles/aap_deploy/README.md
@@ -35,6 +35,8 @@ Key variables:
 - `aap_deploy_setup_install_force`
 - `aap_deploy_bundle_dir` (path containing `/bundle`)
 - `aap_deploy_installer_runner` (`native` or `vendor`, default: `native`)
+- `aap_deploy_installer_wait`
+- `aap_deploy_installer_async_jid_path`
 - `aap_deploy_installer_async_timeout`
 - `aap_deploy_installer_async_retries`
 - `aap_deploy_installer_async_delay`
@@ -99,6 +101,13 @@ Installer behavior:
 - By default, role runs the prepared containerized installer command directly
   with controlled async status polling. Set `aap_deploy_installer_runner:
   vendor` to use `infra.aap_utilities.aap_setup_install` for compatibility.
+- For CI or other orchestrators that cannot hold one Ansible polling task open
+  for the full installer runtime, set `aap_deploy_installer_wait: false`.
+  The role starts the native installer asynchronously, writes the async job id to
+  `aap_deploy_installer_async_jid_path`, skips the install marker, and skips
+  verification for that run. The orchestrator must poll the async job id with
+  short Ansible calls, fail on a non-zero installer return code, and run
+  verification after the async job finishes successfully.
 - Role writes the installer Ansible log below `aap_deploy_installer_log_dir`.
 - On installer failure, role prints redacted diagnostics before returning failure.
 - Default bundle dir is `bundle` (relative to the extracted setup directory).

--- a/roles/aap_deploy/defaults/main.yml
+++ b/roles/aap_deploy/defaults/main.yml
@@ -96,10 +96,13 @@ aap_deploy_setup_install_force: true
 aap_deploy_setup_install_extra_vars: {}
 aap_deploy_setup_install_extra_vars_files: []
 aap_deploy_installer_runner: native
+aap_deploy_installer_wait: true
 aap_deploy_installer_async_timeout: 14400
 aap_deploy_installer_async_retries: 720
 aap_deploy_installer_async_delay: 20
 aap_deploy_installer_log_dir: "{{ aap_deploy_install_dir }}/logs"
+aap_deploy_installer_async_jid_path: >-
+  {{ aap_deploy_installer_log_dir }}/aap_installer_async_jid
 aap_deploy_installer_extra_vars_path: >-
   {{ aap_setup_prep_setup_dir | default(aap_deploy_setup_dir, true) }}/aap_deploy_extra_vars.yml
 aap_deploy_installer_diagnostics_enabled: true

--- a/roles/aap_deploy/tasks/40_install.yml
+++ b/roles/aap_deploy/tasks/40_install.yml
@@ -106,6 +106,15 @@
       changed_when: false
       when: aap_deploy_installer_runner == 'native'
 
+    - name: Write native installer async job id
+      ansible.builtin.copy:
+        dest: "{{ aap_deploy_installer_async_jid_path }}"
+        owner: "{{ aap_deploy_install_user }}"
+        group: "{{ aap_deploy_install_user }}"
+        mode: '0640'
+        content: "{{ aap_deploy_installer_async_job.ansible_job_id }}\n"
+      when: aap_deploy_installer_runner == 'native'
+
     - name: Wait for native AAP containerized installer
       ansible.builtin.async_status:
         jid: "{{ aap_deploy_installer_async_job.ansible_job_id }}"
@@ -118,7 +127,9 @@
       until: aap_deploy_installer_async_status.finished | bool
       retries: "{{ aap_deploy_installer_async_retries | int }}"
       delay: "{{ aap_deploy_installer_async_delay | int }}"
-      when: aap_deploy_installer_runner == 'native'
+      when:
+        - aap_deploy_installer_runner == 'native'
+        - aap_deploy_installer_wait | bool
 
     - name: Fail when native installer exited non-zero
       ansible.builtin.fail:
@@ -130,7 +141,17 @@
           {{ aap_deploy_installer_async_status.stderr | default('') | trim }}
       when:
         - aap_deploy_installer_runner == 'native'
+        - aap_deploy_installer_wait | bool
         - (aap_deploy_installer_async_status.rc | default(0) | int) != 0
+
+    - name: Report native installer external polling handoff
+      ansible.builtin.debug:
+        msg: >-
+          Native AAP containerized installer started asynchronously.
+          External polling is required with jid file {{ aap_deploy_installer_async_jid_path }}.
+      when:
+        - aap_deploy_installer_runner == 'native'
+        - not (aap_deploy_installer_wait | bool)
 
     - name: Run AAP containerized installer via vendor role  # noqa var-naming[no-role-prefix]
       ansible.builtin.include_role:
@@ -179,3 +200,6 @@
       installed=true
       setup_dir={{ aap_setup_prep_setup_dir | default(aap_deploy_setup_dir, true) }}
       playbook=infra.aap_utilities.aap_setup_install
+  when: >-
+    aap_deploy_installer_runner != 'native'
+    or (aap_deploy_installer_wait | bool)

--- a/roles/aap_deploy/tasks/assert.yml
+++ b/roles/aap_deploy/tasks/assert.yml
@@ -52,6 +52,7 @@
       - aap_deploy_setup_download_containerized is boolean
       - aap_deploy_setup_prepare_process_template is boolean
       - aap_deploy_setup_install_force is boolean
+      - aap_deploy_installer_wait is boolean
       - aap_deploy_verify_gateway_https is boolean
       - aap_deploy_manage_rhsm_repos is boolean
       - aap_deploy_install_user | trim | length > 0
@@ -69,6 +70,8 @@
       - aap_deploy_setup_install_extra_vars is mapping
       - aap_deploy_setup_install_extra_vars_files is sequence
       - aap_deploy_setup_install_extra_vars_files is not string
+      - aap_deploy_installer_async_jid_path | trim | length > 0
+      - aap_deploy_installer_async_jid_path.startswith('/')
       - aap_deploy_min_mem_mb | int > 0
       - aap_deploy_validate_archive_min_size_bytes | int >= 0
       - aap_deploy_skip_if_installed_runtime_min_matching_containers | int > 0

--- a/roles/aap_deploy/tasks/main.yml
+++ b/roles/aap_deploy/tasks/main.yml
@@ -92,5 +92,10 @@
   when:
     - aap_deploy_enabled | bool
     - aap_deploy_run_verify | bool
+    - >-
+      aap_deploy_existing_install_detected | default(false)
+      or aap_deploy_installer_runner != 'native'
+      or (aap_deploy_installer_wait | bool)
+      or not (aap_deploy_run_installer | bool)
   tags:
     - verify


### PR DESCRIPTION
## Summary
- add an external polling handoff mode for the native AAP installer
- write the native async job id to a stable path for orchestrators
- skip install marker and verification when the installer is only started asynchronously

## Validation
- scripts/devtools-yamllint.sh roles/aap_deploy/defaults/main.yml roles/aap_deploy/tasks/assert.yml roles/aap_deploy/tasks/40_install.yml roles/aap_deploy/tasks/main.yml
- scripts/devtools-ansible-lint.sh
- pre-commit hook suite during commit