### PR TITLE
fix(aap): harden containerized deployment preflight

### DIFF
--- a/changelogs/fragments/aap-deploy-hub-readiness-url.yml
+++ b/changelogs/fragments/aap-deploy-hub-readiness-url.yml
@@ -1,0 +1,11 @@
+---
+bugfixes:
+  - >-
+    Derive the AAP Hub upload readiness, Hub container registry, and EDA API
+    URLs from aap_fqdn and their standard HTTPS ports. This prevents the
+    upstream installer from probing the Pulp status path through the Gateway
+    endpoint.
+  - >-
+    Preserve the upstream AAP 2.7 Gateway administrator credentials for Hub
+    registry image uploads instead of replacing them with component-local Hub
+    administrator credentials, which the platform registry rejects.

--- a/changelogs/fragments/aap-host-prepare-selinux.yml
+++ b/changelogs/fragments/aap-host-prepare-selinux.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Persist and apply SELinux file contexts for the AAP application mount,
+    temporary directories, alternate user homes, and Podman storage during
+    AAP host preparation.

--- a/changelogs/fragments/aap-prepare-fqdn-fallback.yml
+++ b/changelogs/fragments/aap-prepare-fqdn-fallback.yml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - >-
+    Let aap_prepare use aap_fqdn as the gateway DNS precheck hostname when
+    neither aap_deploy_gateway_main_url nor aap_cac_gateway_hostname is set.
+  - >-
+    Create the controller-local AAP artifact directory before discovering
+    locally supplied setup bundles and manifests.

--- a/changelogs/fragments/aap-tls-source-validation.yml
+++ b/changelogs/fragments/aap-tls-source-validation.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - >-
+    aap_tls now validates that generated deployment certificate, key, and CA
+    files are readable, and aap_deploy validates controller-side customer TLS
+    source files before attempting to stage them.

--- a/roles/aap_deploy/README.md
+++ b/roles/aap_deploy/README.md
@@ -330,6 +330,7 @@ Installer admin password behavior:
 
 Installer TLS behavior:
 - When enabled, the role stages TLS assets under `aap_deploy_tls_dir` on the managed host.
+- Controller-side TLS source files are validated for existence and readability before staging begins.
 - The upstream installer receives only remote file paths (`*_tls_cert`, `*_tls_key`, `custom_ca_cert`).
 - TLS staging and Vault PKI issuing are delegated to `lit.foundational.tls_assets`;
   this role only maps the staged paths into AAP installer inventory variables.

--- a/roles/aap_deploy/defaults/main.yml
+++ b/roles/aap_deploy/defaults/main.yml
@@ -346,11 +346,30 @@ aap_deploy_gateway_nginx_disable_https: false
 aap_deploy_envoy_http_port: 80
 aap_deploy_envoy_https_port: 443
 aap_deploy_envoy_disable_https: false
-aap_deploy_hub_upload_readiness_url: ""
-aap_deploy_hub_container_registry_url: ""
+aap_deploy_hub_upload_readiness_url: >-
+  {{
+    (
+      'https://'
+      ~ aap_fqdn
+      ~ ':8444/api/galaxy/pulp/api/v3/status/'
+    )
+    if (aap_fqdn | default('', true) | trim | length > 0)
+    else ''
+  }}
+aap_deploy_hub_container_registry_url: >-
+  {{
+    ('https://' ~ aap_fqdn ~ ':8444')
+    if (aap_fqdn | default('', true) | trim | length > 0)
+    else ''
+  }}
 aap_deploy_hub_seed_execution_environment_images: true
 aap_deploy_hub_seed_collections: true
-aap_deploy_eda_api_url: ""
+aap_deploy_eda_api_url: >-
+  {{
+    ('https://' ~ aap_fqdn ~ ':8445')
+    if (aap_fqdn | default('', true) | trim | length > 0)
+    else ''
+  }}
 aap_deploy_manage_hub_registry_trust: true
 aap_deploy_hub_registry_trust_system_dir: /etc/containers/certs.d
 aap_deploy_hub_registry_trust_user_dir: >-

--- a/roles/aap_deploy/tasks/15_stage_tls_assets.yml
+++ b/roles/aap_deploy/tasks/15_stage_tls_assets.yml
@@ -1,4 +1,58 @@
 ---
+- name: Inspect controller-side customer TLS service files
+  ansible.builtin.stat:
+    path: "{{ aap_deploy_tls_customer_files[item.0][item.1] }}"
+  loop: "{{ aap_deploy_tls_services | product(['cert_src', 'key_src']) | list }}"
+  loop_control:
+    label: "{{ item.0 }} {{ item.1 }}"
+  register: aap_deploy_tls_customer_service_file_stats
+  delegate_to: localhost
+  changed_when: false
+  when:
+    - aap_deploy_tls_source == 'customer_files'
+    - aap_deploy_tls_customer_files[item.0][item.1] | default('', true) | trim | length > 0
+
+- name: Validate controller-side customer TLS service files
+  ansible.builtin.assert:
+    that:
+      - item.stat.exists
+      - item.stat.isreg
+      - item.stat.readable
+    fail_msg: >-
+      Customer TLS source file is not readable on the automation controller:
+      {{ item.item.0 }} {{ item.item.1 }}={{
+        aap_deploy_tls_customer_files[item.item.0][item.item.1]
+      }}. Generate or provide the TLS assets before running AAP deployment.
+    quiet: true
+  loop: "{{ aap_deploy_tls_customer_service_file_stats.results }}"
+  loop_control:
+    label: "{{ item.item.0 }} {{ item.item.1 }}"
+  when: not (item.skipped | default(false))
+
+- name: Inspect controller-side customer CA certificate
+  ansible.builtin.stat:
+    path: "{{ aap_deploy_tls_customer_files.ca_cert_src }}"
+  register: aap_deploy_tls_customer_ca_file_stat
+  delegate_to: localhost
+  changed_when: false
+  when:
+    - aap_deploy_tls_source == 'customer_files'
+    - aap_deploy_tls_customer_files.ca_cert_src | default('', true) | trim | length > 0
+
+- name: Validate controller-side customer CA certificate
+  ansible.builtin.assert:
+    that:
+      - aap_deploy_tls_customer_ca_file_stat.stat.exists
+      - aap_deploy_tls_customer_ca_file_stat.stat.isreg
+      - aap_deploy_tls_customer_ca_file_stat.stat.readable
+    fail_msg: >-
+      Customer CA certificate is not readable on the automation controller:
+      {{ aap_deploy_tls_customer_files.ca_cert_src }}. Generate or provide the
+      TLS assets before running AAP deployment.
+    quiet: true
+  when:
+    - not (aap_deploy_tls_customer_ca_file_stat.skipped | default(false))
+
 - name: Ensure TLS asset directory exists
   ansible.builtin.file:
     path: "{{ aap_deploy_tls_dir }}"

--- a/roles/aap_deploy/tasks/15_stage_tls_assets.yml
+++ b/roles/aap_deploy/tasks/15_stage_tls_assets.yml
@@ -10,6 +10,7 @@
   changed_when: false
   when:
     - aap_deploy_tls_source == 'customer_files'
+    - not (aap_deploy_tls_customer_files[item.0].remote_src | default(false) | bool)
     - aap_deploy_tls_customer_files[item.0][item.1] | default('', true) | trim | length > 0
 
 - name: Validate controller-side customer TLS service files
@@ -37,6 +38,7 @@
   changed_when: false
   when:
     - aap_deploy_tls_source == 'customer_files'
+    - not (aap_deploy_tls_customer_files.ca_cert_remote_src | default(false) | bool)
     - aap_deploy_tls_customer_files.ca_cert_src | default('', true) | trim | length > 0
 
 - name: Validate controller-side customer CA certificate

--- a/roles/aap_host_prepare/README.md
+++ b/roles/aap_host_prepare/README.md
@@ -19,6 +19,13 @@ includes the `tar` and `unzip` tools required by the vendor setup preparation
 role. The calling runbook controls optional host changes through the existing
 `aap_runbook_manage_*` variables.
 
+`aap_host_prepare_selinux_manage` defaults to `true`. On SELinux-enabled
+hosts, the role persists and applies contexts for `/appl`, temporary paths,
+the alternate user-home hierarchy, and Podman storage before deployment.
+Customize `aap_host_prepare_selinux_fcontexts` and
+`aap_host_prepare_selinux_restore_paths` only when the application filesystem
+layout differs.
+
 ## Dependencies
 
 Optional host operations use roles from `lit.rhel` and the remote temporary

--- a/roles/aap_host_prepare/defaults/main.yml
+++ b/roles/aap_host_prepare/defaults/main.yml
@@ -10,3 +10,21 @@ aap_host_prepare_install_user_shell_effective: >-
   {{ aap_deploy_install_user_shell | default('/bin/bash', true) }}
 aap_host_prepare_setup_dir_effective: >-
   {{ aap_deploy_setup_dir | default('/appl/aap/setup', true) }}
+
+aap_host_prepare_selinux_manage: true
+aap_host_prepare_selinux_fcontexts:
+  - target: /appl
+    setype: var_t
+  - target: /appl/tmp(/.*)?
+    setype: tmp_t
+  - target: /appl/ansible-tmp(/.*)?
+    setype: tmp_t
+  - target: /appl/podman(/.*)?
+    setype: container_var_lib_t
+  - target: /appl/home
+    substitute: /home
+aap_host_prepare_selinux_restore_paths:
+  - /appl/tmp
+  - /appl/ansible-tmp
+  - /appl/podman
+  - /appl/home

--- a/roles/aap_host_prepare/tasks/assert.yml
+++ b/roles/aap_host_prepare/tasks/assert.yml
@@ -10,6 +10,11 @@
       - aap_host_prepare_install_user_shell_effective is match('^/.+')
       - aap_host_prepare_setup_dir_effective is string
       - aap_host_prepare_setup_dir_effective is match('^/.+')
+      - aap_host_prepare_selinux_manage is boolean
+      - aap_host_prepare_selinux_fcontexts is sequence
+      - aap_host_prepare_selinux_fcontexts is not string
+      - aap_host_prepare_selinux_restore_paths is sequence
+      - aap_host_prepare_selinux_restore_paths is not string
     fail_msg: Invalid configuration for lit.supplementary.aap_host_prepare.
     quiet: true
   changed_when: false

--- a/roles/aap_host_prepare/tasks/main.yml
+++ b/roles/aap_host_prepare/tasks/main.yml
@@ -191,6 +191,7 @@
   ansible.builtin.import_tasks: selinux.yml
   when:
     - aap_host_prepare_selinux_manage | bool
+    - not ansible_check_mode
     - ansible_facts.selinux is defined
     - ansible_facts.selinux.status | default('disabled') == 'enabled'
   tags:

--- a/roles/aap_host_prepare/tasks/main.yml
+++ b/roles/aap_host_prepare/tasks/main.yml
@@ -187,6 +187,18 @@
     - os_prep
     - filesystem
 
+- name: Apply persistent SELinux labels for AAP paths
+  ansible.builtin.import_tasks: selinux.yml
+  when:
+    - aap_host_prepare_selinux_manage | bool
+    - ansible_facts.selinux is defined
+    - ansible_facts.selinux.status | default('disabled') == 'enabled'
+  tags:
+    - aap
+    - aap_host_prepare
+    - os_prep
+    - selinux
+
 - name: Prepare Podman on AAP host
   ansible.builtin.include_role:
     name: lit.rhel.podman

--- a/roles/aap_host_prepare/tasks/selinux.yml
+++ b/roles/aap_host_prepare/tasks/selinux.yml
@@ -1,0 +1,59 @@
+---
+- name: Install SELinux management tools for AAP paths
+  ansible.builtin.package:
+    name: policycoreutils-python-utils
+    state: present
+
+- name: Persist SELinux contexts for AAP paths
+  community.general.sefcontext:
+    target: "{{ item.target }}"
+    setype: "{{ item.setype | default(omit) }}"
+    substitute: "{{ item.substitute | default(omit) }}"
+    state: present
+  loop: "{{ aap_host_prepare_selinux_fcontexts }}"
+  loop_control:
+    label: >-
+      {{
+        item.target
+        ~ ' -> '
+        ~ (item.setype | default(item.substitute))
+      }}
+
+- name: Apply persistent SELinux context to AAP mountpoint
+  ansible.builtin.command:
+    argv:
+      - restorecon
+      - -F
+      - -v
+      - /appl
+  register: aap_host_prepare_mountpoint_restorecon
+  changed_when: >-
+    aap_host_prepare_mountpoint_restorecon.stdout
+    | default('')
+    | trim
+    | length > 0
+
+- name: Apply persistent SELinux contexts to AAP paths
+  ansible.builtin.command:
+    argv:
+      - restorecon
+      - -R
+      - -F
+      - -v
+      - "{{ item }}"
+  register: aap_host_prepare_restorecon
+  changed_when: aap_host_prepare_restorecon.stdout | default('') | trim | length > 0
+  loop: "{{ aap_host_prepare_selinux_restore_paths }}"
+  loop_control:
+    label: "{{ item }}"
+
+- name: Validate effective SELinux contexts for AAP paths
+  ansible.builtin.command:
+    argv:
+      - matchpathcon
+      - -V
+      - "{{ item }}"
+  changed_when: false
+  loop: "{{ ['/appl'] + aap_host_prepare_selinux_restore_paths }}"
+  loop_control:
+    label: "{{ item }}"

--- a/roles/aap_prepare/README.md
+++ b/roles/aap_prepare/README.md
@@ -7,9 +7,11 @@ the managed AAP host. It is intentionally independent from the Red Hat installer
 workflow in `aap_deploy` and from API configuration in `aap_cac`.
 
 Before staging artifacts, the role validates that the configured AAP gateway
-hostname resolves to one of the managed host's IPv4 addresses. Disable this
-precheck with `aap_prepare_gateway_dns_precheck_enabled: false` when DNS is
-managed outside the rollout window.
+hostname resolves to one of the managed host's IPv4 addresses. It resolves the
+hostname from `aap_deploy_gateway_main_url`, then
+`aap_cac_gateway_hostname`, and finally `aap_fqdn`. Disable this precheck with
+`aap_prepare_gateway_dns_precheck_enabled: false` when DNS is managed outside
+the rollout window.
 
 ## Requirements
 
@@ -18,6 +20,8 @@ None.
 ## Variables
 
 - `aap_prepare_artifact_dir`: `${PWD}/.artifacts`
+- `aap_prepare_artifact_dir_mode`: `0750`; the role creates this
+  controller-local directory when a local or auto-detected source is used
 - `aap_prepare_gateway_dns_precheck_enabled`: `true`
 - setup bundle patterns:
   - `aap-containerized-setup.tar.gz`

--- a/roles/aap_prepare/defaults/main.yml
+++ b/roles/aap_prepare/defaults/main.yml
@@ -6,6 +6,7 @@ aap_prepare_artifact_dir: >-
     lookup('ansible.builtin.env', 'AAP_ARTIFACT_DIR')
     | default(lookup('ansible.builtin.env', 'PWD') ~ '/.artifacts', true)
   }}
+aap_prepare_artifact_dir_mode: "0750"
 aap_prepare_validate_certs: true
 aap_prepare_timeout: 1800
 aap_prepare_force: false

--- a/roles/aap_prepare/tasks/assert.yml
+++ b/roles/aap_prepare/tasks/assert.yml
@@ -4,6 +4,7 @@
     that:
       - aap_prepare_enabled is boolean
       - aap_prepare_artifact_dir | trim | length > 0
+      - aap_prepare_artifact_dir_mode is match('^0[0-7]{3}$')
       - aap_prepare_validate_certs is boolean
       - aap_prepare_timeout | int > 0
       - aap_prepare_force is boolean

--- a/roles/aap_prepare/tasks/main.yml
+++ b/roles/aap_prepare/tasks/main.yml
@@ -29,6 +29,22 @@
     - aap_prepare
     - artifacts
 
+- name: Ensure controller-local AAP artifact directory exists
+  ansible.builtin.file:
+    path: "{{ aap_prepare_artifact_dir }}"
+    state: directory
+    mode: "{{ aap_prepare_artifact_dir_mode }}"
+  delegate_to: localhost
+  become: false
+  when:
+    - aap_prepare_enabled | bool
+    - >-
+      aap_prepare_bundle_source in ['auto', 'local']
+      or aap_prepare_manifest_source in ['auto', 'local']
+  tags:
+    - aap_prepare
+    - artifacts
+
 - name: Resolve AAP setup bundle artifact
   ansible.builtin.include_tasks: resolve_artifact.yml
   vars:

--- a/roles/aap_prepare/tasks/precheck_gateway_dns.yml
+++ b/roles/aap_prepare/tasks/precheck_gateway_dns.yml
@@ -11,11 +11,15 @@
         if (aap_deploy_gateway_main_url | default('', true) | trim | length > 0)
         else
         (
-          aap_cac_gateway_hostname
-          | default('', true)
-          | regex_replace('^https?://', '')
-          | regex_replace('/.*$', '')
-          | regex_replace(':.*$', '')
+          (
+            aap_cac_gateway_hostname
+            | default('', true)
+            | regex_replace('^https?://', '')
+            | regex_replace('/.*$', '')
+            | regex_replace(':.*$', '')
+          )
+          if (aap_cac_gateway_hostname | default('', true) | trim | length > 0)
+          else (aap_fqdn | default('', true) | trim)
         )
       }}
   changed_when: false
@@ -31,8 +35,8 @@
       - aap_prepare_gateway_dns_precheck_hostname is not match('^https?://')
     fail_msg: >-
       AAP gateway URL precheck requires a resolvable hostname. Set
-      aap_deploy_gateway_main_url or aap_cac_gateway_hostname to the AAP
-      gateway FQDN before running the AAP rollout.
+      aap_deploy_gateway_main_url, aap_cac_gateway_hostname, or aap_fqdn to
+      the AAP gateway FQDN before running the AAP rollout.
     quiet: true
   changed_when: false
   tags:

--- a/roles/aap_tls/tasks/main.yml
+++ b/roles/aap_tls/tasks/main.yml
@@ -153,8 +153,8 @@
       - item.stat.isreg
       - item.stat.readable
     fail_msg: >-
-      Required generated AAP TLS file is not readable on the automation
-      controller: {{ item.item }}
+      Required generated AAP TLS file is not readable on
+      {{ aap_tls_selfsigned_delegate_to }}: {{ item.item }}
     quiet: true
   loop: "{{ aap_tls_selfsigned_deployment_file_stats.results }}"
   loop_control:

--- a/roles/aap_tls/tasks/main.yml
+++ b/roles/aap_tls/tasks/main.yml
@@ -132,6 +132,37 @@
     - aap_tls_selfsigned_enabled | bool
     - not ansible_check_mode
 
+- name: Inspect generated temporary AAP TLS deployment files
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop:
+    - "{{ aap_tls_selfsigned_cert_path }}"
+    - "{{ aap_tls_selfsigned_key_path }}"
+    - "{{ aap_tls_selfsigned_ca_cert_path }}"
+  register: aap_tls_selfsigned_deployment_file_stats
+  delegate_to: "{{ aap_tls_selfsigned_delegate_to }}"
+  changed_when: false
+  when:
+    - aap_tls_selfsigned_enabled | bool
+    - not ansible_check_mode
+
+- name: Assert generated temporary AAP TLS deployment files are readable
+  ansible.builtin.assert:
+    that:
+      - item.stat.exists
+      - item.stat.isreg
+      - item.stat.readable
+    fail_msg: >-
+      Required generated AAP TLS file is not readable on the automation
+      controller: {{ item.item }}
+    quiet: true
+  loop: "{{ aap_tls_selfsigned_deployment_file_stats.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when:
+    - aap_tls_selfsigned_enabled | bool
+    - not ansible_check_mode
+
 - name: Install temporary AAP CA in system trust store
   ansible.builtin.copy:
     src: "{{ aap_tls_selfsigned_ca_cert_path }}"


### PR DESCRIPTION
Production AAP deployment fixes: idempotent /appl substrate and SELinux labeling, FQDN-derived endpoints, controller-side TLS source validation, and preserved upstream AAP 2.7 Hub authentication behavior. Validated with ansible-lint, changelog policy, collection smoke, and AAP deploy Molecule converge/idempotence/verify.