### PR TITLE
fix(release): remove back-sync Issues API dependency

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -226,7 +226,9 @@ jobs:
           elif [ "${PR_AUTHOR}" = "lightning-it-release-automation[bot]" ] \
             && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
             && [[ "${PR_HEAD}" == backsync/release-v*-to-develop ]] \
-            && [ "${PR_BASE}" = "develop" ]; then
+            && [ "${PR_BASE}" = "develop" ] \
+            && jq -e 'index("skip-changelog") != null' \
+              <<<"${PR_LABELS}" >/dev/null; then
             release_tag="${PR_HEAD#backsync/release-}"
             release_tag="${release_tag%-to-develop}"
             if [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -226,9 +226,7 @@ jobs:
           elif [ "${PR_AUTHOR}" = "lightning-it-release-automation[bot]" ] \
             && [ "${PR_HEAD_REPO}" = "${REPOSITORY}" ] \
             && [[ "${PR_HEAD}" == backsync/release-v*-to-develop ]] \
-            && [ "${PR_BASE}" = "develop" ] \
-            && jq -e 'index("skip-changelog") != null' \
-              <<<"${PR_LABELS}" >/dev/null; then
+            && [ "${PR_BASE}" = "develop" ]; then
             release_tag="${PR_HEAD#backsync/release-}"
             release_tag="${release_tag%-to-develop}"
             if [[ "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \

--- a/.github/workflows/release-back-sync.yml
+++ b/.github/workflows/release-back-sync.yml
@@ -261,15 +261,6 @@ jobs:
           fi
           pushed_sha="$(git rev-parse HEAD)"
 
-          if ! gh label list --repo "$REPO" --json name --jq '.[].name' \
-            | grep -Fxq skip-changelog
-          then
-            gh label create skip-changelog \
-              --repo "$REPO" \
-              --description "Changelog fragment intentionally not required for this PR." \
-              --color "6f42c1"
-          fi
-
           owned_pulls="$(
             gh api --method GET "repos/${REPO}/pulls" \
               -f state=open \
@@ -288,8 +279,7 @@ jobs:
                 --base develop \
                 --head "$branch" \
                 --title "$title" \
-                --body "$body" \
-                --label skip-changelog
+                --body "$body"
           fi
 
           owned_pulls="$(
@@ -313,5 +303,4 @@ jobs:
           gh pr edit "$existing" \
             --repo "$REPO" \
             --title "$title" \
-            --body "$body" \
-            --add-label skip-changelog
+            --body "$body"

--- a/changelogs/fragments/release-backsync-least-privilege.yml
+++ b/changelogs/fragments/release-backsync-least-privilege.yml
@@ -1,6 +1,7 @@
 ---
 security_fixes:
   - >-
-    Remove the unused issues permission from release back-sync automation so
-    its GitHub App token requests only repository contents and pull-request
-    access.
+    Remove label operations from release back-sync automation so its GitHub App
+    token needs only repository contents and pull-request access; strict bot,
+    branch, base, title, tag, and immutable-SHA checks identify trusted
+    back-sync pull requests without Issues API access.

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -583,9 +583,6 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertNotIn("gh label ", back_sync)
         self.assertNotIn("--label skip-changelog", back_sync)
         self.assertNotIn("--add-label skip-changelog", back_sync)
-        copilot_review = (WORKFLOWS / "copilot-review.yml").read_text(encoding="utf-8")
-        self.assertIn('[[ "${PR_HEAD}" == backsync/release-v*-to-develop ]]', copilot_review)
-        self.assertIn('[ "${PR_BASE}" = "develop" ]', copilot_review)
         release_prepare = (WORKFLOWS / "release-prepare.yml").read_text(encoding="utf-8")
         self.assertIn(
             '"--force-with-lease=${release_ref}:${remote_release_sha}"',

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -579,6 +579,13 @@ class WorkflowSecurityTests(unittest.TestCase):
         back_sync = (WORKFLOWS / "release-back-sync.yml").read_text(encoding="utf-8")
         self.assertIn('"--force-with-lease=${branch_ref}:${remote_branch_sha}"', back_sync)
         self.assertNotIn("authenticated_push --force origin", back_sync)
+        self.assertNotIn("permission-issues:", back_sync)
+        self.assertNotIn("gh label ", back_sync)
+        self.assertNotIn("--label skip-changelog", back_sync)
+        self.assertNotIn("--add-label skip-changelog", back_sync)
+        copilot_review = (WORKFLOWS / "copilot-review.yml").read_text(encoding="utf-8")
+        self.assertIn('[[ "${PR_HEAD}" == backsync/release-v*-to-develop ]]', copilot_review)
+        self.assertIn('[ "${PR_BASE}" = "develop" ]', copilot_review)
         release_prepare = (WORKFLOWS / "release-prepare.yml").read_text(encoding="utf-8")
         self.assertIn(
             '"--force-with-lease=${release_ref}:${remote_release_sha}"',


### PR DESCRIPTION
## Summary
- remove release back-sync label creation and mutation
- recognize trusted release back-syncs using the existing strict bot/repository/branch/base/title/tag/SHA contract
- keep the release App token limited to contents and pull requests
- add regression assertions and correct the changelog claim

## Validation
- `git diff --check`
- targeted workflow security test passes
- full local module has one platform-only failure because macOS has no `/usr/bin/bash`; unrelated tests pass

Addresses the actionable review findings on promotion PR #509 and Engineering ADR issue #500.