### PR TITLE
fix: isolate collection CI concurrency

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -22,7 +22,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: collection-quality-${{ github.repository }}-${{ github.ref }}-${{ github.event_name }}
+  group: >-
+    collection-quality-${{ github.repository }}-${{ github.workflow }}-${{
+    github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
@@ -316,7 +318,11 @@ jobs:
             'ansible-collection-runtime-protected' }}
     timeout-minutes: 90
     concurrency:
-      group: quality-tiny-${{ github.repository }}-${{ matrix.component }}-${{ matrix.target }}
+      group: >-
+        quality-tiny-${{ github.repository }}-${{ github.workflow }}-${{
+        github.event.pull_request.number || github.ref }}-${{
+        github.event.pull_request.head.sha || github.sha }}-${{
+        matrix.component }}-${{ matrix.target }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
@@ -386,7 +392,11 @@ jobs:
             'ansible-collection-runtime-protected' }}
     timeout-minutes: 180
     concurrency:
-      group: quality-expensive-${{ github.repository }}-${{ matrix.component }}-${{ matrix.target }}
+      group: >-
+        quality-expensive-${{ github.repository }}-${{ github.workflow }}-${{
+        github.event.pull_request.number || github.ref }}-${{
+        github.event.pull_request.head.sha || github.sha }}-${{
+        matrix.component }}-${{ matrix.target }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
@@ -456,7 +466,11 @@ jobs:
             'ansible-collection-runtime-protected' }}
     timeout-minutes: 180
     concurrency:
-      group: quality-expensive-${{ github.repository }}-${{ matrix.component }}-${{ matrix.target }}
+      group: >-
+        quality-expensive-${{ github.repository }}-${{ github.workflow }}-${{
+        github.event.pull_request.number || github.ref }}-${{
+        github.event.pull_request.head.sha || github.sha }}-${{
+        matrix.component }}-${{ matrix.target }}
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -51,6 +51,30 @@ def docker_action_image(path: Path) -> str | None:
 
 
 class WorkflowSecurityTests(unittest.TestCase):
+    def test_collection_ci_concurrency_isolated_by_pr_and_exact_head(self) -> None:
+        workflow = load_yaml(WORKFLOWS / "collection-ci.yml")
+        top_group = workflow["concurrency"]["group"]
+        self.assertIn("github.repository", top_group)
+        self.assertIn("github.workflow", top_group)
+        self.assertIn("github.event.pull_request.number || github.ref", top_group)
+        self.assertNotIn("head.sha", top_group)
+        self.assertEqual(
+            "${{ github.event_name == 'pull_request' }}",
+            workflow["concurrency"]["cancel-in-progress"],
+        )
+
+        jobs = workflow["jobs"]
+        groups = [
+            jobs[name]["concurrency"]["group"]
+            for name in ("tiny-cells", "heavy-cells", "acceptance-cells")
+        ]
+        for group in groups:
+            self.assertIn("github.repository", group)
+            self.assertIn("github.workflow", group)
+            self.assertIn("github.event.pull_request.number || github.ref", group)
+            self.assertIn("github.event.pull_request.head.sha || github.sha", group)
+        self.assertNotEqual(groups[0], groups[1])
+
     def test_all_workflows_and_local_actions_require_release_team_review(self) -> None:
         codeowners = (ROOT / ".github" / "CODEOWNERS").read_text(encoding="utf-8")
         rules = {


### PR DESCRIPTION
## What changed

- scope Collection CI workflow concurrency by repository, workflow, and PR/ref so a newer run cancels only an obsolete run in the same lineage
- scope runtime matrix concurrency additionally by exact head SHA, component, and target
- add regression coverage for cross-PR isolation and same-PR obsolete-run cancellation semantics

## Root cause

The expensive matrix jobs used `quality-expensive-<repository>-<component>-<target>`, so simultaneous PRs in the same repository cancelled or displaced one another. PR #389 was one of five Renovate runs started seconds apart, and its required matrix cells ended as `cancelled` before executing any steps.

## Validation

- `python3 -m unittest tests.unit.test_workflow_security` (13 tests pass)
- `git diff --check`
