### PR TITLE
fix: sync collection release tooling

### DIFF
--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -30,18 +30,61 @@ permissions:
   contents: write
 
 jobs:
-  publish:
+  dispatch:
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.pull_request.merged == true &&
-        startsWith(github.event.pull_request.head.ref, 'release/v')
-      )
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    name: Dispatch collection publish from main
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Derive release publishing settings
+        id: settings
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+
+          create_github_release=false
+          publish_galaxy=false
+          github_release_marker="GitHub release creation: \`true\`"
+          galaxy_publish_marker="Galaxy publishing: \`true\`"
+
+          if [[ "$PR_BODY" == *"$github_release_marker"* ]]; then
+            create_github_release=true
+          fi
+          if [[ "$PR_BODY" == *"$galaxy_publish_marker"* ]]; then
+            publish_galaxy=true
+          fi
+
+          echo "create_github_release=$create_github_release" >> "$GITHUB_OUTPUT"
+          echo "publish_galaxy=$publish_galaxy" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch publish workflow on main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CREATE_GITHUB_RELEASE: ${{ steps.settings.outputs.create_github_release }}
+          PUBLISH_GALAXY: ${{ steps.settings.outputs.publish_galaxy }}
+        run: |
+          set -euo pipefail
+
+          gh workflow run collection-publish.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref main \
+            -f create_github_release="$CREATE_GITHUB_RELEASE" \
+            -f publish_galaxy="$PUBLISH_GALAXY"
+
+  publish:
+    if: github.event_name == 'workflow_dispatch'
     name: Publish collection release
     runs-on: ubuntu-latest
+    environment: ansible-collections
     env:
       RELEASE_BOT_APP_ID: ${{ secrets.RELEASE_BOT_APP_ID }}
       RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+      GALAXY_API_TOKEN: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
 
     steps:
       - name: Create GitHub App token
@@ -91,25 +134,8 @@ jobs:
       - name: Build and publish
         env:
           GH_TOKEN: ${{ steps.token.outputs.value }}
-          CREATE_GITHUB_RELEASE: >-
-            ${{
-              github.event_name == 'workflow_dispatch'
-              && inputs.create_github_release == 'true'
-              || (
-                github.event_name == 'pull_request'
-                && contains(github.event.pull_request.body, 'GitHub release creation: `true`')
-              )
-            }}
-          PUBLISH_GALAXY: >-
-            ${{
-              github.event_name == 'workflow_dispatch'
-              && inputs.publish_galaxy == 'true'
-              || (
-                github.event_name == 'pull_request'
-                && contains(github.event.pull_request.body, 'Galaxy publishing: `true`')
-              )
-            }}
-          GALAXY_API_TOKEN: ${{ secrets.GALAXY_API_TOKEN }}
+          CREATE_GITHUB_RELEASE: ${{ inputs.create_github_release }}
+          PUBLISH_GALAXY: ${{ inputs.publish_galaxy }}
         run: |
           set -euo pipefail
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@
 *.swp
 *.swo
 
+# Python bytecode and test caches
+__pycache__/
+*.py[cod]
+.pytest_cache/
+
 # Node tooling for semantic-release
 node_modules/
 npm-debug.log

--- a/scripts/devtools-ansible-lint.sh
+++ b/scripts/devtools-ansible-lint.sh
@@ -52,14 +52,10 @@ else:
 PY
 )}"
 
-ANSIBLE_LINT_VERSION="${ANSIBLE_LINT_VERSION:-$(python3 - <<'PY'
-try:
-    import ansiblelint  # type: ignore
-    print(getattr(ansiblelint, "__version__", ""))
-except Exception:
-    print("")
-PY
-)}"
+# The lint process runs inside the managed devtools image, so a host-side
+# ansible-lint installation is not authoritative. CI supplies the image version;
+# local callers leave it empty and the compatibility branch below fails safe.
+ANSIBLE_LINT_VERSION="${ANSIBLE_LINT_VERSION:-}"
 
 ANSIBLE_LINT_SKIP_META_RUNTIME=0
 if [ -n "${REQUIRES_ANSIBLE:-}" ]; then


### PR DESCRIPTION
## Summary

- dispatch release publishing from the protected `main` ref
- bind publishing to the `ansible-collections` environment and its `ANSIBLE_GALAXY_API_KEY` secret
- align local ansible-lint compatibility detection with the managed devtools image
- ignore Python caches generated by local validation

These files are byte-identical to the canonical `shared-assets-lit` collection base.

## Validation

- actionlint
- yamllint
- shell syntax
- managed-source byte comparison