### PR TITLE
docs(governance): connect verified release model to ADRs

### DIFF
--- a/OPENSSF.md
+++ b/OPENSSF.md
@@ -8,8 +8,12 @@ This repository follows the Lightning IT shared OpenSSF readiness model generate
 - [Branching, Review and Release Governance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878603438)
 - [Mandatory CI Quality and Artifact Assurance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878636340)
 - [Distributed Test Ownership and Central Heavy Execution](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886566105)
+- [ModuLix Lifecycle, Versioning and Release Evidence](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886926524)
 - [Repository and Secure SDLC Standard](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887778335)
+- [Technology Engineering Standards](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886762765)
+- [Quality Gates and Definition of Done](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887123058)
 - [OpenSSF and Software Supply Chain Assurance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887024876)
+- [Compliance Gaps and Migration Roadmap](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886926554)
 
 ## Repository
 

--- a/OPENSSF.md
+++ b/OPENSSF.md
@@ -2,6 +2,15 @@
 
 This repository follows the Lightning IT shared OpenSSF readiness model generated from `lightning-it/shared-assets-lit`.
 
+## Governing Decisions And Standards
+
+- [Repository Topology and Shared Engineering Assets](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878636297)
+- [Branching, Review and Release Governance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878603438)
+- [Mandatory CI Quality and Artifact Assurance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2878636340)
+- [Distributed Test Ownership and Central Heavy Execution](https://lit.atlassian.net/wiki/spaces/LIT/pages/2886566105)
+- [Repository and Secure SDLC Standard](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887778335)
+- [OpenSSF and Software Supply Chain Assurance](https://lit.atlassian.net/wiki/spaces/LIT/pages/2887024876)
+
 ## Repository
 
 - Repository: `ansible-collection-supplementary`

--- a/changelogs/fragments/adr-assurance.yml
+++ b/changelogs/fragments/adr-assurance.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Document the governing enterprise ADRs and confirm the existing release-assurance controls.

--- a/changelogs/fragments/adr-assurance.yml
+++ b/changelogs/fragments/adr-assurance.yml
@@ -1,3 +1,3 @@
 ---
 trivial:
-  - Document the governing enterprise ADRs and confirm the existing release-assurance controls.
+  - Document the governing enterprise ADRs and the release-assurance controls subject to this alignment review.


### PR DESCRIPTION
Tracks #500. Links the repository directly to the governing ADRs and standards. Existing controls already include CODEOWNERS, exact candidate identity, lint/build/install/tiny/heavy/application-acceptance profiles, long-term evidence, CycloneDX SBOM, provenance, GitHub attestations, Sigstore bundles and consumer-side verification before Galaxy publication. Central one-approval CODEOWNERS enforcement is in lightning-it/github-management-lit#183. The issue remains open until current CI and live settings are verified.