### PR TITLE
fix(aap): disable become for controller TLS checks

### DIFF
--- a/changelogs/fragments/aap-deploy-controller-tls-no-become.yml
+++ b/changelogs/fragments/aap-deploy-controller-tls-no-become.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Prevent controller-side AAP customer TLS file checks from inheriting
+    privilege escalation intended for the managed host, so the checks also
+    work in execution environments without sudo.

--- a/roles/aap_deploy/tasks/15_stage_tls_assets.yml
+++ b/roles/aap_deploy/tasks/15_stage_tls_assets.yml
@@ -7,6 +7,7 @@
     label: "{{ item.0 }} {{ item.1 }}"
   register: aap_deploy_tls_customer_service_file_stats
   delegate_to: localhost
+  become: false
   changed_when: false
   when:
     - aap_deploy_tls_source == 'customer_files'
@@ -35,6 +36,7 @@
     path: "{{ aap_deploy_tls_customer_files.ca_cert_src }}"
   register: aap_deploy_tls_customer_ca_file_stat
   delegate_to: localhost
+  become: false
   changed_when: false
   when:
     - aap_deploy_tls_source == 'customer_files'


### PR DESCRIPTION
## What changed

- disable privilege escalation for controller-local customer TLS file checks
- cover both service certificate/key checks and the customer CA check
- add a bugfix changelog fragment

## Root cause

The delegated localhost tasks inherited ansible_become=true from the managed AAP host. The execution environment intentionally has no sudo binary, so Ansible failed with rc=127 before it could inspect the TLS files.

## Validation

- explicit task-structure assertion
- changelog policy
- yamllint
- ansible-lint