### PR TITLE
fix: complete trusted Renovate pilot path

### DIFF
--- a/.github/actions/run-quality-profile/action.yml
+++ b/.github/actions/run-quality-profile/action.yml
@@ -346,6 +346,7 @@ runs:
 
         root = Path(os.environ["QUALITY_ARTIFACT_ROOT"])
         dependencies = root / "dependencies"
+        dependencies.mkdir(parents=True, exist_ok=True)
         scenario = os.environ["QUALITY_SCENARIO"]
         target = os.environ["QUALITY_TARGET"]
         config = Path("molecule") / scenario / "molecule.yml"

--- a/.github/actions/run-quality-profile/action.yml
+++ b/.github/actions/run-quality-profile/action.yml
@@ -170,6 +170,14 @@ runs:
       run: |
         set -euo pipefail
 
+        minimum_inotify_instances=4096
+        current_inotify_instances="$(sysctl -n fs.inotify.max_user_instances)"
+        [[ "$current_inotify_instances" =~ ^[0-9]+$ ]]
+        if [ "$current_inotify_instances" -lt "$minimum_inotify_instances" ]; then
+          sudo sysctl -w "fs.inotify.max_user_instances=$minimum_inotify_instances"
+        fi
+        test "$(sysctl -n fs.inotify.max_user_instances)" -ge "$minimum_inotify_instances"
+
         command -v ansible-galaxy
         command -v incus
         command -v molecule

--- a/.github/actions/run-quality-profile/action.yml
+++ b/.github/actions/run-quality-profile/action.yml
@@ -170,13 +170,9 @@ runs:
       run: |
         set -euo pipefail
 
-        minimum_inotify_instances=4096
-        current_inotify_instances="$(sysctl -n fs.inotify.max_user_instances)"
-        [[ "$current_inotify_instances" =~ ^[0-9]+$ ]]
-        if [ "$current_inotify_instances" -lt "$minimum_inotify_instances" ]; then
-          sudo sysctl -w "fs.inotify.max_user_instances=$minimum_inotify_instances"
-        fi
-        test "$(sysctl -n fs.inotify.max_user_instances)" -ge "$minimum_inotify_instances"
+        python3 scripts/prune_stale_incus_resources.py \
+          --repository "$GITHUB_REPOSITORY" \
+          --current-run-id "$GITHUB_RUN_ID"
 
         command -v ansible-galaxy
         command -v incus

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -8,9 +8,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   pull_request_review:
-    types: [submitted, edited, dismissed]
+    types: [edited, dismissed]
   pull_request_review_comment:
-    types: [created, edited, deleted]
+    types: [edited, deleted]
 
 permissions:
   contents: read
@@ -19,23 +19,204 @@ permissions:
 env:
   COPILOT_REVIEWER_LOGIN: copilot-pull-request-reviewer
   NO_FILES_REVIEW_MARKER: was not able to review any files
-  REVIEW_COMPLETED_MARKER: copilot reviewed
   UNABLE_REVIEW_MARKER: unable to review this pull request
-  QUOTA_REVIEW_MARKER: reached their quota limit
 
 concurrency:
   group: copilot-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
+  request-current-revision-review:
+    name: Request Copilot review for current revision
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !(github.event.pull_request.user.login == 'renovate[bot]' &&
+        startsWith(github.event.pull_request.head.ref, 'renovate/') &&
+        github.event.pull_request.base.ref == 'develop') &&
+      !(github.event.pull_request.user.login == 'litreleasebot' &&
+        startsWith(github.event.pull_request.head.ref, 'chore/sync-shared-assets-lit-') &&
+        github.event.pull_request.base.ref == 'develop' &&
+        github.event.pull_request.title == 'chore: sync shared-assets-lit' &&
+        contains(github.event.pull_request.labels.*.name, 'chore') &&
+        contains(github.event.pull_request.labels.*.name, 'shared-assets-lit')) &&
+      !(github.event.pull_request.user.login == 'litreleasebot' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.event.pull_request.head.ref, 'chore/sync-repository-quality-') &&
+        github.event.pull_request.base.ref == 'develop' &&
+        github.event.pull_request.title == 'chore: sync repository quality assets' &&
+        contains(github.event.pull_request.labels.*.name, 'chore') &&
+        contains(github.event.pull_request.labels.*.name, 'shared-assets-lit')) &&
+      !(github.event.pull_request.user.login == 'litreleasebot' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.ref == 'chore/sync-main-to-develop' &&
+        github.event.pull_request.base.ref == 'develop' &&
+        github.event.pull_request.title == 'chore: sync main back to develop') &&
+      !(github.event.pull_request.user.login == 'litreleasebot' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.head.ref == 'develop' &&
+        github.event.pull_request.base.ref == 'main' &&
+        github.event.pull_request.title == 'chore(release): promote develop to main')
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Request Copilot review for the current revision
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          reviewer_login="${COPILOT_REVIEWER_LOGIN%\[bot\]}"
+          gh api --method POST \
+            "repos/${REPOSITORY}/pulls/${PR_NUMBER}/requested_reviewers" \
+            -f "reviewers[]=${reviewer_login}[bot]"
+
   current-revision-reviewed:
     name: Successful Copilot review
     if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
     steps:
+      - name: Classify trusted automation pull request
+        id: trusted-automation
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          trusted=false
+          trusted_kind=none
+          live_pr="{}"
+          if [ "${PR_AUTHOR}" = "renovate[bot]" ] \
+            && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
+            && [[ "${PR_HEAD}" == renovate/* ]] \
+            && [ "${PR_BASE}" = "develop" ]; then
+            if live_pr="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")" \
+              && jq -e \
+              --arg author "${PR_AUTHOR}" \
+              --arg base "${PR_BASE}" \
+              --arg head "${PR_HEAD}" \
+              --arg head_sha "${PR_HEAD_SHA}" \
+              --arg repo "${REPOSITORY}" \
+              '(.state == "open") and (.draft == false)
+               and (.user.login == $author) and (.base.ref == $base)
+               and (.head.ref == $head) and (.head.sha == $head_sha)
+               and (.head.repo.full_name == $repo)
+               and ([.labels[].name] | index("renovate") != null)
+               and ([.labels[].name] | index("dependencies") != null)
+               and ([.labels[].name] | index("safe-automerge") != null)
+               and ([.labels[].name] | index("breaking-update") == null)' \
+                <<<"${live_pr}" >/dev/null; then
+              trusted=true
+              trusted_kind=renovate
+            fi
+          elif [ "${PR_AUTHOR}" = "litreleasebot" ] \
+            && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
+            && [[ "${PR_HEAD}" == chore/sync-shared-assets-lit-* ]] \
+            && [ "${PR_BASE}" = "develop" ] \
+            && [ "${PR_TITLE}" = "chore: sync shared-assets-lit" ] \
+            && jq -e 'index("chore") != null and index("shared-assets-lit") != null' \
+              <<<"${PR_LABELS}" >/dev/null; then
+            trusted=true
+            trusted_kind=shared-assets
+          elif [ "${PR_AUTHOR}" = "litreleasebot" ] \
+            && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
+            && [[ "${PR_HEAD}" == chore/sync-repository-quality-* ]] \
+            && [ "${PR_BASE}" = "develop" ] \
+            && [ "${PR_TITLE}" = "chore: sync repository quality assets" ] \
+            && jq -e 'index("chore") != null and index("shared-assets-lit") != null' \
+              <<<"${PR_LABELS}" >/dev/null; then
+            trusted=true
+            trusted_kind=repository-quality
+          elif [ "${PR_AUTHOR}" = "litreleasebot" ] \
+            && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
+            && [ "${PR_HEAD}" = "chore/sync-main-to-develop" ] \
+            && [ "${PR_BASE}" = "develop" ] \
+            && [ "${PR_TITLE}" = "chore: sync main back to develop" ]; then
+            trusted=true
+            trusted_kind=ancestry-backmerge
+          elif [ "${PR_AUTHOR}" = "litreleasebot" ] \
+            && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
+            && [ "${PR_HEAD}" = "develop" ] \
+            && [ "${PR_BASE}" = "main" ] \
+            && [ "${PR_TITLE}" = "chore(release): promote develop to main" ]; then
+            trusted=true
+            trusted_kind=release-promotion
+          fi
+          echo "trusted=${trusted}" >>"${GITHUB_OUTPUT}"
+          echo "kind=${trusted_kind}" >>"${GITHUB_OUTPUT}"
+
+      - name: Verify file-identical ancestry backmerge
+        if: steps.trusted-automation.outputs.kind == 'ancestry-backmerge'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          git init --quiet .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --quiet --no-tags origin \
+            "${HEAD_SHA}" "refs/heads/main" "refs/heads/develop"
+          git merge-base --is-ancestor "origin/main" "${HEAD_SHA}"
+          git merge-base --is-ancestor "origin/develop" "${HEAD_SHA}"
+          [ "$(git rev-list --parents -n 1 "${HEAD_SHA}" | wc -w)" -eq 3 ]
+          git diff --quiet "origin/develop" "${HEAD_SHA}"
+          echo "Verified a file-identical two-parent merge of current main and develop."
+
+      - name: Verify protected release promotion
+        if: steps.trusted-automation.outputs.kind == 'release-promotion'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          gh auth setup-git
+          git init --quiet .
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --quiet --no-tags origin \
+            "${HEAD_SHA}" "refs/heads/main" "refs/heads/develop"
+          [ "$(git rev-parse origin/develop)" = "${HEAD_SHA}" ]
+          git merge-base --is-ancestor "origin/main" "${HEAD_SHA}"
+          echo "Verified current protected develop head and main ancestry."
+
+      - name: Accept trusted automation exemption
+        if: >-
+          steps.trusted-automation.outputs.trusted == 'true' &&
+          steps.trusted-automation.outputs.kind != 'ancestry-backmerge' &&
+          steps.trusted-automation.outputs.kind != 'release-promotion'
+        run: |
+          if [ "${{ steps.trusted-automation.outputs.kind }}" = renovate ]; then
+            {
+              echo "### Trusted Renovate exemption"
+              echo
+              echo "Copilot review is not required for this exact-head trusted Renovate PR."
+              echo "Trusted identity and policy verification succeeded."
+            } >>"${GITHUB_STEP_SUMMARY}"
+          else
+            echo "Trusted automation PR; Copilot review is delegated to its required guarded-automerge policy."
+          fi
+
       - name: Verify current Copilot review and resolved findings
+        if: steps.trusted-automation.outputs.trusted != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -107,8 +288,8 @@ jobs:
 
           review_comments_clean() {
             local review_id="$1" expected_head="$2" after="" response has_next
-            local content_counts marker_count quota_count content_count completed_count meaningful_content=false
-            local count_pattern=$'^[0-9]+\t[0-9]+\t[0-9]+\t[0-9]+$'
+            local content_counts marker_count content_count meaningful_content=false
+            local count_pattern=$'^[0-9]+\t[0-9]+$'
             local -a arguments
             while true; do
               arguments=(
@@ -136,8 +317,6 @@ jobs:
                 jq -er \
                   --arg unable_marker "${UNABLE_REVIEW_MARKER}" \
                   --arg no_files_marker "${NO_FILES_REVIEW_MARKER}" \
-                  --arg completed_marker "${REVIEW_COMPLETED_MARKER}" \
-                  --arg quota_marker "${QUOTA_REVIEW_MARKER}" \
                   'def normalize_review_text:
                       ascii_downcase
                       | gsub("wasn[\u0027\u2019]t"; "was not")
@@ -147,8 +326,6 @@ jobs:
                       (.data.node.comments.nodes[]?.body // "");
                   ($unable_marker | normalize_review_text) as $unable
                   | ($no_files_marker | normalize_review_text) as $no_files
-                  | ($completed_marker | normalize_review_text) as $completed
-                  | ($quota_marker | normalize_review_text) as $quota
                   | [
                     ([
                       review_content
@@ -162,34 +339,20 @@ jobs:
                     ] | length),
                     ([
                       review_content
-                      | select(normalize_review_text | contains($quota))
-                    ] | length),
-                    ([
-                      review_content
                       | select((gsub("\\s"; "")) != "")
-                    ] | length),
-                    ([
-                      review_content
-                      | select(normalize_review_text | contains($completed))
                     ] | length)
                   ]
                   | @tsv' <<<"${response}"
               )"; then
                 echo "Unable to parse review content counts for review ${review_id}; refusing to accept the review." >&2
-                return 3
+                return 2
               fi
               if [[ ! "${content_counts}" =~ ${count_pattern} ]]; then
                 echo "Review ${review_id} returned invalid review content counts; refusing to accept the review." >&2
-                return 3
+                return 2
               fi
-              IFS=$'\t' read -r marker_count quota_count content_count completed_count <<<"${content_counts}"
-              if [ "${marker_count}" -gt 0 ] && [ "${completed_count}" -eq 0 ]; then
-                # A quota response is accepted only as a fallback; the
-                # independent thread gate below must still prove that every
-                # active Copilot finding is resolved.
-                if [ "${quota_count}" -gt 0 ]; then
-                  return 0
-                fi
+              IFS=$'\t' read -r marker_count content_count <<<"${content_counts}"
+              if [ "${marker_count}" -gt 0 ]; then
                 return 1
               fi
               if [ "${content_count}" -gt 0 ]; then
@@ -206,15 +369,16 @@ jobs:
               after="$(jq -r '.data.node.comments.pageInfo.endCursor // empty' <<<"${response}")"
               if [ -z "${after}" ]; then
                 echo "Review-comment pagination cursor is missing." >&2
-                return 3
+                return 2
               fi
             done
           }
 
           # A rejected review cannot become acceptable during this run without
           # an edit event, which starts a fresh run through the concurrency
-          # group. Cache rejected IDs so marker-only reviews cost one detail
-          # query per run instead of one query on every polling attempt.
+          # group. Cache rejected IDs so marker-only, empty, or whitespace-only
+          # reviews cost one detail query per run instead of one query on every
+          # polling attempt.
           declare -A rejected_review_ids=()
           review_complete=false
           head_sha=""
@@ -261,7 +425,7 @@ jobs:
                       )
                     | select(.state == "COMMENTED")
                     | select(.commit.oid == $head)
-                    | .id' <<<"${response}"
+                    | (.id // empty)' <<<"${response}"
               )"
               while IFS= read -r review_id; do
                 if [ -z "${review_id}" ]; then
@@ -278,9 +442,6 @@ jobs:
                   if [ "${comments_status}" -eq 2 ]; then
                     request_failed=true
                     break
-                  fi
-                  if [ "${comments_status}" -eq 3 ]; then
-                    exit 1
                   fi
                   rejected_review_ids["${review_id}"]=1
                 fi
@@ -338,7 +499,6 @@ jobs:
                   pageInfo { hasNextPage endCursor }
                   nodes {
                     isResolved
-                    isOutdated
                     comments(first: 1) {
                       nodes { author { login } }
                     }
@@ -382,7 +542,7 @@ jobs:
                   --arg reviewer "${COPILOT_REVIEWER_LOGIN}" \
                   '[
                     (.data.repository.pullRequest.reviewThreads.nodes // [])[]
-                    | select(.isResolved == false and .isOutdated == false)
+                    | select(.isResolved == false)
                     | select(
                         (.comments.nodes[0].author.login // "") as $login
                         | ($login == $reviewer or $login == ($reviewer + "[bot]"))

--- a/.github/workflows/renovate-guarded-automerge.yml
+++ b/.github/workflows/renovate-guarded-automerge.yml
@@ -4,17 +4,21 @@ name: Renovate guarded automerge
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled, ready_for_review]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled, ready_for_review, converted_to_draft]
 
 permissions:
   contents: write
+  issues: read
   pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   approve-renovate:
     name: Approve trusted Renovate PR
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
 
     steps:
       - name: Verify Renovate PR identity
@@ -22,9 +26,15 @@ jobs:
         env:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
           PR_HEAD: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_LABELS: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
           TRIGGER_ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -35,6 +45,32 @@ jobs:
           }
 
           trusted=true
+
+          live_pr="{}"
+          if ! live_pr="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"; then
+            trusted=false
+          fi
+          if ! jq -e \
+            --arg author "$PR_AUTHOR" \
+            --arg base "$PR_BASE" \
+            --arg head "$PR_HEAD" \
+            --arg head_sha "$PR_HEAD_SHA" \
+            --arg repo "$REPO" \
+            '(.state == "open") and (.draft == false)
+             and (.user.login == $author) and (.base.ref == $base)
+             and (.head.ref == $head) and (.head.sha == $head_sha)
+             and (.head.repo.full_name == $repo)
+             and ([.labels[].name] | index("renovate") != null)
+             and ([.labels[].name] | index("dependencies") != null)
+             and ([.labels[].name] | index("safe-automerge") != null)
+             and ([.labels[].name] | index("breaking-update") == null)' \
+            >/dev/null <<<"$live_pr"; then
+            trusted=false
+          fi
+
+          if [ "$PR_DRAFT" != "false" ]; then
+            trusted=false
+          fi
 
           if [ "$TRIGGER_ACTOR" != "renovate[bot]" ]; then
             trusted=false
@@ -53,22 +89,189 @@ jobs:
             trusted=false
           fi
 
-          if ! has_label renovate || ! has_label dependencies; then
+          if ! has_label renovate || ! has_label dependencies \
+            || ! has_label safe-automerge || has_label breaking-update; then
+            trusted=false
+          fi
+
+          label_events=""
+          if ! label_events="$(
+            gh api --paginate \
+              "repos/${REPO}/issues/${PR_NUMBER}/events?per_page=100" \
+              --jq '.[] | [.event, (.label.name // ""), (.actor.login // "")] | @tsv'
+          )"; then
+            trusted=false
+          fi
+          safe_event="$(
+            awk -F '\t' \
+              '$2 == "safe-automerge" && ($1 == "labeled" || $1 == "unlabeled") { latest=$0 } END { print latest }' \
+              <<<"$label_events"
+          )"
+          if [ "$safe_event" != $'labeled\tsafe-automerge\trenovate[bot]' ]; then
+            trusted=false
+          fi
+          if grep -Fq $'labeled\tbreaking-update\t' <<<"$label_events"; then
             trusted=false
           fi
 
           echo "trusted=$trusted" >>"$GITHUB_OUTPUT"
 
+      - name: Revoke auto-merge for an untrusted state or event
+        if: steps.guard.outputs.trusted != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          current_live_is_safe() {
+            local label_events live_pr safe_event
+            if ! live_pr="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"; then
+              return 1
+            fi
+            if ! jq -e \
+              --arg repo "$REPO" \
+              '(.state == "open") and (.draft == false)
+               and (.user.login == "renovate[bot]")
+               and (.base.ref == "develop")
+               and (.head.ref | startswith("renovate/"))
+               and (.head.repo.full_name == $repo)
+               and ([.labels[].name] | index("renovate") != null)
+               and ([.labels[].name] | index("dependencies") != null)
+               and ([.labels[].name] | index("safe-automerge") != null)
+               and ([.labels[].name] | index("breaking-update") == null)' \
+              >/dev/null <<<"$live_pr"; then
+              return 1
+            fi
+            if ! label_events="$(
+              gh api --paginate \
+                "repos/${REPO}/issues/${PR_NUMBER}/events?per_page=100" \
+                --jq '.[] | [.event, (.label.name // ""), (.actor.login // "")] | @tsv'
+            )"; then
+              return 1
+            fi
+            safe_event="$(
+              awk -F '\t' \
+                '$2 == "safe-automerge" && ($1 == "labeled" || $1 == "unlabeled") { latest=$0 } END { print latest }' \
+                <<<"$label_events"
+            )"
+            [ "$safe_event" = $'labeled\tsafe-automerge\trenovate[bot]' ] \
+              && ! grep -Fq $'labeled\tbreaking-update\t' <<<"$label_events"
+          }
+
+          if current_live_is_safe; then
+            echo "Current live PR state is safe; no revocation is needed."
+            exit 0
+          fi
+
+          owner="${REPO%%/*}"
+          name="${REPO#*/}"
+          query="query(\$owner:String!,\$name:String!,\$number:Int!){"
+          query+="repository(owner:\$owner,name:\$name){"
+          query+="pullRequest(number:\$number){autoMergeRequest{__typename}}}}"
+          auto_merge_enabled="$(
+            gh api graphql \
+              -f query="$query" \
+              -f owner="$owner" \
+              -f name="$name" \
+              -F number="$PR_NUMBER" \
+              --jq '.data.repository.pullRequest.autoMergeRequest != null'
+          )"
+          case "$auto_merge_enabled" in
+            true) gh pr merge "$PR_URL" --disable-auto ;;
+            false) ;;
+            *)
+              echo "ERROR: unable to determine auto-merge state for ${PR_URL}." >&2
+              exit 1
+              ;;
+          esac
+
       - name: Approve and enable auto-merge
         if: steps.guard.outputs.trusted == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
 
+          assert_live_safe() {
+            local label_events live_pr safe_event
+            if ! live_pr="$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")"; then
+              return 1
+            fi
+            if ! jq -e \
+              --arg author "$PR_AUTHOR" \
+              --arg base "$PR_BASE" \
+              --arg head "$PR_HEAD" \
+              --arg head_sha "$PR_HEAD_SHA" \
+              --arg repo "$REPO" \
+              '(.state == "open") and (.draft == false)
+               and (.user.login == $author) and (.base.ref == $base)
+               and (.head.ref == $head) and (.head.sha == $head_sha)
+               and (.head.repo.full_name == $repo)
+               and ([.labels[].name] | index("renovate") != null)
+               and ([.labels[].name] | index("dependencies") != null)
+               and ([.labels[].name] | index("safe-automerge") != null)
+               and ([.labels[].name] | index("breaking-update") == null)' \
+              >/dev/null <<<"$live_pr"; then
+              return 1
+            fi
+            if ! label_events="$(
+              gh api --paginate \
+                "repos/${REPO}/issues/${PR_NUMBER}/events?per_page=100" \
+                --jq '.[] | [.event, (.label.name // ""), (.actor.login // "")] | @tsv'
+            )"; then
+              return 1
+            fi
+            safe_event="$(
+              awk -F '\t' \
+                '$2 == "safe-automerge" && ($1 == "labeled" || $1 == "unlabeled") { latest=$0 } END { print latest }' \
+                <<<"$label_events"
+            )"
+            [ "$safe_event" = $'labeled\tsafe-automerge\trenovate[bot]' ] \
+              && ! grep -Fq $'labeled\tbreaking-update\t' <<<"$label_events"
+          }
+
+          disable_auto_merge() {
+            local auto_merge_enabled name owner query
+            owner="${REPO%%/*}"
+            name="${REPO#*/}"
+            query="query(\$owner:String!,\$name:String!,\$number:Int!){"
+            query+="repository(owner:\$owner,name:\$name){"
+            query+="pullRequest(number:\$number){autoMergeRequest{__typename}}}}"
+            auto_merge_enabled="$(
+              gh api graphql \
+                -f query="$query" \
+                -f owner="$owner" \
+                -f name="$name" \
+                -F number="$PR_NUMBER" \
+                --jq '.data.repository.pullRequest.autoMergeRequest != null'
+            )"
+            [ "$auto_merge_enabled" = false ] \
+              || gh pr merge "$PR_URL" --disable-auto
+          }
+
+          if ! assert_live_safe; then
+            disable_auto_merge
+            exit 1
+          fi
+          body="Approved a bot-triggered non-major Renovate update with a"
+          body+=" bot-applied safe-automerge label and no breaking-update history."
           gh pr review "$PR_URL" \
             --approve \
-            --body "Approved trusted Renovate dependency update after actor, label, branch, and base-branch checks."
+            --body "$body"
 
-          gh pr merge "$PR_URL" --auto --merge
+          if ! assert_live_safe; then
+            disable_auto_merge
+            exit 1
+          fi
+          gh pr merge "$PR_URL" --auto --merge \
+            --match-head-commit "$PR_HEAD_SHA"

--- a/molecule/shared/incus/create.yml
+++ b/molecule/shared/incus/create.yml
@@ -511,6 +511,10 @@
               )
           }}
       when: molecule_incus_network_before.rc != 0
+      register: molecule_incus_network_create
+      until: molecule_incus_network_create.rc == 0
+      retries: 3
+      delay: 10
       changed_when: true
 
     - name: Reconcile configuration only on the exact-owned managed network

--- a/renovate.json
+++ b/renovate.json
@@ -20,14 +20,29 @@
   "packageRules": [
     {
       "description": "Automerge safe non-major updates into develop after CI passes",
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "pinDigest"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest",
+        "pinDigest",
+        "lockFileMaintenance"
+      ],
+      "addLabels": ["safe-automerge"],
       "automerge": true,
       "automergeType": "pr"
     },
     {
       "description": "Require manual approval for major updates",
       "matchUpdateTypes": ["major"],
+      "addLabels": ["breaking-update"],
+      "automerge": false,
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Keep every component of the GitHub Actions toolchain on one version",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions"
     },
     {
       "description": "Keep community.general on 11.x for linux_system_roles compatibility",

--- a/scripts/prune_stale_incus_resources.py
+++ b/scripts/prune_stale_incus_resources.py
@@ -60,8 +60,13 @@ def prune(repository: str, current_run_id: str) -> None:
         if NETWORK_RE.fullmatch(name) is None or not isinstance(config, dict) or used_by:
             continue
         if exact_owner(config, repository, current_run_id) and revalidate("network", name, repository, current_run_id):
-            shown = json.loads(incus("network", "show", name, "--format", "json"))
-            if not shown.get("used_by", []):
+            refreshed = json.loads(incus("network", "list", "--format", "json"))
+            current = next((item for item in refreshed if item.get("name") == name), None)
+            if (
+                current is not None
+                and not current.get("used_by", [])
+                and exact_owner(current.get("config", {}), repository, current_run_id)
+            ):
                 incus("network", "delete", name, capture=False)
 
 

--- a/scripts/prune_stale_incus_resources.py
+++ b/scripts/prune_stale_incus_resources.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Remove unused Incus resources owned by superseded runs of this repository."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from typing import Any
+
+REPOSITORY_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+RUN_ID_RE = re.compile(r"^[1-9][0-9]*$")
+NETWORK_RE = re.compile(r"^lit[0-9a-f]{12}$")
+OWNER_KEY = "user.lit-molecule-owner"
+REPOSITORY_KEY = "user.lit-molecule-repository"
+RUN_ID_KEY = "user.lit-molecule-run-id"
+
+
+def incus(*arguments: str, capture: bool = True) -> str:
+    result = subprocess.run(  # noqa: S603 - argv is validated and never invokes a shell.
+        ["/usr/bin/incus", *arguments],
+        check=True,
+        capture_output=capture,
+        text=True,
+    )
+    return result.stdout or ""
+
+
+def exact_owner(config: dict[str, Any], repository: str, current_run_id: str) -> bool:
+    run_id = str(config.get(RUN_ID_KEY, ""))
+    return (
+        config.get(REPOSITORY_KEY) == repository
+        and bool(config.get(OWNER_KEY))
+        and RUN_ID_RE.fullmatch(run_id) is not None
+        and run_id != current_run_id
+    )
+
+
+def revalidate(kind: str, name: str, repository: str, current_run_id: str) -> bool:
+    values = {key: incus(kind, "get", name, key).strip() for key in (REPOSITORY_KEY, RUN_ID_KEY, OWNER_KEY)}
+    return exact_owner(values, repository, current_run_id)
+
+
+def prune(repository: str, current_run_id: str) -> None:
+    instances = json.loads(incus("list", "--format", "json"))
+    for instance in instances:
+        name = str(instance.get("name", ""))
+        config = instance.get("config", {})
+        if not name or not isinstance(config, dict):
+            continue
+        if exact_owner(config, repository, current_run_id) and revalidate("config", name, repository, current_run_id):
+            incus("delete", "--force", name, capture=False)
+
+    networks = json.loads(incus("network", "list", "--format", "json"))
+    for network in networks:
+        name = str(network.get("name", ""))
+        config = network.get("config", {})
+        used_by = network.get("used_by", [])
+        if NETWORK_RE.fullmatch(name) is None or not isinstance(config, dict) or used_by:
+            continue
+        if exact_owner(config, repository, current_run_id) and revalidate("network", name, repository, current_run_id):
+            shown = json.loads(incus("network", "show", name, "--format", "json"))
+            if not shown.get("used_by", []):
+                incus("network", "delete", name, capture=False)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--current-run-id", required=True)
+    args = parser.parse_args()
+    if REPOSITORY_RE.fullmatch(args.repository) is None:
+        parser.error("repository must be an owner/name slug")
+    if RUN_ID_RE.fullmatch(args.current_run_id) is None:
+        parser.error("current run ID must be a positive integer")
+    prune(args.repository, args.current_run_id)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_incus_lifecycle.py
+++ b/tests/unit/test_incus_lifecycle.py
@@ -202,19 +202,22 @@ class IncusLifecycleTests(unittest.TestCase):
         self.assertIn('echo "MOLECULE_TEST_IMAGE=$TEST_IMAGE"', action)
         self.assertIn("dependencies.mkdir(parents=True, exist_ok=True)", action)
 
-    def test_quality_action_enforces_inotify_capacity_before_network_creation(
+    def test_quality_action_prunes_only_superseded_exact_owned_resources(
         self,
     ) -> None:
-        action = (
-            ROOT / ".github" / "actions" / "run-quality-profile" / "action.yml"
-        ).read_text(encoding="utf-8")
+        action = (ROOT / ".github" / "actions" / "run-quality-profile" / "action.yml").read_text(encoding="utf-8")
 
-        self.assertIn("minimum_inotify_instances=4096", action)
-        self.assertIn("sudo sysctl -w", action)
+        self.assertIn("scripts/prune_stale_incus_resources.py", action)
         self.assertLess(
-            action.index("minimum_inotify_instances=4096"),
+            action.index("scripts/prune_stale_incus_resources.py"),
             action.index("molecule test"),
         )
+
+        helper = (ROOT / "scripts" / "prune_stale_incus_resources.py").read_text(encoding="utf-8")
+        self.assertIn("run_id != current_run_id", helper)
+        self.assertIn("config.get(REPOSITORY_KEY) == repository", helper)
+        self.assertIn("bool(config.get(OWNER_KEY))", helper)
+        self.assertIn("or used_by", helper)
 
     def test_legacy_static_entrypoint_fails_before_create(self) -> None:
         payload = yaml.safe_load((SHARED / "create-static-network.yml").read_text(encoding="utf-8"))

--- a/tests/unit/test_incus_lifecycle.py
+++ b/tests/unit/test_incus_lifecycle.py
@@ -202,6 +202,20 @@ class IncusLifecycleTests(unittest.TestCase):
         self.assertIn('echo "MOLECULE_TEST_IMAGE=$TEST_IMAGE"', action)
         self.assertIn("dependencies.mkdir(parents=True, exist_ok=True)", action)
 
+    def test_quality_action_enforces_inotify_capacity_before_network_creation(
+        self,
+    ) -> None:
+        action = (
+            ROOT / ".github" / "actions" / "run-quality-profile" / "action.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("minimum_inotify_instances=4096", action)
+        self.assertIn("sudo sysctl -w", action)
+        self.assertLess(
+            action.index("minimum_inotify_instances=4096"),
+            action.index("molecule test"),
+        )
+
     def test_legacy_static_entrypoint_fails_before_create(self) -> None:
         payload = yaml.safe_load((SHARED / "create-static-network.yml").read_text(encoding="utf-8"))
         self.assertEqual(

--- a/tests/unit/test_incus_lifecycle.py
+++ b/tests/unit/test_incus_lifecycle.py
@@ -55,6 +55,9 @@ class IncusLifecycleTests(unittest.TestCase):
         network_argv = str(network_create["ansible.builtin.command"]["argv"])
         self.assertIn("'incus', 'network', 'create'", network_argv)
         self.assertIn("user.lit-molecule-owner=", network_argv)
+        self.assertEqual(3, network_create["retries"])
+        self.assertEqual(10, network_create["delay"])
+        self.assertEqual("molecule_incus_network_create.rc == 0", network_create["until"])
 
         instance_init = task_named(
             tasks,
@@ -197,6 +200,7 @@ class IncusLifecycleTests(unittest.TestCase):
         action = (ROOT / ".github" / "actions" / "run-quality-profile" / "action.yml").read_text(encoding="utf-8")
         self.assertIn('echo "MOLECULE_TEST_INSTANCE=$instance"', action)
         self.assertIn('echo "MOLECULE_TEST_IMAGE=$TEST_IMAGE"', action)
+        self.assertIn("dependencies.mkdir(parents=True, exist_ok=True)", action)
 
     def test_legacy_static_entrypoint_fails_before_create(self) -> None:
         payload = yaml.safe_load((SHARED / "create-static-network.yml").read_text(encoding="utf-8"))

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -64,10 +64,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         )
 
         jobs = workflow["jobs"]
-        groups = [
-            jobs[name]["concurrency"]["group"]
-            for name in ("tiny-cells", "heavy-cells", "acceptance-cells")
-        ]
+        groups = [jobs[name]["concurrency"]["group"] for name in ("tiny-cells", "heavy-cells", "acceptance-cells")]
         for group in groups:
             self.assertIn("github.repository", group)
             self.assertIn("github.workflow", group)


### PR DESCRIPTION
## What changed

- deploy the canonical exact-head trusted-Renovate Copilot gate and guarded auto-merge workflow
- align the supplementary Renovate override with safe-automerge, breaking-update, lock-file, and grouped Actions policy
- recreate dependency evidence immediately before binding exact scenario inputs
- retry transient Incus network creation failures with a bounded fail-closed policy
- format the previously merged concurrency regression test

## Root causes

The supplementary enterprise-safe sync intentionally omitted managed workflow and Renovate-policy updates, leaving PR #389 on the obsolete Copilot path. Runtime evidence cleanup could remove the dependency directory before the binding step. The protected Incus runner also hit dnsmasq inotify exhaustion during network creation.

## Validation

- `python3 -m unittest tests.unit.test_incus_lifecycle tests.unit.test_workflow_security` (23 passed)
- role-quality Ruff formatting hook
- JSON and YAML parsing
- `git diff --check`
