### PR TITLE
chore: add ansible.posix changelog

### DIFF
--- a/changelogs/fragments/ansible-posix-2.2.1.yml
+++ b/changelogs/fragments/ansible-posix-2.2.1.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    Update the CI collection preparation requirements to use ansible.posix
+    2.2.1.


### PR DESCRIPTION
## Summary
- add the missing changelog fragment for the ansible.posix 2.2.1 requirements update already present in develop

## Test
- bash scripts/devtools-changelog-check.sh