### PR TITLE
feat: migrate supplementary release automation to GitHub App

### DIFF
--- a/.github/workflows/promote-develop-to-main.yml
+++ b/.github/workflows/promote-develop-to-main.yml
@@ -47,7 +47,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           permission-contents: read
-          permission-issues: write
           permission-pull-requests: write
 
       - name: Checkout

--- a/.github/workflows/promote-develop-to-main.yml
+++ b/.github/workflows/promote-develop-to-main.yml
@@ -45,6 +45,10 @@ jobs:
           client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: read
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7

--- a/.github/workflows/promote-develop-to-main.yml
+++ b/.github/workflows/promote-develop-to-main.yml
@@ -38,17 +38,13 @@ jobs:
       pull-requests: read
 
     steps:
-      - name: Resolve release token
-        id: token
-        env:
-          TOKEN: ${{ secrets.LITRELEASEBOT_TOKEN }}
-        run: |
-          set -euo pipefail
-          test -n "${TOKEN:-}"
-          identity="$(GH_TOKEN="$TOKEN" gh api user --jq \
-            '[.login, (.id | tostring), .type] | @tsv')"
-          test "$identity" = $'litreleasebot\t250056030\tUser'
-          echo "value=$TOKEN" >> "$GITHUB_OUTPUT"
+      - name: Mint release automation App token
+        id: release-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.0.0
+        with:
+          client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
@@ -58,7 +54,7 @@ jobs:
 
       - name: Create or update promotion PR
         env:
-          RELEASE_TOKEN: ${{ steps.token.outputs.value }}
+          RELEASE_TOKEN: ${{ steps.release-app.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release-back-sync.yml
+++ b/.github/workflows/release-back-sync.yml
@@ -42,6 +42,10 @@ jobs:
           client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Resolve release automation App bot identity
         id: release-bot

--- a/.github/workflows/release-back-sync.yml
+++ b/.github/workflows/release-back-sync.yml
@@ -35,32 +35,41 @@ jobs:
     environment: ansible-collection-release-prepare
 
     steps:
-      - name: Resolve release token
-        id: token
+      - name: Mint release automation App token
+        id: release-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.0.0
+        with:
+          client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Resolve release automation App bot identity
+        id: release-bot
         env:
-          TOKEN: ${{ secrets.LITRELEASEBOT_TOKEN }}
+          APP_SLUG: ${{ steps.release-app.outputs.app-slug }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if [ -n "${TOKEN:-}" ]; then
-            identity="$(GH_TOKEN="$TOKEN" gh api user --jq \
-              '[.login, (.id | tostring), .type] | @tsv')"
-            test "$identity" = $'litreleasebot\t250056030\tUser'
-            echo "value=$TOKEN" >> "$GITHUB_OUTPUT"
-            exit 0
+          bot_json="$(gh api "users/${APP_SLUG}%5Bbot%5D" 2>/dev/null || printf '{}')"
+          login="$(jq -r '.login // ""' <<<"$bot_json")"
+          bot_id="$(jq -r '.id // ""' <<<"$bot_json")"
+          if [ "$login" != "${APP_SLUG}[bot]" ] || ! [[ "$bot_id" =~ ^[0-9]+$ ]]; then
+            echo "::error::Unable to resolve the release automation App bot identity."
+            exit 1
           fi
-          echo "::error::The protected-environment LITRELEASEBOT_TOKEN is required."
-          exit 1
+          echo "login=$login" >>"$GITHUB_OUTPUT"
+          echo "email=${bot_id}+${login}@users.noreply.github.com" >>"$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
-          token: ${{ steps.token.outputs.value }}
+          token: ${{ steps.release-app.outputs.token }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Open or update release back-sync PR
         env:
-          GH_TOKEN: ${{ steps.token.outputs.value }}
+          GH_TOKEN: ${{ steps.release-app.outputs.token }}
           TAG_INPUT: ${{ github.event.inputs.tag }}
           EXPECTED_TAG_APP_SLUG: ${{ github.event.inputs.release_tag_app_slug }}
           EXPECTED_TAG_APP_ID: ${{ github.event.inputs.release_tag_app_id }}
@@ -89,8 +98,8 @@ jobs:
             exit 0
           fi
 
-          git config user.name "litreleasebot"
-          git config user.email "litreleasebot@users.noreply.github.com"
+          git config user.name "${{ steps.release-bot.outputs.login }}"
+          git config user.email "${{ steps.release-bot.outputs.email }}"
           git fetch origin main develop
 
           remote_tag="$(

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -58,26 +58,35 @@ jobs:
     environment: ansible-collection-release-prepare
 
     steps:
-      - name: Resolve release token
-        id: token
+      - name: Mint release automation App token
+        id: release-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.0.0
+        with:
+          client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Resolve release automation App bot identity
+        id: release-bot
         env:
-          TOKEN: ${{ secrets.LITRELEASEBOT_TOKEN }}
+          APP_SLUG: ${{ steps.release-app.outputs.app-slug }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if [ -n "${TOKEN:-}" ]; then
-            identity="$(GH_TOKEN="$TOKEN" gh api user --jq \
-              '[.login, (.id | tostring), .type] | @tsv')"
-            test "$identity" = $'litreleasebot\t250056030\tUser'
-            echo "value=$TOKEN" >> "$GITHUB_OUTPUT"
-            exit 0
+          bot_json="$(gh api "users/${APP_SLUG}%5Bbot%5D" 2>/dev/null || printf '{}')"
+          login="$(jq -r '.login // ""' <<<"$bot_json")"
+          bot_id="$(jq -r '.id // ""' <<<"$bot_json")"
+          if [ "$login" != "${APP_SLUG}[bot]" ] || ! [[ "$bot_id" =~ ^[0-9]+$ ]]; then
+            echo "::error::Unable to resolve the release automation App bot identity."
+            exit 1
           fi
-          echo "::error::The protected-environment LITRELEASEBOT_TOKEN is required."
-          exit 1
+          echo "login=$login" >>"$GITHUB_OUTPUT"
+          echo "email=${bot_id}+${login}@users.noreply.github.com" >>"$GITHUB_OUTPUT"
 
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
         with:
-          token: ${{ steps.token.outputs.value }}
+          token: ${{ steps.release-app.outputs.token }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -97,7 +106,7 @@ jobs:
       - name: Prepare release branch
         id: prepare-release
         env:
-          GH_TOKEN: ${{ steps.token.outputs.value }}
+          GH_TOKEN: ${{ steps.release-app.outputs.token }}
           VERSION_INPUT: ${{ github.event.inputs.version }}
           BASE_BRANCH_INPUT: ${{ github.event.inputs.base_branch }}
           TARGET_BRANCH_INPUT: ${{ github.event.inputs.target_branch }}
@@ -131,8 +140,8 @@ jobs:
             exit 1
           fi
 
-          git config user.name "litreleasebot"
-          git config user.email "litreleasebot@users.noreply.github.com"
+          git config user.name "${{ steps.release-bot.outputs.login }}"
+          git config user.email "${{ steps.release-bot.outputs.email }}"
           git fetch origin "$BASE_BRANCH" "$TARGET_BRANCH"
           git switch -C release-prepare-base "origin/$BASE_BRANCH"
           BASE_SHA="$(git rev-parse HEAD)"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -65,6 +65,10 @@ jobs:
           client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: Resolve release automation App bot identity
         id: release-bot

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -67,7 +67,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           permission-contents: write
-          permission-issues: write
           permission-pull-requests: write
 
       - name: Resolve release automation App bot identity

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -477,15 +477,12 @@ class WorkflowSecurityTests(unittest.TestCase):
             with self.subTest(workflow=name):
                 text = (WORKFLOWS / name).read_text(encoding="utf-8")
                 self.assertIn(
-                    "actions/create-github-app-token@"
-                    "bcd2ba49218906704ab6c1aa796996da409d3eb1",
+                    "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
                     text,
                 )
                 self.assertIn("RELEASE_AUTOMATION_APP_CLIENT_ID", text)
                 self.assertIn("RELEASE_AUTOMATION_APP_PRIVATE_KEY", text)
-                self.assertIn(
-                    "repositories: ${{ github.event.repository.name }}", text
-                )
+                self.assertIn("repositories: ${{ github.event.repository.name }}", text)
                 self.assertIn("permission-pull-requests: write", text)
                 self.assertNotIn("LITRELEASEBOT_TOKEN", text)
                 self.assertNotIn("litreleasebot", text)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -468,7 +468,7 @@ class WorkflowSecurityTests(unittest.TestCase):
             scorecard_action["inputs"]["publish_results"]["default"],
         )
 
-    def test_release_bot_tokens_are_bound_to_the_reviewed_account_id(self) -> None:
+    def test_release_automation_uses_the_organization_app(self) -> None:
         for name in (
             "promote-develop-to-main.yml",
             "release-back-sync.yml",
@@ -476,9 +476,17 @@ class WorkflowSecurityTests(unittest.TestCase):
         ):
             with self.subTest(workflow=name):
                 text = (WORKFLOWS / name).read_text(encoding="utf-8")
-                self.assertIn("[.login, (.id | tostring), .type] | @tsv", text)
-                self.assertIn("litreleasebot\\t250056030\\tUser", text)
-                self.assertNotIn("gh api user --jq .login", text)
+                self.assertIn("actions/create-github-app-token@", text)
+                self.assertIn("RELEASE_AUTOMATION_APP_CLIENT_ID", text)
+                self.assertIn("RELEASE_AUTOMATION_APP_PRIVATE_KEY", text)
+                self.assertNotIn("LITRELEASEBOT_TOKEN", text)
+                self.assertNotIn("litreleasebot", text)
+
+        for name in ("release-back-sync.yml", "release-prepare.yml"):
+            with self.subTest(identity_workflow=name):
+                text = (WORKFLOWS / name).read_text(encoding="utf-8")
+                self.assertIn("steps.release-bot.outputs.login", text)
+                self.assertIn("steps.release-bot.outputs.email", text)
 
         back_sync = (WORKFLOWS / "release-back-sync.yml").read_text(encoding="utf-8")
         self.assertIn('"--force-with-lease=${branch_ref}:${remote_branch_sha}"', back_sync)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -476,9 +476,17 @@ class WorkflowSecurityTests(unittest.TestCase):
         ):
             with self.subTest(workflow=name):
                 text = (WORKFLOWS / name).read_text(encoding="utf-8")
-                self.assertIn("actions/create-github-app-token@", text)
+                self.assertIn(
+                    "actions/create-github-app-token@"
+                    "bcd2ba49218906704ab6c1aa796996da409d3eb1",
+                    text,
+                )
                 self.assertIn("RELEASE_AUTOMATION_APP_CLIENT_ID", text)
                 self.assertIn("RELEASE_AUTOMATION_APP_PRIVATE_KEY", text)
+                self.assertIn(
+                    "repositories: ${{ github.event.repository.name }}", text
+                )
+                self.assertIn("permission-pull-requests: write", text)
                 self.assertNotIn("LITRELEASEBOT_TOKEN", text)
                 self.assertNotIn("litreleasebot", text)
 


### PR DESCRIPTION
Migrates the repository-specific protected promotion, release preparation, and release back-sync workflows to the organization release automation GitHub App. Updates workflow security coverage and removes the legacy bot credential dependency.