### PR TITLE
fix(release): record publish candidate correction

### DIFF
--- a/changelogs/fragments/490-publish-candidate-selection.yml
+++ b/changelogs/fragments/490-publish-candidate-selection.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    Restrict release publication to the lit.supplementary collection archive
+    when runtime evidence bundles are present beside the candidate.


### PR DESCRIPTION
Emergency follow-up for the validated publication candidate fix. Adds the changelog fragment required for an App-authored v2.0.1 release preparation.