### PR TITLE
Promote develop to main

### DIFF
--- a/changelogs/fragments/foundational-release-artifact.yml
+++ b/changelogs/fragments/foundational-release-artifact.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Install the foundational collection from the v1.26.0 release artifact during
+    collection preparation so CI can satisfy the declared ``lit.foundational``
+    dependency before the matching Galaxy version is available.

--- a/collections/requirements.yml
+++ b/collections/requirements.yml
@@ -12,5 +12,5 @@ collections:
     version: "5.10.0"
   - name: lit.rhel
     version: "1.17.1"
-  - name: lit.foundational
-    version: "1.21.0"
+  - name: https://github.com/lightning-it/ansible-collection-foundational/releases/download/v1.26.0/lit-foundational-1.26.0.tar.gz
+    type: url


### PR DESCRIPTION
## Summary
- promote the supplementary dependency fix from develop to main
- supersede the failed main Collection CI run caused by unresolved lit.foundational >=1.25.0 on Galaxy

## Validation
- PR #325 green: changelog, CodeQL, lint, smoke, molecule