### PR TITLE
fix(release): correct validation repository name

### DIFF
--- a/changelogs/fragments/delegate-infrastructure-validation.yml
+++ b/changelogs/fragments/delegate-infrastructure-validation.yml
@@ -2,5 +2,5 @@
 minor_changes:
   - >-
     Delegate protected Heavy and Application Acceptance execution to the pinned
-    reusable workflow owned by ``modulix-validation-lit`` while retaining the
+    reusable workflow owned by ``modulix-validation`` while retaining the
     exact-candidate, evidence, and fail-closed collection release gates.


### PR DESCRIPTION
Emergency release unblock.

Correct the public validation repository name in the pending v2.0.0 changelog source fragment. This addresses the existing Copilot release finding before regenerating the release candidate.

Validated locally with yamllint, changelog policy, and whitespace checks.