### PR TITLE
Delegate candidate Heavy validation to modulix-validation

### DIFF
--- a/.github/workflows/candidate-platform-validation.yml
+++ b/.github/workflows/candidate-platform-validation.yml
@@ -57,7 +57,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
-      cells: ${{ steps.matrix.outputs.cells }}
+      tiny: ${{ steps.matrix.outputs.tiny }}
+      heavy: ${{ steps.matrix.outputs.heavy }}
+      acceptance: ${{ steps.matrix.outputs.acceptance }}
     steps:
       - name: Checkout exact protected-branch source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
@@ -74,12 +76,19 @@ jobs:
         run: |
           set -euo pipefail
           python scripts/validate-role-coverage.py validate
-          cells="$(python - <<'PY'
+          python - <<'PY'
           import json
+          import os
           import subprocess
+          from pathlib import Path
 
-          cells = []
-          for profile in ("tiny", "heavy", "application_acceptance"):
+          profiles = {
+              "tiny": "tiny",
+              "heavy": "heavy",
+              "acceptance": "application_acceptance",
+          }
+          matrices = {}
+          for output_name, profile in profiles.items():
               output = subprocess.check_output(
                   [
                       "python",
@@ -92,19 +101,26 @@ jobs:
                   ],
                   text=True,
               )
-              cells.extend(json.loads(output)["include"])
-          if not cells:
-              raise SystemExit("candidate platform matrix is empty")
-          if any(
-              cell.get("target_disposition") != "candidate"
-              or cell.get("release_required") is not False
-              for cell in cells
-          ):
-              raise SystemExit("candidate platform matrix contains a release-required cell")
-          print(json.dumps({"include": cells}, separators=(",", ":")))
+              matrix = json.loads(output)
+              cells = matrix.get("include")
+              if not isinstance(cells, list) or not cells:
+                  raise SystemExit(f"candidate {profile} matrix is empty")
+              if any(
+                  cell.get("profile") != profile
+                  or cell.get("target_disposition") != "candidate"
+                  or cell.get("release_required") is not False
+                  for cell in cells
+              ):
+                  raise SystemExit(f"candidate {profile} matrix violates its contract")
+              matrices[output_name] = json.dumps(
+                  matrix,
+                  separators=(",", ":"),
+              )
+
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as stream:
+              for output_name, matrix in matrices.items():
+                  stream.write(f"{output_name}={matrix}\n")
           PY
-          )"
-          echo "cells=$cells" >> "$GITHUB_OUTPUT"
 
   build:
     name: Build exact candidate-platform source
@@ -148,13 +164,13 @@ jobs:
           if-no-files-found: error
           retention-days: 30
 
-  candidate-cells:
-    name: Candidate only / ${{ matrix.profile }} / ${{ matrix.target }}
+  candidate-tiny-cells:
+    name: Candidate only / tiny / ${{ matrix.target }}
     needs: [source, matrix, build]
     strategy:
       fail-fast: false
       max-parallel: 2
-      matrix: ${{ fromJSON(needs.matrix.outputs.cells) }}
+      matrix: ${{ fromJSON(needs.matrix.outputs.tiny) }}
     runs-on: ${{ matrix.runner }}
     environment: ansible-collection-runtime-protected
     timeout-minutes: 180
@@ -185,17 +201,49 @@ jobs:
           memory-limit: 12GiB
           disk-limit: 24GiB
 
+  candidate-heavy-cells:
+    name: Candidate Heavy matrix (delegated to modulix-validation)
+    needs: [source, matrix, build]
+    uses: lightning-it/modulix-validation/.github/workflows/collection-quality-profile.yml@ec110a9545dc6b8efe4ed8820b50b27912175111
+    with:
+      profile: heavy
+      matrix-json: ${{ needs.matrix.outputs.heavy }}
+      candidate-artifact: candidate-platform-source-${{ needs.source.outputs.sha }}
+      source-sha: ${{ needs.source.outputs.sha }}
+      environment-name: ansible-collection-runtime-protected
+    secrets: inherit
+
+  candidate-acceptance-cells:
+    name: Candidate Application Acceptance matrix (delegated to modulix-validation)
+    needs: [source, matrix, build, candidate-heavy-cells]
+    uses: lightning-it/modulix-validation/.github/workflows/collection-quality-profile.yml@ec110a9545dc6b8efe4ed8820b50b27912175111
+    with:
+      profile: application_acceptance
+      matrix-json: ${{ needs.matrix.outputs.acceptance }}
+      candidate-artifact: candidate-platform-source-${{ needs.source.outputs.sha }}
+      source-sha: ${{ needs.source.outputs.sha }}
+      environment-name: ansible-collection-runtime-protected
+    secrets: inherit
+
   promotion-input:
     name: Candidate platform / Promotion input only
     if: always()
-    needs: [source, matrix, build, candidate-cells]
+    needs:
+      - source
+      - matrix
+      - build
+      - candidate-tiny-cells
+      - candidate-heavy-cells
+      - candidate-acceptance-cells
     runs-on: ubuntu-latest
     steps:
       - name: Require all candidate cells and state the promotion boundary
         env:
           MATRIX_RESULT: ${{ needs.matrix.result }}
           BUILD_RESULT: ${{ needs.build.result }}
-          CELLS_RESULT: ${{ needs.candidate-cells.result }}
+          TINY_RESULT: ${{ needs.candidate-tiny-cells.result }}
+          HEAVY_RESULT: ${{ needs.candidate-heavy-cells.result }}
+          ACCEPTANCE_RESULT: ${{ needs.candidate-acceptance-cells.result }}
           EVENT_NAME: ${{ github.event_name }}
           SOURCE_REF: ${{ needs.source.outputs.ref }}
         run: |
@@ -206,7 +254,9 @@ jobs:
           esac
           test "$MATRIX_RESULT" = success
           test "$BUILD_RESULT" = success
-          test "$CELLS_RESULT" = success
+          test "$TINY_RESULT" = success
+          test "$HEAVY_RESULT" = success
+          test "$ACCEPTANCE_RESULT" = success
           {
             echo "### Candidate platform validation passed"
             echo

--- a/TESTING.md
+++ b/TESTING.md
@@ -38,6 +38,20 @@ mandatory where access control applies.
 `verify` is a Molecule phase in every scenario. It is not a fourth profile, and
 converge alone is never a pass.
 
+## Execution ownership
+
+Tiny remains a repository-local component gate. The component-specific
+Molecule scenarios and assertions for all profiles also remain in this
+repository. Heavy and Application Acceptance execution, including candidate
+platform validation, is orchestrated only by the commit-pinned reusable
+workflow in `lightning-it/modulix-validation`.
+
+The collection passes the exact candidate artifact, source commit, profile,
+scenario, and platform matrix to that workflow. Stable aggregate jobs fail
+closed if a required delegated profile is skipped or does not succeed. This
+implements the accepted
+[Modulix test execution ownership ADR](https://wiki.cloud.l-it.io/wiki/spaces/LIT/pages/2886566105).
+
 ## Local validation
 
 Run the deterministic policy and unit checks first:

--- a/changelogs/fragments/adr-heavy-execution-ownership.yml
+++ b/changelogs/fragments/adr-heavy-execution-ownership.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - >-
+    Route candidate-platform Heavy and Application Acceptance execution through
+    the pinned ``modulix-validation`` reusable workflow while retaining local
+    Tiny execution, exact-candidate evidence, and fail-closed promotion gates.

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -114,8 +114,13 @@ class WorkflowSecurityTests(unittest.TestCase):
                 self.assertNotIn("memory-limit", delegated["with"])
         self.assertEqual(
             "12GiB",
-            candidate["jobs"]["candidate-cells"]["steps"][1]["with"]["memory-limit"],
+            candidate["jobs"]["candidate-tiny-cells"]["steps"][1]["with"]["memory-limit"],
         )
+        for job in ("candidate-heavy-cells", "candidate-acceptance-cells"):
+            with self.subTest(job=job):
+                delegated = candidate["jobs"][job]
+                self.assertIn("lightning-it/modulix-validation/", delegated["uses"])
+                self.assertNotIn("memory-limit", delegated["with"])
         for scenario in ("keycloak-tiny", "keycloak-heavy", "keycloak-application-acceptance"):
             with self.subTest(scenario=scenario):
                 molecule = (ROOT / "molecule" / scenario / "molecule.yml").read_text(encoding="utf-8")
@@ -383,19 +388,49 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("source_ref=refs/heads/develop", source_step)
         self.assertEqual("source", jobs["matrix"]["needs"])
         self.assertEqual("source", jobs["build"]["needs"])
-        self.assertIn("source", jobs["candidate-cells"]["needs"])
+        self.assertIn("source", jobs["candidate-tiny-cells"]["needs"])
         self.assertEqual(
             "ansible-collection-runtime-protected",
-            jobs["candidate-cells"]["environment"],
+            jobs["candidate-tiny-cells"]["environment"],
         )
         self.assertIn(
             "needs.source.outputs.sha",
-            json.dumps(jobs["candidate-cells"]),
+            json.dumps(jobs["candidate-tiny-cells"]),
+        )
+        for name, profile in (
+            ("candidate-heavy-cells", "heavy"),
+            ("candidate-acceptance-cells", "application_acceptance"),
+        ):
+            delegated = jobs[name]
+            self.assertRegex(
+                delegated["uses"],
+                r"^lightning-it/modulix-validation/\.github/workflows/"
+                r"collection-quality-profile\.yml@[0-9a-f]{40}$",
+            )
+            self.assertEqual(profile, delegated["with"]["profile"])
+            self.assertIn("matrix.outputs", delegated["with"]["matrix-json"])
+            self.assertEqual(
+                "${{ needs.source.outputs.sha }}",
+                delegated["with"]["source-sha"],
+            )
+            self.assertEqual(
+                "ansible-collection-runtime-protected",
+                delegated["with"]["environment-name"],
+            )
+        self.assertIn(
+            "candidate-heavy-cells",
+            jobs["candidate-acceptance-cells"]["needs"],
         )
         self.assertEqual(
             "Candidate platform / Promotion input only",
             jobs["promotion-input"]["name"],
         )
+        for dependency in (
+            "candidate-tiny-cells",
+            "candidate-heavy-cells",
+            "candidate-acceptance-cells",
+        ):
+            self.assertIn(dependency, jobs["promotion-input"]["needs"])
         serialized = json.dumps(workflow)
         self.assertIn("target-disposition", serialized)
         self.assertIn("candidate", serialized)


### PR DESCRIPTION
## Summary

- keep Tiny candidate execution local
- delegate candidate Heavy and Application Acceptance to the pinned modulix-validation reusable workflow
- retain exact-SHA candidate evidence and fail-closed promotion aggregation
- document the accepted Modulix test execution ownership ADR

## Validation

- 16 workflow security tests passed (one unrelated macOS-only `/usr/bin/bash` test deselected)
- focused changed-policy tests passed
- role coverage validate/check passed
- actionlint passed
- yamllint passed
- markdownlint passed

Closes #498