### PR TITLE
fix: wrap auto-release workflow description

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -8,7 +8,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Release version, for example 1.2.3. Leave empty on manual runs to calculate the next feature version.
+        description: >-
+          Release version, for example 1.2.3. Leave empty on manual runs to calculate the next feature version.
         required: false
         default: ""
       base_branch:


### PR DESCRIPTION
Wrap the release workflow version input description so ansible-lint accepts the rendered workflow. This keeps the auto-release PR workflow from shared-assets-lit passing before promotion to main.