### PR TITLE
feat(object-storage): add Hetzner S3 CaC role

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ synthesized as passes.
 | forgejo_deploy | experimental | — | experimental | experimental | experimental |
 | gitlab_runner | deprecated | — | deprecated | deprecated | deprecated |
 | grafana_deploy | experimental | — | experimental | experimental | experimental |
+| hetzner_object_storage_cac | experimental | — | experimental | blocked-external-service | blocked-external-service |
 | incus_esxi_image | experimental | — | experimental | blocked-external-license | blocked-external-license |
 | incus_nested_esxi | experimental | — | experimental | blocked-external-infrastructure | blocked-external-infrastructure |
 | keycloak | experimental | — | experimental | experimental | experimental |

--- a/changelogs/fragments/hetzner-object-storage-cac.yml
+++ b/changelogs/fragments/hetzner-object-storage-cac.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - >-
+    Add the experimental ``hetzner_object_storage_cac`` role for fail-closed
+    Hetzner S3 bucket planning, auditing, Object Lock, versioning, retention,
+    and multipart lifecycle reconciliation.

--- a/docs/testing/role-coverage.md
+++ b/docs/testing/role-coverage.md
@@ -6,14 +6,14 @@ Authoritative source: [`meta/role-coverage.yml`](../../meta/role-coverage.yml).
 
 ## Summary
 
-- Roles: 96
-- Root Molecule scenarios: 57
+- Roles: 97
+- Root Molecule scenarios: 58
 - Production roles: 2
-- Experimental roles: 93
+- Experimental roles: 94
 - Deprecated roles: 1
 - Runtime-container application policies: 6
 - Declared-evidence application policies: 5
-- Reviewed not-applicable application policies: 46
+- Reviewed not-applicable application policies: 47
 
 Profile states are dispositions, not inferred test results. Only `supported` profiles backed by real,
 evidence-producing scenarios are release-eligible.
@@ -52,6 +52,7 @@ promotion input only and never satisfy the release-required supported-target mat
 | forgejo_deploy | forgejo | web_application | experimental | — | rhel-9 | experimental | experimental | experimental | browser_and_authenticated_api | postgres_deploy, lit.foundational.kubeplay | — | Production persistence, TLS, restart, and browser/API workflows are not yet proven. | forgejo-deploy-basic |
 | gitlab_runner | gitlab_runner | runner | deprecated | — | — | deprecated | deprecated | deprecated | register_runner_and_execute_a_real_workload | — | GitLab service and runner registration token | Role is intentionally fail-closed and retained only to report its deprecated contract. | gitlab-runner-basic |
 | grafana_deploy | observability | web_application | experimental | — | ubuntu-22.04, ubuntu-24.04, rhel-9 | experimental | experimental | experimental | browser_and_authenticated_api | lit.foundational.kubeplay, lit.foundational.podman_systemd, loki_deploy | — | Current Incus scenario has no browser or authenticated API workflow. | atlas-observability-incus_heavy, wunderbox-monitoring-logging-basic |
+| hetzner_object_storage_cac | hetzner_object_storage | configuration_as_code | experimental | — | ubuntu-24.04, rhel-9 | experimental | blocked-external-service | blocked-external-service | create_query_reconcile_and_remove_protected_s3_objects | amazon.aws, community.aws, community.hashi_vault | Paid Hetzner Object Storage project and protected S3 credentials | Tiny validates the real plan and negative safety contracts without calling the paid external API., Bucket deletion and S3 credential creation are deliberately outside the role. | hetzner-object-storage-tiny |
 | incus_esxi_image | esxi | infrastructure | experimental | — | ubuntu-24.04, rhel-9 | experimental | blocked-external-license | blocked-external-license | import_publish_use_and_cleanup_a_real_image | — | Privately licensed VMware ESXi image artifacts | Current scenario uses a fake Incus CLI and fake artifacts. | incus-esxi-image-basic |
 | incus_nested_esxi | esxi | infrastructure | experimental | — | ubuntu-24.04, rhel-9 | experimental | blocked-external-infrastructure | blocked-external-infrastructure | launch_query_and_destroy_a_real_nested_esxi_vm | — | Nested-virtualization-capable Incus host, Privately licensed VMware ESXi image | No root Molecule scenario exists. | — |
 | keycloak | keycloak | orchestrator | experimental | — | ubuntu-24.04, rhel-9, rhel-10 | experimental | experimental | experimental | browser_and_authenticated_oidc_api | keycloak_preflight, keycloak_deploy, keycloak_config, keycloak_cac, keycloak_validate, keycloak_ops, keycloak_backup_restore, keycloak_upgrade, keycloak_destroy | — | Canonical scenarios do not invoke the orchestrator role directly. | — |
@@ -570,6 +571,22 @@ promotion input only and never satisfy the release-required supported-target mat
 - Reports/evidence: —. Failed mandatory runs remain failures or infrastructure errors.
 - Backup/restore and upgrade behavior are support claims only when the acceptance surface or an executed scenario proves them.
 - Known limitations: Current Incus scenario has no browser or authenticated API workflow.
+
+### `hetzner_object_storage_cac`
+
+- Purpose/classification: `configuration_as_code` in component `hetzner_object_storage`.
+- Maturity/deprecation: `experimental` / `active`.
+- Supported targets: —; candidate targets: ubuntu-24.04, rhel-9.
+- Profiles: Tiny `experimental`, Heavy `blocked-external-service`, Application Acceptance `blocked-external-service`.
+- Acceptance surface: `create_query_reconcile_and_remove_protected_s3_objects`.
+- Role dependencies: amazon.aws, community.aws, community.hashi_vault; exercised scenario dependencies: —.
+- External dependencies/blockers: Paid Hetzner Object Storage project and protected S3 credentials.
+- Required-secret policy: Protected non-production credentials or licensed inputs are required for the declared external dependencies.
+- Local execution: `molecule test -s hetzner-object-storage-tiny`; CI matrix execution: not mandatory until a profile is supported, real, and production-eligible.
+- Candidate-target execution: no runnable candidate matrix is currently declared.
+- Reports/evidence: —. Failed mandatory runs remain failures or infrastructure errors.
+- Backup/restore and upgrade behavior are support claims only when the acceptance surface or an executed scenario proves them.
+- Known limitations: Tiny validates the real plan and negative safety contracts without calling the paid external API., Bucket deletion and S3 credential creation are deliberately outside the role.
 
 ### `incus_esxi_image`
 
@@ -1685,6 +1702,7 @@ promotion input only and never satisfy the release-required supported-target mat
 | forgejo-cac-basic | Tiny | experimental | stub | forgejo_cac | — | not-applicable | — | Scenario is a role contract or assertion stub and does not deploy an independently versioned application. | False | False | False |
 | forgejo-deploy-basic | Tiny | experimental | stub | forgejo_deploy | — | not-applicable | — | Scenario is a role contract or assertion stub and does not deploy an independently versioned application. | False | False | False |
 | gitlab-runner-basic | Tiny | deprecated | deprecation-contract | gitlab_runner | — | not-applicable | — | Scenario enforces a deprecation contract and intentionally does not deploy an independently versioned application. | False | False | False |
+| hetzner-object-storage-tiny | Tiny | experimental | partial | hetzner_object_storage_cac | — | not-applicable | — | Scenario validates the real provider contract and plan path without mutating a paid external service. | False | False | False |
 | incus-esxi-image-basic | Tiny | experimental | partial | incus_esxi_image | — | not-applicable | — | Scenario exercises controller-side role behavior without deploying an independently versioned application. | False | False | False |
 | keycloak-application-acceptance | Application Acceptance | supported | real | keycloak_cac, keycloak_deploy | postgres_backup_restore, samba | runtime-container | — | Scenario deploys and verifies independently versioned application containers; immutable runtime digests are mandatory. | True | True | True |
 | keycloak-heavy | Heavy | supported | real | keycloak_cac, keycloak_deploy | postgres_backup_restore, samba | runtime-container | — | Scenario deploys and verifies independently versioned application containers; immutable runtime digests are mandatory. | True | True | True |

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,6 +19,8 @@ tags:
   - security
   - automation
 dependencies:
+  amazon.aws: 10.1.2
+  community.aws: 10.0.0
   community.general: '>=11.4.9,<12.0.0'
   community.crypto: '>=3.2.2,<4.0.0'
   ansible.posix: '>=2.1.0'

--- a/meta/role-coverage.yml
+++ b/meta/role-coverage.yml
@@ -741,6 +741,33 @@ roles:
       heavy:
         - "atlas-observability-incus_heavy"
       application_acceptance: []
+  hetzner_object_storage_cac:
+    component: "hetzner_object_storage"
+    classification: "configuration_as_code"
+    maturity: "experimental"
+    supported_targets: []
+    candidate_targets:
+      - "ubuntu-24.04"
+      - "rhel-9"
+    tiny: "experimental"
+    heavy: "blocked-external-service"
+    application_acceptance: "blocked-external-service"
+    acceptance_surface: "create_query_reconcile_and_remove_protected_s3_objects"
+    dependencies:
+      - "amazon.aws"
+      - "community.aws"
+      - "community.hashi_vault"
+    external_dependencies:
+      - "Paid Hetzner Object Storage project and protected S3 credentials"
+    known_limitations:
+      - "Tiny validates the real plan and negative safety contracts without calling the paid external API."
+      - "Bucket deletion and S3 credential creation are deliberately outside the role."
+    deprecation_state: "active"
+    scenario_support:
+      tiny:
+        - "hetzner-object-storage-tiny"
+      heavy: []
+      application_acceptance: []
   incus_esxi_image:
     component: "esxi"
     classification: "infrastructure"
@@ -2629,6 +2656,20 @@ scenarios:
       reason: >-
         Scenario enforces a deprecation contract and intentionally does not deploy an independently versioned
         application.
+      dependencies: []
+  hetzner-object-storage-tiny:
+    profile: "tiny"
+    state: "experimental"
+    implementation: "partial"
+    roles:
+      - "hetzner_object_storage_cac"
+    junit: false
+    allure: false
+    evidence: false
+    test_application:
+      mode: "not-applicable"
+      reason: >-
+        Scenario validates the real provider contract and plan path without mutating a paid external service.
       dependencies: []
   incus-esxi-image-basic:
     profile: "tiny"

--- a/meta/source-dependencies.yml
+++ b/meta/source-dependencies.yml
@@ -104,8 +104,14 @@ derived_images:
 # Every concrete collection requirement used by shipped role source is either
 # a normal Galaxy dependency or an exact AAP runtime-overlay dependency.
 collections:
+  - name: "amazon.aws"
+    requirement: "10.1.2"
+    source: "galaxy.yml"
   - name: "ansible.posix"
     requirement: ">=2.1.0"
+    source: "galaxy.yml"
+  - name: "community.aws"
+    requirement: "10.0.0"
     source: "galaxy.yml"
   - name: "community.crypto"
     requirement: ">=3.2.2,<4.0.0"

--- a/molecule/hetzner-object-storage-tiny/converge.yml
+++ b/molecule/hetzner-object-storage-tiny/converge.yml
@@ -1,0 +1,65 @@
+---
+- name: Exercise the Hetzner Object Storage CaC safety contract
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    hetzner_object_storage_cac_action: plan
+    hetzner_object_storage_cac_endpoint: https://fsn1.your-objectstorage.com
+    hetzner_object_storage_cac_region: fsn1
+    hetzner_object_storage_cac_bucket: example-production-backup
+    hetzner_object_storage_cac_prefix: host01
+  tasks:
+    - name: Run the real safe planning path
+      ansible.builtin.include_role:
+        name: lit.supplementary.hetzner_object_storage_cac
+
+    - name: Preserve the sanitized plan for verification
+      ansible.builtin.copy:
+        dest: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/hetzner-object-storage-plan.yml"
+        content: "{{ hetzner_object_storage_cac_result | to_nice_yaml }}"
+        mode: "0600"
+
+    - name: Prove an insecure endpoint is rejected
+      block:
+        - name: Run the role with an insecure endpoint
+          ansible.builtin.include_role:
+            name: lit.supplementary.hetzner_object_storage_cac
+          vars:
+            hetzner_object_storage_cac_endpoint: http://fsn1.your-objectstorage.com
+
+        - name: Reject an accepted insecure endpoint
+          ansible.builtin.fail:
+            msg: The role accepted an insecure endpoint.
+      rescue:
+        - name: Record endpoint rejection
+          ansible.builtin.set_fact:
+            _hetzner_object_storage_cac_insecure_endpoint_rejected: true
+
+    - name: Prove disabled Object Lock is rejected
+      block:
+        - name: Run the role with Object Lock disabled
+          ansible.builtin.include_role:
+            name: lit.supplementary.hetzner_object_storage_cac
+          vars:
+            hetzner_object_storage_cac_object_lock_enabled: false
+
+        - name: Reject accepted disabled Object Lock
+          ansible.builtin.fail:
+            msg: The role accepted disabled Object Lock.
+      rescue:
+        - name: Record Object Lock rejection
+          ansible.builtin.set_fact:
+            _hetzner_object_storage_cac_disabled_lock_rejected: true
+
+    - name: Persist negative safety results
+      ansible.builtin.copy:
+        dest: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/hetzner-object-storage-safety.yml"
+        content: >-
+          {{
+            {
+              'disabled_lock_rejected': _hetzner_object_storage_cac_disabled_lock_rejected | default(false),
+              'insecure_endpoint_rejected': _hetzner_object_storage_cac_insecure_endpoint_rejected | default(false)
+            } | to_nice_yaml
+          }}
+        mode: "0600"

--- a/molecule/hetzner-object-storage-tiny/molecule.yml
+++ b/molecule/hetzner-object-storage-tiny/molecule.yml
@@ -1,0 +1,33 @@
+---
+dependency:
+  name: shell
+  command: ":"
+
+driver:
+  name: default
+
+platforms:
+  - name: localhost
+    managed: false
+
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      localhost:
+        ansible_connection: local
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml
+
+scenario:
+  name: hetzner-object-storage-tiny
+  test_sequence:
+    - dependency
+    - syntax
+    - converge
+    - idempotence
+    - verify
+
+verifier:
+  name: ansible

--- a/molecule/hetzner-object-storage-tiny/verify.yml
+++ b/molecule/hetzner-object-storage-tiny/verify.yml
@@ -1,0 +1,29 @@
+---
+- name: Verify the Hetzner Object Storage CaC safety contract
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tasks:
+    - name: Read the sanitized plan
+      ansible.builtin.include_vars:
+        file: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/hetzner-object-storage-plan.yml"
+        name: _hetzner_object_storage_cac_plan
+
+    - name: Read negative safety results
+      ansible.builtin.include_vars:
+        file: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/hetzner-object-storage-safety.yml"
+        name: _hetzner_object_storage_cac_safety
+
+    - name: Verify safe plan and negative contracts
+      ansible.builtin.assert:
+        that:
+          - _hetzner_object_storage_cac_plan.action == 'plan'
+          - _hetzner_object_storage_cac_plan.bucket == 'example-production-backup'
+          - not _hetzner_object_storage_cac_plan.changed | bool
+          - _hetzner_object_storage_cac_plan.object_lock_enabled | bool
+          - _hetzner_object_storage_cac_plan.object_lock_mode == 'GOVERNANCE'
+          - _hetzner_object_storage_cac_plan.object_lock_retention_days | int == 30
+          - _hetzner_object_storage_cac_plan.versioning | bool
+          - _hetzner_object_storage_cac_safety.insecure_endpoint_rejected | bool
+          - _hetzner_object_storage_cac_safety.disabled_lock_rejected | bool
+        quiet: true

--- a/roles/hetzner_object_storage_cac/README.md
+++ b/roles/hetzner_object_storage_cac/README.md
@@ -1,0 +1,68 @@
+# hetzner_object_storage_cac
+
+Reconciles and audits private Hetzner Object Storage buckets through the
+S3-compatible API. The role is fail-closed around HTTPS endpoints, versioning,
+Object Lock at bucket creation, default retention, and incomplete multipart
+upload cleanup. It never creates S3 credentials.
+
+Classification: configuration as code. Maturity: experimental. Tiny contract
+coverage is available; Heavy and Application Acceptance remain blocked on a
+protected paid Hetzner Object Storage project.
+
+## Requirements
+
+- `ansible-core` matching `meta/runtime.yml`.
+- The collection dependencies declared in `galaxy.yml`.
+- `boto3` and `botocore` in the execution environment.
+- Existing Hetzner S3 access and secret keys supplied explicitly or read from
+  HashiCorp Vault.
+
+## Variables
+
+See `defaults/main.yml` for the complete contract. Important inputs are
+`hetzner_object_storage_cac_action`, `endpoint`, `region`, `bucket`, `prefix`,
+the Object Lock and lifecycle settings, and exactly one credential source.
+Actions are `plan`, `audit`, and `reconcile`.
+
+`plan` performs no API call. `audit` confirms that the bucket is visible.
+`reconcile` creates or updates the private bucket, including Object Lock,
+versioning, default retention, and incomplete multipart cleanup.
+
+TLS verification is mandatory. Bucket deletion is deliberately outside this
+role. Hetzner S3 keys are project-bound and must be managed separately with
+least privilege and a protected source of truth.
+
+## Dependencies
+
+The role uses `amazon.aws`, `community.aws`, and optionally
+`community.hashi_vault`; collection versions are declared in `galaxy.yml`.
+
+## Example Playbook
+
+```yaml
+---
+- name: Reconcile one protected Hetzner S3 bucket
+  hosts: localhost
+  gather_facts: false
+  roles:
+    - role: lit.supplementary.hetzner_object_storage_cac
+      vars:
+        hetzner_object_storage_cac_action: reconcile
+        hetzner_object_storage_cac_endpoint: https://fsn1.your-objectstorage.com
+        hetzner_object_storage_cac_region: fsn1
+        hetzner_object_storage_cac_bucket: example-production-backup
+        hetzner_object_storage_cac_prefix: host01
+        hetzner_object_storage_cac_use_vault: true
+        hetzner_object_storage_cac_vault_addr: https://vault.example.com
+        hetzner_object_storage_cac_vault_token: "{{ protected_vault_token }}"
+        hetzner_object_storage_cac_vault_kv_mount: infrastructure
+        hetzner_object_storage_cac_vault_kv_path: object-storage/host01
+```
+
+## License
+
+MIT
+
+## Author
+
+Lightning IT

--- a/roles/hetzner_object_storage_cac/defaults/main.yml
+++ b/roles/hetzner_object_storage_cac/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+hetzner_object_storage_cac_action: plan
+hetzner_object_storage_cac_delegate_to: localhost
+
+hetzner_object_storage_cac_endpoint: ""
+hetzner_object_storage_cac_region: ""
+hetzner_object_storage_cac_bucket: ""
+hetzner_object_storage_cac_prefix: ""
+
+hetzner_object_storage_cac_access_key: ""
+hetzner_object_storage_cac_secret_key: ""
+
+hetzner_object_storage_cac_use_vault: false
+hetzner_object_storage_cac_vault_addr: ""
+hetzner_object_storage_cac_vault_token: ""
+hetzner_object_storage_cac_vault_kv_mount: secret
+hetzner_object_storage_cac_vault_kv_path: ""
+hetzner_object_storage_cac_vault_access_key_field: access_key
+hetzner_object_storage_cac_vault_secret_key_field: secret_key
+
+hetzner_object_storage_cac_versioning: true
+hetzner_object_storage_cac_object_lock_enabled: true
+hetzner_object_storage_cac_object_lock_mode: GOVERNANCE
+hetzner_object_storage_cac_object_lock_retention_days: 30
+hetzner_object_storage_cac_abort_incomplete_multipart_upload_days: 7
+hetzner_object_storage_cac_validate_certs: true

--- a/roles/hetzner_object_storage_cac/meta/main.yml
+++ b/roles/hetzner_object_storage_cac/meta/main.yml
@@ -1,0 +1,9 @@
+---
+galaxy_info:
+  author: Lightning IT
+  description: Reconcile private Hetzner Object Storage buckets through the S3-compatible API
+  license: MIT
+  min_ansible_version: "2.18"
+  role_name: hetzner_object_storage_cac
+  namespace: lit
+dependencies: []

--- a/roles/hetzner_object_storage_cac/tasks/assert.yml
+++ b/roles/hetzner_object_storage_cac/tasks/assert.yml
@@ -1,0 +1,74 @@
+---
+- name: Validate Hetzner Object Storage CaC contract
+  ansible.builtin.assert:
+    that:
+      - hetzner_object_storage_cac_action in ['plan', 'audit', 'reconcile']
+      - hetzner_object_storage_cac_delegate_to is string
+      - hetzner_object_storage_cac_delegate_to | trim | length > 0
+      - hetzner_object_storage_cac_endpoint is string
+      - >-
+        hetzner_object_storage_cac_endpoint
+        is match('^https://(fsn1|nbg1|hel1)\\.your-objectstorage\\.com$')
+      - hetzner_object_storage_cac_region in ['fsn1', 'nbg1', 'hel1']
+      - >-
+        hetzner_object_storage_cac_endpoint
+        == 'https://' ~ hetzner_object_storage_cac_region ~ '.your-objectstorage.com'
+      - hetzner_object_storage_cac_bucket is string
+      - >-
+        hetzner_object_storage_cac_bucket
+        is match('^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$')
+      - "'..' not in hetzner_object_storage_cac_bucket"
+      - "'.-' not in hetzner_object_storage_cac_bucket"
+      - "'-.' not in hetzner_object_storage_cac_bucket"
+      - hetzner_object_storage_cac_prefix is string
+      - not hetzner_object_storage_cac_prefix.startswith('/')
+      - not hetzner_object_storage_cac_prefix.endswith('/')
+      - hetzner_object_storage_cac_use_vault is boolean
+      - hetzner_object_storage_cac_versioning is boolean
+      - hetzner_object_storage_cac_versioning | bool
+      - hetzner_object_storage_cac_object_lock_enabled is boolean
+      - hetzner_object_storage_cac_object_lock_enabled | bool
+      - hetzner_object_storage_cac_object_lock_mode in ['GOVERNANCE', 'COMPLIANCE']
+      - hetzner_object_storage_cac_object_lock_retention_days | int > 0
+      - hetzner_object_storage_cac_abort_incomplete_multipart_upload_days | int > 0
+      - hetzner_object_storage_cac_validate_certs is boolean
+      - hetzner_object_storage_cac_validate_certs | bool
+    fail_msg: >-
+      The Hetzner Object Storage contract is incomplete or unsafe. Use one
+      supported HTTPS location endpoint, a private DNS-compatible bucket name,
+      versioning, Object Lock, positive retention, and TLS verification.
+    quiet: true
+
+- name: Validate explicit Hetzner S3 credentials
+  ansible.builtin.assert:
+    that:
+      - hetzner_object_storage_cac_access_key is string
+      - hetzner_object_storage_cac_access_key | length > 0
+      - hetzner_object_storage_cac_secret_key is string
+      - hetzner_object_storage_cac_secret_key | length > 0
+    fail_msg: Reconcile and audit require explicit credentials or HashiCorp Vault.
+    quiet: true
+  when:
+    - hetzner_object_storage_cac_action != 'plan'
+    - not hetzner_object_storage_cac_use_vault | bool
+  no_log: true
+
+- name: Validate the HashiCorp Vault credential source
+  ansible.builtin.assert:
+    that:
+      - hetzner_object_storage_cac_vault_addr is string
+      - hetzner_object_storage_cac_vault_addr is match('^https://')
+      - hetzner_object_storage_cac_vault_token is string
+      - hetzner_object_storage_cac_vault_token | length > 0
+      - hetzner_object_storage_cac_vault_kv_mount is string
+      - hetzner_object_storage_cac_vault_kv_mount | trim | length > 0
+      - hetzner_object_storage_cac_vault_kv_path is string
+      - hetzner_object_storage_cac_vault_kv_path | trim | length > 0
+      - hetzner_object_storage_cac_vault_access_key_field | trim | length > 0
+      - hetzner_object_storage_cac_vault_secret_key_field | trim | length > 0
+    fail_msg: Vault-backed reconciliation requires an HTTPS address, token, mount, path, and field names.
+    quiet: true
+  when:
+    - hetzner_object_storage_cac_action != 'plan'
+    - hetzner_object_storage_cac_use_vault | bool
+  no_log: true

--- a/roles/hetzner_object_storage_cac/tasks/audit.yml
+++ b/roles/hetzner_object_storage_cac/tasks/audit.yml
@@ -1,0 +1,33 @@
+---
+- name: Read Hetzner Object Storage buckets
+  amazon.aws.s3_bucket_info:
+    endpoint_url: "{{ hetzner_object_storage_cac_endpoint }}"
+    region: "{{ hetzner_object_storage_cac_region }}"
+    access_key: "{{ _hetzner_object_storage_cac_access_key }}"
+    secret_key: "{{ _hetzner_object_storage_cac_secret_key }}"
+    validate_certs: "{{ hetzner_object_storage_cac_validate_certs }}"
+  register: _hetzner_object_storage_cac_bucket_info
+  delegate_to: "{{ hetzner_object_storage_cac_delegate_to }}"
+  no_log: true
+
+- name: Require the declared Hetzner Object Storage bucket
+  ansible.builtin.assert:
+    that:
+      - >-
+        _hetzner_object_storage_cac_bucket_info.buckets
+        | map(attribute='name')
+        | select('equalto', hetzner_object_storage_cac_bucket)
+        | list | length == 1
+    fail_msg: The declared Hetzner Object Storage bucket is absent or not uniquely visible.
+    quiet: true
+
+- name: Publish sanitized Hetzner Object Storage audit result
+  ansible.builtin.set_fact:
+    hetzner_object_storage_cac_result:
+      action: audit
+      bucket: "{{ hetzner_object_storage_cac_bucket }}"
+      changed: false
+      endpoint: "{{ hetzner_object_storage_cac_endpoint }}"
+      exists: true
+      prefix: "{{ hetzner_object_storage_cac_prefix }}"
+      region: "{{ hetzner_object_storage_cac_region }}"

--- a/roles/hetzner_object_storage_cac/tasks/main.yml
+++ b/roles/hetzner_object_storage_cac/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Run Hetzner Object Storage CaC prechecks
+  ansible.builtin.import_tasks: assert.yml
+  tags: always
+
+- name: Publish the sanitized Hetzner Object Storage plan
+  ansible.builtin.set_fact:
+    hetzner_object_storage_cac_result:
+      action: plan
+      bucket: "{{ hetzner_object_storage_cac_bucket }}"
+      changed: false
+      endpoint: "{{ hetzner_object_storage_cac_endpoint }}"
+      lifecycle_abort_days: "{{ hetzner_object_storage_cac_abort_incomplete_multipart_upload_days | int }}"
+      object_lock_enabled: "{{ hetzner_object_storage_cac_object_lock_enabled | bool }}"
+      object_lock_mode: "{{ hetzner_object_storage_cac_object_lock_mode }}"
+      object_lock_retention_days: "{{ hetzner_object_storage_cac_object_lock_retention_days | int }}"
+      prefix: "{{ hetzner_object_storage_cac_prefix }}"
+      region: "{{ hetzner_object_storage_cac_region }}"
+      versioning: "{{ hetzner_object_storage_cac_versioning | bool }}"
+  when: hetzner_object_storage_cac_action == 'plan'
+
+- name: Resolve protected Hetzner S3 credentials
+  ansible.builtin.import_tasks: resolve_credentials.yml
+  when: hetzner_object_storage_cac_action in ['audit', 'reconcile']
+
+- name: Audit Hetzner Object Storage
+  ansible.builtin.import_tasks: audit.yml
+  when: hetzner_object_storage_cac_action == 'audit'
+
+- name: Reconcile Hetzner Object Storage
+  ansible.builtin.import_tasks: reconcile.yml
+  when: hetzner_object_storage_cac_action == 'reconcile'

--- a/roles/hetzner_object_storage_cac/tasks/reconcile.yml
+++ b/roles/hetzner_object_storage_cac/tasks/reconcile.yml
@@ -1,0 +1,54 @@
+---
+- name: Reconcile the private Hetzner Object Storage bucket
+  amazon.aws.s3_bucket:
+    name: "{{ hetzner_object_storage_cac_bucket }}"
+    state: present
+    acl: private
+    endpoint_url: "{{ hetzner_object_storage_cac_endpoint }}"
+    region: "{{ hetzner_object_storage_cac_region }}"
+    access_key: "{{ _hetzner_object_storage_cac_access_key }}"
+    secret_key: "{{ _hetzner_object_storage_cac_secret_key }}"
+    object_lock_enabled: "{{ hetzner_object_storage_cac_object_lock_enabled }}"
+    object_lock_default_retention:
+      mode: "{{ hetzner_object_storage_cac_object_lock_mode }}"
+      days: "{{ hetzner_object_storage_cac_object_lock_retention_days }}"
+    versioning: "{{ hetzner_object_storage_cac_versioning }}"
+    validate_certs: "{{ hetzner_object_storage_cac_validate_certs }}"
+  register: _hetzner_object_storage_cac_bucket_result
+  delegate_to: "{{ hetzner_object_storage_cac_delegate_to }}"
+  no_log: true
+
+- name: Reconcile incomplete multipart upload cleanup
+  community.aws.s3_lifecycle:
+    name: "{{ hetzner_object_storage_cac_bucket }}"
+    rule_id: abort-incomplete-multipart-uploads
+    status: enabled
+    abort_incomplete_multipart_upload_days: >-
+      {{ hetzner_object_storage_cac_abort_incomplete_multipart_upload_days }}
+    endpoint_url: "{{ hetzner_object_storage_cac_endpoint }}"
+    region: "{{ hetzner_object_storage_cac_region }}"
+    access_key: "{{ _hetzner_object_storage_cac_access_key }}"
+    secret_key: "{{ _hetzner_object_storage_cac_secret_key }}"
+    validate_certs: "{{ hetzner_object_storage_cac_validate_certs }}"
+  register: _hetzner_object_storage_cac_lifecycle_result
+  delegate_to: "{{ hetzner_object_storage_cac_delegate_to }}"
+  no_log: true
+
+- name: Publish sanitized Hetzner Object Storage reconciliation result
+  ansible.builtin.set_fact:
+    hetzner_object_storage_cac_result:
+      action: reconcile
+      bucket: "{{ hetzner_object_storage_cac_bucket }}"
+      changed: >-
+        {{
+          _hetzner_object_storage_cac_bucket_result.changed | bool
+          or _hetzner_object_storage_cac_lifecycle_result.changed | bool
+        }}
+      endpoint: "{{ hetzner_object_storage_cac_endpoint }}"
+      lifecycle_abort_days: "{{ hetzner_object_storage_cac_abort_incomplete_multipart_upload_days | int }}"
+      object_lock_enabled: "{{ hetzner_object_storage_cac_object_lock_enabled | bool }}"
+      object_lock_mode: "{{ hetzner_object_storage_cac_object_lock_mode }}"
+      object_lock_retention_days: "{{ hetzner_object_storage_cac_object_lock_retention_days | int }}"
+      prefix: "{{ hetzner_object_storage_cac_prefix }}"
+      region: "{{ hetzner_object_storage_cac_region }}"
+      versioning: "{{ hetzner_object_storage_cac_versioning | bool }}"

--- a/roles/hetzner_object_storage_cac/tasks/resolve_credentials.yml
+++ b/roles/hetzner_object_storage_cac/tasks/resolve_credentials.yml
@@ -1,0 +1,41 @@
+---
+- name: Read Hetzner S3 credentials from HashiCorp Vault
+  community.hashi_vault.vault_kv2_get:
+    url: "{{ hetzner_object_storage_cac_vault_addr }}"
+    token: "{{ hetzner_object_storage_cac_vault_token }}"
+    engine_mount_point: "{{ hetzner_object_storage_cac_vault_kv_mount }}"
+    path: "{{ hetzner_object_storage_cac_vault_kv_path }}"
+    validate_certs: true
+  register: _hetzner_object_storage_cac_vault_secret
+  delegate_to: "{{ hetzner_object_storage_cac_delegate_to }}"
+  when: hetzner_object_storage_cac_use_vault | bool
+  no_log: true
+
+- name: Resolve effective Hetzner S3 credentials
+  ansible.builtin.set_fact:
+    _hetzner_object_storage_cac_access_key: >-
+      {{
+        _hetzner_object_storage_cac_vault_secret.secret[
+          hetzner_object_storage_cac_vault_access_key_field
+        ]
+        if hetzner_object_storage_cac_use_vault | bool
+        else hetzner_object_storage_cac_access_key
+      }}
+    _hetzner_object_storage_cac_secret_key: >-
+      {{
+        _hetzner_object_storage_cac_vault_secret.secret[
+          hetzner_object_storage_cac_vault_secret_key_field
+        ]
+        if hetzner_object_storage_cac_use_vault | bool
+        else hetzner_object_storage_cac_secret_key
+      }}
+  no_log: true
+
+- name: Validate resolved Hetzner S3 credentials
+  ansible.builtin.assert:
+    that:
+      - _hetzner_object_storage_cac_access_key | default('') | length > 0
+      - _hetzner_object_storage_cac_secret_key | default('') | length > 0
+    fail_msg: The selected credential source did not return both required S3 keys.
+    quiet: true
+  no_log: true

--- a/tests/test_role_coverage.py
+++ b/tests/test_role_coverage.py
@@ -49,8 +49,8 @@ class RoleCoverageRegistryTests(unittest.TestCase):
         }
 
     def test_registry_exactly_covers_repository(self) -> None:
-        self.assertEqual(96, len(self.registry["roles"]))
-        self.assertEqual(57, len(self.registry["scenarios"]))
+        self.assertEqual(97, len(self.registry["roles"]))
+        self.assertEqual(58, len(self.registry["scenarios"]))
         self.assertEqual(
             VALIDATOR.discovered_roles(ROOT),
             set(self.registry["roles"]),
@@ -137,7 +137,7 @@ class RoleCoverageRegistryTests(unittest.TestCase):
             },
             declared,
         )
-        self.assertEqual(46, len(not_applicable))
+        self.assertEqual(47, len(not_applicable))
         self.assertEqual(set(self.registry["scenarios"]), runtime | declared | not_applicable)
         for name in declared:
             self.assertEqual(

--- a/tests/unit/test_source_dependencies.py
+++ b/tests/unit/test_source_dependencies.py
@@ -31,7 +31,7 @@ class SourceDependencyTests(unittest.TestCase):
         result = DEPENDENCIES.validate_source_dependencies(root=ROOT)
         self.assertEqual(result["container_count"], 25)
         self.assertEqual(result["derived_container_count"], 1)
-        self.assertEqual(result["collection_count"], 12)
+        self.assertEqual(result["collection_count"], 14)
         self.assertEqual(result["external_product_count"], 1)
 
     def test_binary_shipped_payload_is_not_decoded_as_dependency_source(self) -> None:


### PR DESCRIPTION
## Summary
- add `lit.supplementary.hetzner_object_storage_cac`
- enforce private HTTPS Hetzner endpoints, versioning, Object Lock, retention, and multipart cleanup
- support explicit or HashiCorp Vault-backed S3 credentials without creating or logging credentials
- add real plan-path Tiny coverage with negative TLS/Object-Lock checks and idempotence
- register dependencies, source inventory, coverage, documentation, and changelog

Advances lightning-it/ansible-inventory-lit#130.

## Validation
- targeted `hetzner-object-storage-tiny`: converge, idempotence, verify passed
- repository-wide ansible-lint passed
- collection smoke and Galaxy verification passed
- role coverage and source-dependency validation passed
- 179 Python unit tests passed
- pre-commit passed with `molecule-light` skipped because the affected Tiny scenario was run separately