### PR TITLE
chore: sync v2.1.1 release back to develop

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Lightning IT Collection Release Notes Release Notes
 
 .. contents:: Topics
 
+v2.1.1
+======
+
+Security Fixes
+--------------
+
+- Remove label operations from release back-sync automation so its GitHub App token needs only repository contents and pull-request access; strict bot, branch, base, title, tag, and immutable-SHA checks identify trusted back-sync pull requests without Issues API access.
+
 v2.1.0
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -25,4 +25,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 2.1.0
+version: 2.1.1

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -395,3 +395,15 @@ releases:
       - shared-assets-sync.yml
       - trusted-renovate-changelog-policy.yml
     release_date: '2026-07-29'
+  2.1.1:
+    changes:
+      security_fixes:
+        - Remove label operations from release back-sync automation so its GitHub
+          App token needs only repository contents and pull-request access; strict
+          bot, branch, base, title, tag, and immutable-SHA checks identify trusted
+          back-sync pull requests without Issues API access.
+    fragments:
+      - release-backsync-least-privilege.yml
+      - shared-assets-sync-30440111944.yml
+      - trusted-release-preparation-review.yml
+    release_date: '2026-07-29'

--- a/changelogs/fragments/release-backsync-least-privilege.yml
+++ b/changelogs/fragments/release-backsync-least-privilege.yml
@@ -1,7 +1,0 @@
----
-security_fixes:
-  - >-
-    Remove label operations from release back-sync automation so its GitHub App
-    token needs only repository contents and pull-request access; strict bot,
-    branch, base, title, tag, and immutable-SHA checks identify trusted
-    back-sync pull requests without Issues API access.

--- a/changelogs/fragments/shared-assets-sync-30440111944.yml
+++ b/changelogs/fragments/shared-assets-sync-30440111944.yml
@@ -1,3 +1,0 @@
----
-trivial:
-  - Synchronize centrally managed repository standards.

--- a/changelogs/fragments/trusted-release-preparation-review.yml
+++ b/changelogs/fragments/trusted-release-preparation-review.yml
@@ -1,5 +1,0 @@
----
-trivial:
-  - >-
-    Document the exact-SHA trusted verifier used for App-authored
-    release-preparation changes and its fail-closed review boundaries.

--- a/changelogs/release-preparation.json
+++ b/changelogs/release-preparation.json
@@ -1,94 +1,22 @@
 {
-  "base_sha": "59583e4d94399186d399a73d02a1b12ab9ed9c29",
-  "current_version": "2.0.3",
+  "base_sha": "506f059df026cf5fa426d6ded706786479d9ad68",
+  "current_version": "2.1.0",
   "fragments": [
     {
-      "path": "aap-cac-gateway-organization-token.yml",
-      "sha256": "93fd4c3746a72cfec339a43030c435c147c2c86ffe40d65546d120a768ccff9e"
+      "path": "release-backsync-least-privilege.yml",
+      "sha256": "5fa73473ca6d6d145d847bcf8aecd20069a3ab869fa9efc3ce10a5bfc3e6242a"
     },
     {
-      "path": "aap-deploy-hub-readiness-url.yml",
-      "sha256": "333e3e99de4caa4a68e020d70d36e3860f80d14fcbe5054cf3b750c0cbf95100"
-    },
-    {
-      "path": "aap-deploy-prepare-without-passwords.yml",
-      "sha256": "cd979c7778aabc69bacb2c6083e14d47d753d02cd24a7597528bc1da90168cee"
-    },
-    {
-      "path": "aap-host-prepare-installer-prerequisites.yml",
-      "sha256": "cc4ff7b570fbef714ac54876b70089d60f33fd228a1421eab6d03e417eec940d"
-    },
-    {
-      "path": "aap-host-prepare-selinux.yml",
-      "sha256": "7aedf48b749414a1543e3e7547c040839819e1ebb55af0d97ecbbe4480e5c361"
-    },
-    {
-      "path": "aap-preflight-check-mode.yml",
-      "sha256": "179825e98ae41f6d4dd8424812d88353b38c5c36a5e88e14d659e69c4b0ed80e"
-    },
-    {
-      "path": "aap-preflight-phase-contract.yml",
-      "sha256": "eb23dc94907b54139cc59be263eaa88703e23dc41afc163b57dc41d44407f771"
-    },
-    {
-      "path": "aap-preflight-platform-dns.yml",
-      "sha256": "d1921d692d635e0ee9a799742ead60d03625a7faa68d2806da666f5b61f4888a"
-    },
-    {
-      "path": "aap-prepare-fqdn-fallback.yml",
-      "sha256": "9ce71d8e2c46ee831c0d1caad6da8d847c235206b4bfbc102537ccb0f5f0cccd"
-    },
-    {
-      "path": "aap-selfsigned-system-trust.yml",
-      "sha256": "424bab35dd7df9312357f9f975dad2a9587f662796a4fbd1fa2375099cb4f258"
-    },
-    {
-      "path": "aap-tls-source-validation.yml",
-      "sha256": "948abe84172a58b058b7722a0a003d12ad7bddbf12b85a2526486a8f2fe21cd0"
-    },
-    {
-      "path": "adr-assurance.yml",
-      "sha256": "5927b59543d8228c3cd5bcd07b7f2f21565d2a89eaeff63b53e184e998ec737e"
-    },
-    {
-      "path": "adr-heavy-execution-ownership.yml",
-      "sha256": "dc653a7c2dbab533c25d5fc7967797d15702b9656c75afc5c18db995876e2678"
-    },
-    {
-      "path": "shared-assets-sync-29853456486.yml",
+      "path": "shared-assets-sync-30440111944.yml",
       "sha256": "b637a090dd4cd427b7154c68ccb11efd1e13b7fc1974bd0bb36b7886a978a440"
     },
     {
-      "path": "shared-assets-sync-29869010879.yml",
-      "sha256": "b637a090dd4cd427b7154c68ccb11efd1e13b7fc1974bd0bb36b7886a978a440"
-    },
-    {
-      "path": "shared-assets-sync-29901680048.yml",
-      "sha256": "b637a090dd4cd427b7154c68ccb11efd1e13b7fc1974bd0bb36b7886a978a440"
-    },
-    {
-      "path": "shared-assets-sync-29908171139.yml",
-      "sha256": "b637a090dd4cd427b7154c68ccb11efd1e13b7fc1974bd0bb36b7886a978a440"
-    },
-    {
-      "path": "shared-assets-sync-29910506345.yml",
-      "sha256": "b637a090dd4cd427b7154c68ccb11efd1e13b7fc1974bd0bb36b7886a978a440"
-    },
-    {
-      "path": "shared-assets-sync-29913646011.yml",
-      "sha256": "b637a090dd4cd427b7154c68ccb11efd1e13b7fc1974bd0bb36b7886a978a440"
-    },
-    {
-      "path": "shared-assets-sync.yml",
-      "sha256": "b637a090dd4cd427b7154c68ccb11efd1e13b7fc1974bd0bb36b7886a978a440"
-    },
-    {
-      "path": "trusted-renovate-changelog-policy.yml",
-      "sha256": "d12ff95caab1172a145a55bd06fb2199307eb18fbab678850b418d3d847eb5cd"
+      "path": "trusted-release-preparation-review.yml",
+      "sha256": "bd3e36be56ce8595e5b546948dfb85f4a9d223531570db08c238f0da214ccc80"
     }
   ],
-  "impact": "minor",
-  "next_version": "2.1.0",
+  "impact": "patch",
+  "next_version": "2.1.1",
   "preparer": {
     "account_id": "307565056",
     "email": "307565056+lightning-it-release-automation[bot]@users.noreply.github.com",
@@ -104,7 +32,7 @@
     "path": ".github/workflows/release-prepare.yml",
     "ref": "lightning-it/ansible-collection-supplementary/.github/workflows/release-prepare.yml@refs/heads/main",
     "run_attempt": "1",
-    "run_id": "30423885334",
-    "source_sha": "59583e4d94399186d399a73d02a1b12ab9ed9c29"
+    "run_id": "30447681926",
+    "source_sha": "506f059df026cf5fa426d6ded706786479d9ad68"
   }
 }

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: lit
 name: supplementary
-version: 2.1.0
+version: 2.1.1
 readme: README.md
 description: 'Supplementary Ansible collection for ModuLix, providing configuration
   and integration roles for platform services and Terraform-backed workflows.


### PR DESCRIPTION
Release back-sync of `v2.1.1` (`fdac9d98d20252840b437a7080e2e73904c08bc9`) to `develop`.

This PR brings the exact release-generated changelog files and `galaxy.yml` version back to `develop`, removes the three fragments consumed by v2.1.1, and makes the annotated release commit a parent of the back-sync merge commit.

The automatic back-sync workflow failed before creating a branch because its release-automation App token cannot query metadata for the separate private release-tag App (`HTTP 403`). The release and tag themselves were successfully published and independently verified; this PR reproduces only the intended back-sync result while that workflow defect is fixed separately.

Validation:

- merge parents are current `origin/develop` and exact v2.1.1 commit
- release-generated files are byte-identical to v2.1.1
- consumed fragments are absent
- `git diff --check` passes

Merge this PR with a merge commit, not squash or rebase, so the exact tagged release remains an ancestor of `develop`.
