### PR TITLE
fix(release): select only collection publish candidate

### DIFF
--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -483,7 +483,8 @@ jobs:
           set -euo pipefail
 
           mapfile -t candidates < <(
-            find incoming/candidate -maxdepth 1 -type f -name '*.tar.gz' -print
+            find incoming/candidate -maxdepth 1 -type f \
+              -name 'lit-supplementary-*.tar.gz' -print
           )
           test "${#candidates[@]}" -eq 1
           candidate="${candidates[0]}"

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -93,6 +93,13 @@ class WorkflowSecurityTests(unittest.TestCase):
             "find artifacts/candidate -maxdepth 1 -type f -name '*.tar.gz'",
             workflow,
         )
+
+        publish_workflow = (WORKFLOWS / "collection-publish.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("-name 'lit-supplementary-*.tar.gz'", publish_workflow)
+        self.assertNotIn("-name '*.tar.gz'", publish_workflow)
+
         payload = load_yaml(WORKFLOWS / "collection-ci.yml")
         self.assertNotIn("QUALITY_SOURCE_SHA", payload["env"])
         self.assertEqual(


### PR DESCRIPTION
Emergency publish unblock: restrict the publish candidate lookup to lit-supplementary archives so the runtime collection bundle is not counted as a second candidate. Includes a regression assertion. Local workflow unit tests and actionlint pass.