### PR TITLE
fix(release): scope public candidate checksum

### DIFF
--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -730,8 +730,11 @@ jobs:
           mv dist/release/SHA256SUMS.sigstore.json \
             dist/release/ci-release-assets-SHA256SUMS.sigstore.json
           cp "incoming/candidate/${CANDIDATE_NAME}" dist/release/
-          cp incoming/candidate/candidate-SHA256SUMS \
-            dist/release/ci-candidate-SHA256SUMS
+          awk -v candidate="$CANDIDATE_NAME" \
+            '$2 == candidate { print }' \
+            incoming/candidate/candidate-SHA256SUMS \
+            > dist/release/ci-candidate-SHA256SUMS
+          test "$(wc -l < dist/release/ci-candidate-SHA256SUMS)" -eq 1
           cp incoming/evidence/evidence/security/vulnerability-report.json \
             dist/release/vulnerability-report.json
           cp incoming/evidence/evidence/security/secret-scan-summary.json \

--- a/changelogs/fragments/495-release-candidate-checksum.yml
+++ b/changelogs/fragments/495-release-candidate-checksum.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    Limit the public release candidate checksum manifest to the collection
+    archive when the CI candidate artifact also contains a runtime bundle.

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -97,6 +97,14 @@ class WorkflowSecurityTests(unittest.TestCase):
         publish_workflow = (WORKFLOWS / "collection-publish.yml").read_text(encoding="utf-8")
         self.assertIn("-name 'lit-supplementary-*.tar.gz'", publish_workflow)
         self.assertNotIn("-name '*.tar.gz'", publish_workflow)
+        self.assertIn(
+            "'$2 == candidate { print }'",
+            publish_workflow,
+        )
+        self.assertNotIn(
+            "cp incoming/candidate/candidate-SHA256SUMS",
+            publish_workflow,
+        )
 
         payload = load_yaml(WORKFLOWS / "collection-ci.yml")
         self.assertNotIn("QUALITY_SOURCE_SHA", payload["env"])


### PR DESCRIPTION
Emergency publish unblock: retain only the selected collection archive in the public candidate checksum manifest; the internal runtime bundle remains validated before release assembly. Includes a regression assertion and patch fragment. All 22 affected unit tests, Ruff, yamllint, actionlint, and diff checks pass.