### PR TITLE
fix(aap): preserve prepared EDA task YAML

### DIFF
--- a/changelogs/fragments/aap-eda-readiness-yaml.yml
+++ b/changelogs/fragments/aap-eda-readiness-yaml.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - aap_deploy - Preserve valid YAML indentation when hardening the prepared EDA readiness condition.

--- a/molecule/aap-deploy-basic/converge.yml
+++ b/molecule/aap-deploy-basic/converge.yml
@@ -7,6 +7,8 @@
     aap_deploy_molecule_execute_role: false
     aap_deploy_molecule_marker_path: >-
       {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/aap-deploy-coverage-mode
+    aap_deploy_molecule_fixture_dir: >-
+      {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/prepared-installer
   tasks:
     - name: Import lit.supplementary.aap_deploy for syntax coverage
       ansible.builtin.import_role:
@@ -16,6 +18,80 @@
     - name: Record lit.supplementary.aap_deploy Molecule coverage mode
       ansible.builtin.set_fact:
         aap_deploy_molecule_coverage_mode: syntax_stub
+
+    - name: Create prepared installer fixture directories
+      ansible.builtin.file:
+        path: "{{ aap_deploy_molecule_fixture_dir }}/{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - collections/ansible_collections/ansible/containerized_installer/playbooks
+        - collections/ansible_collections/ansible/containerized_installer/roles/automationeda/tasks
+        - collections/ansible_collections/ansible/containerized_installer/roles/automationeda/templates
+
+    - name: Create prepared installer playbook fixture
+      ansible.builtin.copy:
+        dest: >-
+          {{ aap_deploy_molecule_fixture_dir
+          }}/collections/ansible_collections/ansible/containerized_installer/playbooks/install.yml
+        force: false
+        mode: "0644"
+        content: |-
+          ---
+          - name: Seed automation hub
+            hosts: localhost
+            gather_facts: false
+            tasks: []
+            when: groups.get('automationhub', []) | length > 0
+
+    - name: Create prepared EDA settings fixture
+      ansible.builtin.copy:
+        dest: >-
+          {{ aap_deploy_molecule_fixture_dir
+          }}/collections/ansible_collections/ansible/containerized_installer/roles/automationeda/templates/settings.yaml.j2
+        force: false
+        mode: "0644"
+        content: |-
+          ---
+          ENABLE_SERVICE_BACKED_SSO: False
+
+    - name: Create prepared EDA task fixture
+      ansible.builtin.copy:
+        dest: >-
+          {{ aap_deploy_molecule_fixture_dir
+          }}/collections/ansible_collections/ansible/containerized_installer/roles/automationeda/tasks/decision_environment.yml
+        force: false
+        mode: "0644"
+        content: !unsafe |-
+          ---
+          - name: Ensure automation eda is ready
+            ansible.builtin.uri:
+              url: '{{ hostvars[groups["automationgateway"][0]]["_gateway_proxy_url"] }}/api/eda/v1/status/'
+            register: _eda_ready
+            until:
+              - _eda_ready.content != ""
+              - _eda_ready.content != "no healthy upstream"
+              - (_eda_ready.content | from_json).status == 'good'
+            retries: 5
+            delay: 60
+
+          - name: Create automation eda decision environments
+            ansible.containerized_installer.eda_decision_environment:
+              eda_server_url: '{{ hostvars[groups["automationgateway"][0]]["_gateway_proxy_url"] }}'
+            loop: '{{ _default_de | union(_de_extra_images | default([])) }}'
+
+          - name: Create eda resources for Automation Hub
+            when: groups.get('automationhub', []) | length > 0
+            vars:
+              __dest_url: '{{ hostvars[groups["automationgateway"][0]]["_gateway_proxy_url"] }}'
+            block: []
+
+    - name: Exercise prepared installer customizations
+      ansible.builtin.include_role:
+        name: lit.supplementary.aap_deploy
+        tasks_from: 25_customize_prepared_installer.yml
+      vars:
+        aap_setup_prep_setup_dir: "{{ aap_deploy_molecule_fixture_dir }}"
 
     - name: Persist lit.supplementary.aap_deploy Molecule coverage mode
       ansible.builtin.copy:

--- a/molecule/aap-deploy-basic/converge.yml
+++ b/molecule/aap-deploy-basic/converge.yml
@@ -9,6 +9,7 @@
       {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/aap-deploy-coverage-mode
     aap_deploy_molecule_fixture_dir: >-
       {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/prepared-installer
+    aap_setup_prep_setup_dir: "{{ aap_deploy_molecule_fixture_dir }}"
   tasks:
     - name: Import lit.supplementary.aap_deploy for syntax coverage
       ansible.builtin.import_role:
@@ -90,8 +91,6 @@
       ansible.builtin.include_role:
         name: lit.supplementary.aap_deploy
         tasks_from: 25_customize_prepared_installer.yml
-      vars:
-        aap_setup_prep_setup_dir: "{{ aap_deploy_molecule_fixture_dir }}"
 
     - name: Persist lit.supplementary.aap_deploy Molecule coverage mode
       ansible.builtin.copy:

--- a/molecule/aap-deploy-basic/verify.yml
+++ b/molecule/aap-deploy-basic/verify.yml
@@ -6,6 +6,9 @@
   vars:
     aap_deploy_molecule_marker_path: >-
       {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/aap-deploy-coverage-mode
+    aap_deploy_molecule_eda_task_path: >-
+      {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY')
+      }}/prepared-installer/collections/ansible_collections/ansible/containerized_installer/roles/automationeda/tasks/decision_environment.yml
   tasks:
     - name: Read lit.supplementary.aap_deploy coverage marker
       ansible.builtin.slurp:
@@ -16,4 +19,24 @@
       ansible.builtin.assert:
         that:
           - aap_deploy_molecule_marker.content | b64decode | trim == 'syntax_stub'
+        quiet: true
+
+    - name: Read customized prepared EDA tasks
+      ansible.builtin.slurp:
+        src: "{{ aap_deploy_molecule_eda_task_path }}"
+      register: aap_deploy_molecule_eda_task_file
+
+    - name: Parse customized prepared EDA tasks as YAML
+      ansible.builtin.set_fact:
+        aap_deploy_molecule_eda_tasks: >-
+          {{ aap_deploy_molecule_eda_task_file.content | b64decode | from_yaml }}
+
+    - name: Assert the EDA readiness condition remains valid YAML
+      ansible.builtin.assert:
+        that:
+          - aap_deploy_molecule_eda_tasks[0].retries == 20
+          - aap_deploy_molecule_eda_tasks[0].until | length == 3
+          - >-
+            aap_deploy_molecule_eda_tasks[0].until[2]
+            == "(_eda_ready.content | trim).startswith('{') and (_eda_ready.content | from_json).status == 'good'"
         quiet: true

--- a/roles/aap_deploy/tasks/25_customize_prepared_installer.yml
+++ b/roles/aap_deploy/tasks/25_customize_prepared_installer.yml
@@ -87,8 +87,9 @@
     regexp: >-
       ^(\s*)- \(_eda_ready\.content \| from_json\)\.status == 'good'$
     replace: |-
-      \1- (_eda_ready.content | trim).startswith('{')
-      and (_eda_ready.content | from_json).status == 'good'
+      \1- >-
+      \1  (_eda_ready.content | trim).startswith('{')
+      \1  and (_eda_ready.content | from_json).status == 'good'
 
 - name: Give prepared EDA readiness check enough startup time
   ansible.builtin.replace:


### PR DESCRIPTION
## Summary

- preserve valid YAML indentation when hardening the prepared EDA readiness condition
- add a regression fixture that reparses the customized vendor task as YAML
- verify the customization remains idempotent

## Verification

- `ANSIBLE_LINT_VERSION=6.22.2 bash scripts/devtools-ansible-lint.sh`
- `bash scripts/devtools-molecule.sh aap-deploy-basic`
- full non-heavy Molecule suite, collection smoke, changelog policy, actionlint, Renovate validation, and Galaxy role verification passed in pre-commit
- real AAP 2.7 / RHEL 10 Incus validation: https://github.com/lightning-it/modulix-validation-lit/actions/runs/29214284257

## Security

- [x] No secrets, private infrastructure data, or customer data are added.
- [x] Workflow permission changes are least-privilege and justified (no workflow changes).
- [x] Release or publishing changes run only from trusted branches/events (no release changes).