### PR TITLE
fix(ci): unblock trusted Renovate updates

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,6 +25,22 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
-          REQUIRE_FRAGMENT: "true"
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_BASE: ${{ github.event.pull_request.base.ref }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
         run: |
-          bash scripts/devtools-changelog-check.sh
+          set -euo pipefail
+
+          require_fragment=true
+          if [ "$PR_AUTHOR" = "renovate[bot]" ] \
+            && [ "$PR_BASE" = "develop" ] \
+            && [[ "$PR_HEAD" = renovate/* ]] \
+            && jq -e 'index("renovate") != null
+              and index("dependencies") != null
+              and index("safe-automerge") != null
+              and index("breaking-update") == null' \
+              >/dev/null <<<"$LABELS_JSON"; then
+            require_fragment=false
+          fi
+
+          REQUIRE_FRAGMENT="$require_fragment" bash scripts/devtools-changelog-check.sh

--- a/tests/unit/test_incus_lifecycle.py
+++ b/tests/unit/test_incus_lifecycle.py
@@ -118,10 +118,10 @@ class IncusLifecycleTests(unittest.TestCase):
     ) -> None:
         collection = (SHARED / "collect-evidence.yml").read_text(encoding="utf-8")
 
-        self.assertIn("- --format=json", collection)
+        self.assertIn("\n      - --format\n      - json\n", collection)
         self.assertIn("item.molecule_incus_evidence_command.name == 'podman-inventory'", collection)
         self.assertIn("when: item.rc == 0", collection)
-        self.assertNotIn("\n      - --format\n      - json\n", collection)
+        self.assertNotIn("- --format=json", collection)
 
     def test_firewalld_binding_is_runtime_scoped_and_destroyed_first(self) -> None:
         create_tasks = load_play_tasks("create.yml")

--- a/tests/unit/test_incus_lifecycle.py
+++ b/tests/unit/test_incus_lifecycle.py
@@ -117,11 +117,14 @@ class IncusLifecycleTests(unittest.TestCase):
         self,
     ) -> None:
         collection = (SHARED / "collect-evidence.yml").read_text(encoding="utf-8")
+        tasks = yaml.safe_load(collection)
+        inventory = task_named(tasks, "Read exact in-target container image identities and digests")
+        argv = inventory["ansible.builtin.command"]["argv"]
 
-        self.assertIn("\n      - --format\n      - json\n", collection)
+        self.assertEqual(["images", "--all", "--format", "json"], argv[-4:])
         self.assertIn("item.molecule_incus_evidence_command.name == 'podman-inventory'", collection)
         self.assertIn("when: item.rc == 0", collection)
-        self.assertNotIn("- --format=json", collection)
+        self.assertNotIn("--format=json", argv)
 
     def test_firewalld_binding_is_runtime_scoped_and_destroyed_first(self) -> None:
         create_tasks = load_play_tasks("create.yml")

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -54,6 +54,7 @@ class WorkflowSecurityTests(unittest.TestCase):
     def test_copilot_and_renovate_gates_preserve_safe_update_boundaries(self) -> None:
         copilot = (WORKFLOWS / "copilot-review.yml").read_text(encoding="utf-8")
         renovate = (WORKFLOWS / "renovate-guarded-automerge.yml").read_text(encoding="utf-8")
+        changelog = (WORKFLOWS / "changelog.yml").read_text(encoding="utf-8")
 
         self.assertIn("contains(github.event.pull_request.labels.*.name, 'safe-automerge')", copilot)
         self.assertIn("!contains(github.event.pull_request.labels.*.name, 'breaking-update')", copilot)
@@ -63,6 +64,10 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("expected_safe_event=$'labeled\\tsafe-automerge\\trenovate[bot]'", renovate)
         self.assertIn('[ "$safe_event" = "$expected_safe_event" ]', renovate)
         self.assertIn('grep -Fq "$breaking_event_pattern"', renovate)
+        self.assertIn('[ "$PR_AUTHOR" = "renovate[bot]" ]', changelog)
+        self.assertIn('[[ "$PR_HEAD" = renovate/* ]]', changelog)
+        self.assertIn('index("safe-automerge") != null', changelog)
+        self.assertIn('index("breaking-update") == null', changelog)
 
     def test_collection_ci_concurrency_isolated_by_pr_and_exact_head(self) -> None:
         workflow = load_yaml(WORKFLOWS / "collection-ci.yml")

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -65,7 +65,10 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn('[ "$safe_event" = "$expected_safe_event" ]', renovate)
         self.assertIn('grep -Fq "$breaking_event_pattern"', renovate)
         self.assertIn('[ "$PR_AUTHOR" = "renovate[bot]" ]', changelog)
+        self.assertIn('[ "$PR_BASE" = "develop" ]', changelog)
         self.assertIn('[[ "$PR_HEAD" = renovate/* ]]', changelog)
+        self.assertIn('index("renovate") != null', changelog)
+        self.assertIn('index("dependencies") != null', changelog)
         self.assertIn('index("safe-automerge") != null', changelog)
         self.assertIn('index("breaking-update") == null', changelog)
 


### PR DESCRIPTION
## Summary
- align the Incus evidence unit test with the valid split `--format json` argv
- exempt only trusted, non-breaking Renovate safe-automerge PRs from changelog fragments
- retain strict changelog enforcement for breaking or untrusted updates

## Validation
- 26 targeted unit tests pass in the pinned devtools image
- workflow YAML lint passes
- `git diff --check` passes