### PR TITLE
fix(aap): validate service fqdn during preflight

### DIFF
--- a/changelogs/fragments/aap-preflight-transport-address-hotfix.yml
+++ b/changelogs/fragments/aap-preflight-transport-address-hotfix.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    Validate the configured AAP service FQDN during preflight instead of the
+    execution environment's SSH transport address.

--- a/roles/aap_preflight/tasks/main.yml
+++ b/roles/aap_preflight/tasks/main.yml
@@ -103,7 +103,7 @@
     database: ahostsv4
     key: "{{ item }}"
   loop:
-    - "{{ ansible_host | default(inventory_hostname) }}"
+    - "{{ aap_preflight_expected_fqdn }}"
     - >-
       {{
         (


### PR DESCRIPTION
Emergency production unblock.

The AAP preflight resolved the SSH transport address (`host.containers.internal`) on the managed host. It now validates `aap_preflight_expected_fqdn`, preserving the separation between EE transport routing and the AAP service identity.

Validated locally:
- yamllint
- ansible-lint production profile
- aap-preflight-basic Molecule converge/idempotence/verify
- collection smoke test
- changelog policy

The full unrelated Molecule matrix also reached the affected scenario successfully; a separate Vault cleanup later failed because the local evidence directory was not writable.