### PR TITLE
fix(aap): remove partial install autoreset

### DIFF
--- a/changelogs/fragments/aap-restore-upstream-gateway-upload.yml
+++ b/changelogs/fragments/aap-restore-upstream-gateway-upload.yml
@@ -8,4 +8,8 @@ bugfixes:
     and readiness bundle rewrites. Leave EDA settings with the upstream
     installer so ``ENABLE_SERVICE_BACKED_SSO`` is not emitted twice in
     ``/etc/eda.yaml``. Generate the public Envoy URL without the internal
-    Gateway Nginx port and leave automatic partial-install reset disabled.
+    Gateway Nginx port.
+removed_features:
+  - >-
+    Remove the opt-in destructive partial-install reset from ``aap_deploy``.
+    Incomplete deployments must be cleaned explicitly before a clean reinstall.

--- a/roles/aap_deploy/README.md
+++ b/roles/aap_deploy/README.md
@@ -91,7 +91,6 @@ Key variables:
 - `aap_deploy_runtime_probe_all_containers` (default: `true`, uses `podman ps -a`)
 - `aap_deploy_runtime_name_regex` (default: `.*(automation|ansible|aap).*`)
 - `aap_deploy_runtime_min_matching_containers` (default: `1`)
-- `aap_deploy_reset_partial_install_enabled` (default: `false`)
 - `aap_deploy_enforce_min_mem_check` (default: `true`)
 - `aap_deploy_min_mem_mb` (default: `15000`, approximately 16GB)
 - `aap_deploy_growth_inventory_connection` (default: `local`)

--- a/roles/aap_deploy/README.md
+++ b/roles/aap_deploy/README.md
@@ -89,7 +89,7 @@ Key variables:
 - `aap_deploy_skip_if_installed_runtime_min_matching_containers` (default: `1`)
 - `aap_deploy_skip_if_runtime_active`
 - `aap_deploy_runtime_probe_all_containers` (default: `true`, uses `podman ps -a`)
-- `aap_deploy_runtime_name_regex` (default: `.*(automation|ansible|aap).*`)
+- `aap_deploy_runtime_name_regex` (default: `^(automation-|postgresql$|redis-|receptor$)`)
 - `aap_deploy_runtime_min_matching_containers` (default: `1`)
 - `aap_deploy_enforce_min_mem_check` (default: `true`)
 - `aap_deploy_min_mem_mb` (default: `15000`, approximately 16GB)

--- a/roles/aap_deploy/defaults/main.yml
+++ b/roles/aap_deploy/defaults/main.yml
@@ -508,9 +508,6 @@ aap_deploy_skip_if_runtime_active: true
 aap_deploy_runtime_probe_all_containers: true
 aap_deploy_runtime_name_regex: '^(automation-|postgresql$|redis-|receptor$)'
 aap_deploy_runtime_min_matching_containers: 1
-aap_deploy_reset_partial_install_enabled: false
-aap_deploy_reset_partial_install_remove_setup: true
-aap_deploy_reset_partial_install_remove_logs: true
 
 # Post-install verification
 aap_deploy_verify_gateway_https: false

--- a/roles/aap_deploy/tasks/05_detect_existing_install.yml
+++ b/roles/aap_deploy/tasks/05_detect_existing_install.yml
@@ -18,11 +18,6 @@
           (aap_deploy_skip_if_runtime_active | bool)
           and (aap_deploy_install_marker_precheck.stat.exists | default(false))
         )
-        or
-        (
-          (aap_deploy_reset_partial_install_enabled | bool)
-          and not (aap_deploy_install_marker_precheck.stat.exists | default(false))
-        )
       }}
   changed_when: false
 
@@ -65,72 +60,6 @@
         else []
       }}
   changed_when: false
-
-- name: Detect partial AAP runtime without install marker
-  ansible.builtin.set_fact:
-    aap_deploy_partial_install_runtime_detected: >-
-      {{
-        (aap_deploy_reset_partial_install_enabled | bool)
-        and not (aap_deploy_install_marker_precheck.stat.exists | default(false))
-        and (aap_deploy_runtime_probe_available | default(false))
-        and (
-          (aap_deploy_runtime_matching_containers | length)
-          >= (aap_deploy_runtime_min_matching_containers | int)
-        )
-      }}
-  changed_when: false
-
-- name: Reset partial AAP runtime when install marker is absent
-  when: aap_deploy_partial_install_runtime_detected | bool
-  block:
-    - name: Stop and remove partial AAP containers
-      ansible.builtin.command:
-        argv: "{{ ['podman', 'rm', '-f'] + aap_deploy_runtime_matching_containers }}"
-      become: true
-      become_user: "{{ aap_deploy_install_user }}"
-      register: aap_deploy_partial_container_reset
-      changed_when: aap_deploy_partial_container_reset.rc == 0
-
-    - name: Remove partial AAP Podman volumes
-      ansible.builtin.shell:
-        cmd: |
-          set -euo pipefail
-          volumes="$(podman volume ls -q)"
-          if [ -n "${volumes}" ]; then
-            podman volume rm -f ${volumes}
-          fi
-        executable: /bin/bash
-      become: true
-      become_user: "{{ aap_deploy_install_user }}"
-      register: aap_deploy_partial_volume_reset
-      changed_when: aap_deploy_partial_volume_reset.stdout | trim | length > 0
-
-    - name: Remove partial installer workspace
-      ansible.builtin.file:
-        path: "{{ aap_deploy_setup_dir }}"
-        state: absent
-      when: aap_deploy_reset_partial_install_remove_setup | bool
-
-    - name: Remove partial installer logs
-      ansible.builtin.file:
-        path: "{{ aap_deploy_installer_log_dir }}"
-        state: absent
-      when: aap_deploy_reset_partial_install_remove_logs | bool
-
-    - name: Recreate setup directory after partial reset
-      ansible.builtin.file:
-        path: "{{ aap_deploy_setup_dir }}"
-        state: directory
-        owner: "{{ aap_deploy_install_user }}"
-        group: "{{ aap_deploy_install_user }}"
-        mode: '0755'
-
-    - name: Clear runtime detection facts after partial reset
-      ansible.builtin.set_fact:
-        aap_deploy_runtime_probe_available: false
-        aap_deploy_runtime_matching_containers: []
-        aap_deploy_partial_install_runtime_detected: false
-      changed_when: false
 
 - name: Compute marker-based skip decision
   ansible.builtin.set_fact:

--- a/roles/aap_host_prepare/tasks/main.yml
+++ b/roles/aap_host_prepare/tasks/main.yml
@@ -280,37 +280,17 @@
     - os_prep
     - runtime
 
-- name: Report partial install-user runtime handoff
-  ansible.builtin.debug:
-    msg: >-
-      Install-user runtime exists before the install marker is present.
-      Leaving it for aap_deploy partial-install reset because
-      aap_deploy_reset_partial_install_enabled=true.
-  when:
-    - aap_runbook_cleanup_stale_install_user_runtime | default(true) | bool
-    - not (aap_host_prepare_installed_marker.stat.exists | default(false))
-    - aap_host_prepare_install_user_processes.rc | default(1) == 0
-    - (aap_host_prepare_install_user_unexpected_runtime_lines | default([])) | length > 0
-    - aap_deploy_reset_partial_install_enabled | default(false) | bool
-  tags:
-    - aap
-    - aap_host_prepare
-    - os_prep
-    - runtime
-
 - name: Fail when unexpected install-user runtime exists before first install
   ansible.builtin.fail:
     msg: >-
       Install user {{ aap_host_prepare_install_user_effective }} has runtime
-      processes before the AAP install marker exists. Stop those processes or
-      enable aap_deploy_reset_partial_install_enabled for partial-install
-      recovery before running base/preflight again.
+      processes before the AAP install marker exists. Clean the incomplete
+      installation explicitly before running base/preflight again.
   when:
     - aap_runbook_cleanup_stale_install_user_runtime | default(true) | bool
     - not (aap_host_prepare_installed_marker.stat.exists | default(false))
     - aap_host_prepare_install_user_processes.rc | default(1) == 0
     - (aap_host_prepare_install_user_unexpected_runtime_lines | default([])) | length > 0
-    - not (aap_deploy_reset_partial_install_enabled | default(false) | bool)
   tags:
     - aap
     - aap_host_prepare

--- a/roles/aap_local_execution/templates/aap-local/inventories/group_vars/aaps/aap.yml.j2
+++ b/roles/aap_local_execution/templates/aap-local/inventories/group_vars/aaps/aap.yml.j2
@@ -14,7 +14,6 @@ aap_deploy_gateway_verify_url: "{{ '{{' }} aap_deploy_gateway_main_url {{ '}}' }
 aap_deploy_install_user: {{ aap_local_execution_effective_install_user }}
 aap_deploy_install_user_home: /appl/home/{{ aap_local_execution_effective_install_user }}
 aap_deploy_install_user_shell: /bin/bash
-aap_deploy_reset_partial_install_enabled: false
 
 aap_deploy_growth_gateway_host: {{ aap_inventory_host | to_json }}
 aap_deploy_growth_controller_host: {{ aap_inventory_host | to_json }}

--- a/tests/unit/test_aap_gateway_contracts.py
+++ b/tests/unit/test_aap_gateway_contracts.py
@@ -67,10 +67,23 @@ class AapGatewayContractsTests(unittest.TestCase):
             'aap_deploy_gateway_main_url: "https://{{ aap_fqdn }}:8446"',
             template,
         )
-        self.assertIn(
-            "aap_deploy_reset_partial_install_enabled: false",
-            template,
+
+    def test_partial_install_autoreset_is_not_supported(self) -> None:
+        files = (
+            ROOT / "roles/aap_deploy/defaults/main.yml",
+            ROOT / "roles/aap_deploy/tasks/assert.yml",
+            ROOT / "roles/aap_deploy/tasks/05_detect_existing_install.yml",
+            ROOT / "roles/aap_host_prepare/tasks/main.yml",
+            ROOT / "roles/aap_local_execution/templates/aap-local/inventories/group_vars/aaps/aap.yml.j2",
+            ROOT / "roles/aap_deploy/README.md",
         )
+
+        for path in files:
+            with self.subTest(path=path):
+                self.assertNotIn(
+                    "aap_deploy_reset_partial_install",
+                    path.read_text(encoding="utf-8"),
+                )
 
     def test_registry_trust_remains_owned_by_upstream_installer(self) -> None:
         role_main = (ROOT / "roles/aap_deploy/tasks/main.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

- remove all `aap_deploy_reset_partial_install_*` role inputs
- remove the destructive automatic cleanup of Podman containers, volumes,
  setup data, and installer logs
- stop emitting a partial-reset override in local inventories
- make host preparation fail closed when runtime exists without an install
  marker
- add a regression contract that prevents the reset API from returning

## Why

The role should implement the supported clean-install path and normal
idempotency for a completed installation. Repairing an arbitrary partial
installation is environment-specific and destructive. A broken deployment must
instead be explicitly uninstalled or cleaned before starting a fresh install.

## Impact

Clean RHEL installations continue through the normal Red Hat AAP 2.7
containerized installer. Completed deployments are still detected by marker
and runtime. Incomplete deployments are never deleted automatically.

## Validation

- `python3 -m unittest -v tests.unit.test_aap_gateway_contracts` (7/7)
- Molecule `aap-deploy-basic`: dependency, syntax, converge, idempotence, verify
- collection smoke test
- changelog policy
- `git diff --check`
