### PR TITLE
fix: sync main fixes back to develop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         name: ansible-lint (via ee-wunder-devtools-ubi9)
         language: system
         entry: >-
-          bash -lc "ANSIBLE_CORE_VERSION=2.15.13
+          bash -lc "ANSIBLE_CORE_VERSION=2.18.18
           ANSIBLE_LINT_VERSION=6.22.2
           scripts/devtools-ansible-lint.sh"
         pass_filenames: false

--- a/changelogs/fragments/dhcp-deploy-meta-platform.yml
+++ b/changelogs/fragments/dhcp-deploy-meta-platform.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - dhcp_deploy - Use a valid Ubuntu platform version in role metadata.

--- a/roles/dhcp_deploy/meta/main.yml
+++ b/roles/dhcp_deploy/meta/main.yml
@@ -13,8 +13,7 @@ galaxy_info:
         - "9"
     - name: Ubuntu
       versions:
-        - "jammy"
-        - "noble"
+        - all
   galaxy_tags:
     - modulix
     - dhcp


### PR DESCRIPTION
## Summary
- sync the DHCP role metadata fix from main back to develop
- sync the matching changelog fragment
- keep the pre-commit ansible-core version aligned with main

## Why
#266 was merged to main from a resolved promotion branch, so these fixes were not yet present on develop. This keeps develop from reintroducing the same lint failure.

## Testing
- git diff --check
- checked for merge conflict markers with rg