### PR TITLE
fix: restore ansible.posix 2.1 compatibility

### DIFF
--- a/changelogs/fragments/ansible-posix-21-compat.yml
+++ b/changelogs/fragments/ansible-posix-21-compat.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    dependency - Lower the ``ansible.posix`` minimum to 2.1.0 and require ``lit.foundational`` 1.31.0 or newer,
+    restoring a resolvable graph with ``fedora.linux_system_roles`` 1.127.2 and its
+    ``ansible.posix >=2.1.0,<2.2.0`` constraint while leaving the Supplementary maximum uncapped for other consumers.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -21,9 +21,9 @@ tags:
 dependencies:
   community.general: '>=11.4.9,<12.0.0'
   community.crypto: '>=3.2.2,<4.0.0'
-  ansible.posix: '>=2.2.0'
+  ansible.posix: '>=2.1.0'
   community.vmware: 5.10.0
-  lit.foundational: '>=1.30.0'
+  lit.foundational: '>=1.31.0'
   lit.rhel: '>=1.17.1'
   community.hashi_vault: 7.1.0
 build_ignore:


### PR DESCRIPTION
## Summary

- lower the ansible.posix minimum from 2.2.0 to 2.1.0 without adding an upper cap
- require lit.foundational 1.31.0, the first compatible Foundational release
- document restored compatibility with fedora.linux_system_roles 1.127.2

## Compatibility proof

A clean temporary Ansible configuration and collection path resolved a locally built lit.supplementary 1.39.0 artifact together with exact ansible.posix 2.1.0 and fedora.linux_system_roles 1.127.2. Galaxy selected public lit.foundational 1.31.0 and freshly installed the complete 15-collection transitive graph.

Manifest assertions confirmed the Supplementary and Foundational Posix floors and the Fedora >=2.1.0,<2.2.0 constraint. Resolution checks passed for ansible.posix.authorized_key, ansible.posix.firewalld, ansible.posix.sysctl, lit.supplementary.aap_bootstrap, fedora.linux_system_roles.firewall, and the OpenVPN Molecule converge syntax check.

## Validation

- git diff --check
- pre-commit run --all-files
- isolated ansible-galaxy build/install and dependency graph assertions
- full non-heavy Molecule suite, including openvpn-basic
- collection build/install smoke and Galaxy-style role verification