### PR TITLE
fix(incus): allow short guest hostnames

### DIFF
--- a/deploy/incus/README.md
+++ b/deploy/incus/README.md
@@ -108,10 +108,23 @@ Create the default validated RHEL 9.8 VM:
 deploy/incus/create.sh --version 9 --vm --name aap-rhel9-dev
 ```
 
+Use a separate short guest hostname when the Incus instance name needs extra
+uniqueness:
+
+```bash
+deploy/incus/create.sh --version 9 --vm --name aap-rhel9-dev-123456 --hostname aap-rhel9-dev
+```
+
 Print a usable Ansible inventory:
 
 ```bash
 deploy/incus/inventory.sh aap-rhel9-dev > /tmp/aap-rhel9-dev.yml
+```
+
+Use the same short name as inventory alias when needed:
+
+```bash
+deploy/incus/inventory.sh aap-rhel9-dev-123456 --host-alias aap-rhel9-dev > /tmp/aap-rhel9-dev.yml
 ```
 
 Wait for the instance explicitly:

--- a/deploy/incus/create.sh
+++ b/deploy/incus/create.sh
@@ -5,13 +5,14 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   cat <<'EOF'
-Usage: deploy/incus/create.sh [--version 9|10] [--vm|--container] [--name INSTANCE]
+Usage: deploy/incus/create.sh [--version 9|10] [--vm|--container] [--name INSTANCE] [--hostname HOSTNAME]
 
 Create a local Incus instance for AAP development.
 Defaults:
   --version 9
   --vm
   --name aap-rhel<version>-<timestamp>
+  --hostname INSTANCE
 EOF
 }
 
@@ -162,6 +163,7 @@ raise SystemExit(1)
 version="9"
 mode="vm"
 name=""
+hostname=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -179,6 +181,10 @@ while [ "$#" -gt 0 ]; do
       ;;
     --name)
       name="${2:-}"
+      shift 2
+      ;;
+    --hostname)
+      hostname="${2:-}"
       shift 2
       ;;
     -h|--help)
@@ -216,6 +222,10 @@ if [ -z "$name" ]; then
   name="aap-rhel${version}-$(date -u +%Y%m%d%H%M%S)"
 fi
 
+if [ -z "$hostname" ]; then
+  hostname="$name"
+fi
+
 if incus info "$name" >/dev/null 2>&1; then
   echo "ERROR: Incus instance already exists: ${name}" >&2
   exit 1
@@ -231,10 +241,10 @@ if [ -z "$public_key" ]; then
   exit 1
 fi
 
-if [[ "$name" == *.* ]]; then
-  fqdn="$name"
+if [[ "$hostname" == *.* ]]; then
+  fqdn="$hostname"
 else
-  fqdn="${name}.${INCUS_FQDN_SUFFIX:-incus.local}"
+  fqdn="${hostname}.${INCUS_FQDN_SUFFIX:-incus.local}"
 fi
 
 case "$version" in
@@ -245,7 +255,7 @@ esac
 tmp_user_data="$(mktemp)"
 tmp_network_config="$(mktemp)"
 trap 'rm -f "${tmp_user_data}" "${tmp_network_config}"' EXIT
-render_user_data "$profile_file" "$name" "$fqdn" "$ssh_user" "$public_key" > "${tmp_user_data}"
+render_user_data "$profile_file" "$hostname" "$fqdn" "$ssh_user" "$public_key" > "${tmp_user_data}"
 
 if [ "$mode" = "vm" ]; then
   require_cmd mkisofs
@@ -288,6 +298,7 @@ ip_address="$(instance_ipv4 "$name")"
 
 echo "Instance ready."
 echo "  Name: ${name}"
+echo "  Hostname: ${hostname}"
 echo "  Mode: ${mode}"
 echo "  Image: ${image}"
 echo "  FQDN: ${fqdn}"

--- a/deploy/incus/inventory.sh
+++ b/deploy/incus/inventory.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: deploy/incus/inventory.sh INSTANCE [--group GROUP]
+Usage: deploy/incus/inventory.sh INSTANCE [--group GROUP] [--host-alias HOST]
 
 Print a YAML inventory for an Incus instance created by deploy/incus/create.sh.
 EOF
@@ -70,12 +70,17 @@ fi
 
 name="$1"
 group="aap_hosts"
+host_alias=""
 shift
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --group)
       group="${2:-}"
+      shift 2
+      ;;
+    --host-alias)
+      host_alias="${2:-}"
       shift 2
       ;;
     -h|--help)
@@ -107,13 +112,14 @@ fi
 ssh_user="${INCUS_SSH_USER:-cloud-user}"
 private_key_file="$(resolve_ssh_private_key_file)"
 ssh_common_args="${INCUS_SSH_COMMON_ARGS:--o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null}"
+inventory_host="${host_alias:-$name}"
 
 cat <<EOF
 all:
   children:
     ${group}:
       hosts:
-        ${name}:
+        ${inventory_host}:
           ansible_host: "${ip_address}"
           ansible_user: ${ssh_user}
           ansible_become: true

--- a/docs/development/aap/AGENTS.md
+++ b/docs/development/aap/AGENTS.md
@@ -91,6 +91,10 @@ automation/inventory repositories.
    `deploy/incus/README.md` together when image assumptions change.
 6. `/dev/kvm` is required for VM-based Incus testing. Container-only Incus tests
    do not need KVM, but the AAP RHEL 10 workflow is VM-based.
+7. Keep AAP test guest hostnames short. AAP EDA builds PostgreSQL identifiers
+   from the hostname and a UUID; use `deploy/incus/create.sh --hostname` and
+   `deploy/incus/inventory.sh --host-alias` when the Incus instance name includes
+   a long CI run ID.
 
 ## RHEL Registration Rules
 

--- a/docs/testing/aap.md
+++ b/docs/testing/aap.md
@@ -84,6 +84,9 @@ deploy/incus/destroy.sh aap-rhel10-dev
 ```
 
 The Incus helper inventory targets the `aap_hosts` group used by `playbooks/aap_deploy.yml`.
+For AAP EDA tests, keep the guest hostname short. If the Incus instance name is
+long because it includes a run ID, pass `--hostname` to `deploy/incus/create.sh`
+and the same short name as `--host-alias` to `deploy/incus/inventory.sh`.
 
 For registered RHEL test VMs, keep the base image unregistered and prepare each
 runtime VM idempotently after boot. The playbook composes `lit.rhel.rhsm`,


### PR DESCRIPTION
## Summary
- add an optional Incus cloud-init hostname separate from the instance name
- add an optional generated inventory host alias
- document the short-hostname requirement for AAP EDA tests

## Validation
- shellcheck deploy/incus/create.sh deploy/incus/inventory.sh deploy/incus/destroy.sh deploy/incus/wait-for-instance.sh
- git diff --check
- commit hooks