### PR TITLE
fix: serialize delegated quality profiles

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -476,7 +476,10 @@ jobs:
       (github.event_name == 'workflow_dispatch' &&
        ((inputs.execution_mode == 'manual-main' && github.ref == 'refs/heads/main') ||
         (inputs.execution_mode == 'nightly-develop' && github.ref == 'refs/heads/develop'))))
-    needs: [build-install, quality-matrix]
+    # The reusable validation workflow has a repository-wide Incus concurrency
+    # group. Run acceptance only after the Heavy aggregate completes so the two
+    # delegated profiles from this workflow cannot cancel each other.
+    needs: [build-install, quality-matrix, heavy]
     uses: lightning-it/modulix-validation/.github/workflows/collection-quality-profile.yml@ec110a9545dc6b8efe4ed8820b50b27912175111
     with:
       profile: application_acceptance

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -200,6 +200,12 @@ class WorkflowSecurityTests(unittest.TestCase):
                 delegated["with"]["source-sha"],
             )
 
+        self.assertIn(
+            "heavy",
+            jobs["acceptance-cells"]["needs"],
+            "delegated Incus profiles must run serially to avoid concurrency cancellation",
+        )
+
     def test_all_workflows_and_local_actions_require_release_team_review(self) -> None:
         codeowners = (ROOT / ".github" / "CODEOWNERS").read_text(encoding="utf-8")
         rules = {


### PR DESCRIPTION
## Summary
- run the delegated application-acceptance profile only after the Heavy aggregate finishes
- prevent the shared `modulix-validation-incus` concurrency group from cancelling one mandatory profile with the other
- add a workflow-policy regression assertion

## Validation
- `python3.13 -m unittest tests.unit.test_workflow_security.WorkflowSecurityTests.test_collection_ci_concurrency_isolated_by_pr_and_exact_head`
- `git diff --check`

The full local workflow-security module otherwise reached 16 passing tests and one environment-only error because this macOS host has no `/usr/bin/bash`; CI provides that path.