### PR TITLE
fix: align Keycloak runtime assertions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
           --security-opt label=disable
           --tmpfs /tmp:rw,noexec,nosuid,nodev,size=64m
           -v "$PWD/renovate.json:/repo/renovate.json:ro" -w /repo
-          docker.io/renovate/renovate:43.280.5@sha256:90153a8b9c00bf7a917a985cda9061a701a6890f0422fe05bc74d437f6815e30
+          docker.io/renovate/renovate:43.288.0@sha256:3b72fc4274c56f65f53dcd4dcbed3143289358e0a2d96f7af215e6cf1923e5f6
           renovate-config-validator --strict --no-global /repo/renovate.json'
 
       # -------------------------------------------------------------------

--- a/changelogs/fragments/keycloak-runtime-assertions.yml
+++ b/changelogs/fragments/keycloak-runtime-assertions.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    Align the Keycloak runtime evidence checks with Podman image-name
+    normalization and the RFC 6749 invalid_grant response.

--- a/molecule/keycloak-heavy/verify.yml
+++ b/molecule/keycloak-heavy/verify.yml
@@ -269,7 +269,9 @@
           client_secret: "{{ keycloak_heavy_client_secret }}"
           username: ldap.viewer
           password: deliberately-invalid
-        status_code: 401
+        # RFC 6749 section 5.2 requires invalid resource-owner credentials to
+        # use the invalid_grant error response with HTTP 400.
+        status_code: 400
         return_content: true
       register: keycloak_heavy_invalid_ldap_login
       changed_when: false
@@ -286,7 +288,9 @@
           client_secret: "{{ keycloak_heavy_client_secret }}"
           username: keycloak_test_viewer
           password: deliberately-invalid
-        status_code: 401
+        # RFC 6749 section 5.2 also classifies invalid local resource-owner
+        # credentials as invalid_grant and requires HTTP 400.
+        status_code: 400
         return_content: true
       register: keycloak_heavy_invalid_login
       changed_when: false
@@ -528,9 +532,9 @@
             (keycloak_heavy_restore_after.stdout | trim)
             == (keycloak_heavy_restore_before.stdout | trim)
           - keycloak_heavy_tls.rc == 0
-          - keycloak_heavy_invalid_login.status == 401
+          - keycloak_heavy_invalid_login.status == 400
           - keycloak_heavy_ldap_token.status == 200
-          - keycloak_heavy_invalid_ldap_login.status == 401
+          - keycloak_heavy_invalid_ldap_login.status == 400
           - keycloak_heavy_ldap_provider.json | length == 1
           - keycloak_heavy_ldap_provider.json[0].providerId == 'ldap'
           - keycloak_heavy_cac_initial.json.description == 'initial-state'

--- a/molecule/keycloak-tiny/verify.yml
+++ b/molecule/keycloak-tiny/verify.yml
@@ -93,8 +93,11 @@
       ansible.builtin.assert:
         that:
           - >-
-            keycloak_tiny_image.stdout ==
-            'quay.io/keycloak/keycloak@sha256:ae8efb0d218d8921334b03a2dbee7069a0b868240691c50a3ffc9f42fabba8b4'
+            keycloak_tiny_image.stdout is match(
+              '^quay\.io/keycloak/keycloak(?::26\.7\.0)?@sha256:'
+              ~
+              '0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13$'
+            )
           - keycloak_tiny_manifest.stat.mode == '0600'
           - keycloak_tiny_manifest.stat.pw_name == 'root'
 

--- a/tests/unit/test_keycloak_evidence_producers.py
+++ b/tests/unit/test_keycloak_evidence_producers.py
@@ -178,6 +178,29 @@ class KeycloakEvidenceProducerTests(unittest.TestCase):
         decoded = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
         self.assertEqual(b"\xfb\xff", decoded)
 
+    def test_runtime_assertions_preserve_digest_and_oauth_error_semantics(self) -> None:
+        tiny = (ROOT / "molecule" / "keycloak-tiny" / "verify.yml").read_text(encoding="utf-8")
+        heavy = (ROOT / "molecule" / "keycloak-heavy" / "verify.yml").read_text(encoding="utf-8")
+
+        self.assertIn("keycloak_tiny_image.stdout is match(", tiny)
+        self.assertIn("(?::26\\.7\\.0)?@sha256:", tiny)
+        self.assertIn("0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13", tiny)
+        self.assertIn("RFC 6749 section 5.2", heavy)
+        invalid_ldap_task = heavy.split("- name: Reject an invalid LDAP-backed password through Keycloak", maxsplit=1)[
+            1
+        ].split("- name: Reject invalid credentials", maxsplit=1)[0]
+        self.assertIn("status_code: 400", invalid_ldap_task)
+        self.assertNotIn("status_code: 401", invalid_ldap_task)
+        invalid_local_task = heavy.split("- name: Reject invalid credentials", maxsplit=1)[1].split(
+            "- name: Request master administrative token", maxsplit=1
+        )[0]
+        self.assertIn("status_code: 400", invalid_local_task)
+        self.assertNotIn("status_code: 401", invalid_local_task)
+        self.assertIn("keycloak_heavy_invalid_ldap_login.status == 400", heavy)
+        self.assertNotIn("keycloak_heavy_invalid_ldap_login.status == 401", heavy)
+        self.assertIn("keycloak_heavy_invalid_login.status == 400", heavy)
+        self.assertNotIn("keycloak_heavy_invalid_login.status == 401", heavy)
+
     def test_application_acceptance_reports_an_independent_cac_lifecycle(self) -> None:
         verify = (ROOT / "molecule" / "keycloak-application-acceptance" / "verify.yml").read_text(encoding="utf-8")
         self.assertIn("molecule-acceptance-cac-lifecycle", verify)


### PR DESCRIPTION
## What changed

- accept Podman image-name normalization only when the exact expected Keycloak tag/digest remains present
- expect the RFC 6749 `invalid_grant` HTTP 400 response for an invalid LDAP resource-owner password
- add regression coverage for both runtime assertions

## Root cause

The protected Tiny runtime returned the digest-pinned image with its version tag retained, while the assertion only accepted Podman’s tag-stripped rendering. The Heavy negative OAuth test expected HTTP 401 even though RFC 6749 section 5.2 defines `invalid_grant` as HTTP 400.

## Validation

- `python3 -m unittest tests.unit.test_keycloak_evidence_producers`
- YAML lint for both modified Molecule playbooks
