### PR TITLE
fix: install foundational release artifact

### DIFF
--- a/changelogs/fragments/foundational-release-artifact.yml
+++ b/changelogs/fragments/foundational-release-artifact.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Install the foundational collection from the v1.26.0 release artifact during
+    collection preparation so CI can satisfy the declared ``lit.foundational``
+    dependency before the matching Galaxy version is available.

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -12,5 +12,5 @@ collections:
     version: "5.10.0"
   - name: lit.rhel
     version: "1.17.1"
-  - name: lit.foundational
-    version: "1.21.0"
+  - name: https://github.com/lightning-it/ansible-collection-foundational/releases/download/v1.26.0/lit-foundational-1.26.0.tar.gz
+    type: url


### PR DESCRIPTION
## Summary
- install lit.foundational from the v1.26.0 GitHub release artifact because Galaxy does not provide >=1.25.0
- keep galaxy.yml dependency constraint unchanged

## Test
- bash scripts/devtools-ansible-lint.sh
- bash scripts/devtools-collection-smoke.sh
- bash scripts/devtools-molecule.sh