### PR TITLE
fix(aap): require a clean install state

### DIFF
--- a/changelogs/fragments/aap-deploy-strict-clean-state.yml
+++ b/changelogs/fragments/aap-deploy-strict-clean-state.yml
@@ -1,0 +1,19 @@
+---
+bugfixes:
+  - >-
+    Make ``aap_deploy`` fail closed when its success marker and the dedicated
+    install user's Podman containers disagree. Clean hosts proceed, complete
+    installations are skipped, and incomplete installations require an
+    explicit official uninstall.
+removed_features:
+  - >-
+    Remove configurable runtime-only and marker-only install detection. These
+    modes could continue from an incomplete deployment instead of requiring a
+    clean reinstall.
+  - >-
+    Remove detached installer handoff. The role now waits for the official
+    installer to finish before it writes its success marker.
+security_fixes:
+  - >-
+    Suppress the setup inventory fact and installer output that can contain
+    resolved credentials.

--- a/molecule/aap-deploy-basic/verify.yml
+++ b/molecule/aap-deploy-basic/verify.yml
@@ -19,6 +19,8 @@
       {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY')
       }}/prepared-installer/collections/ansible_collections/ansible/containerized_installer/playbooks/install.yml
     aap_deploy_molecule_role_main_path: "{{ playbook_dir }}/../../roles/aap_deploy/tasks/main.yml"
+    aap_deploy_molecule_state_guard_path: >-
+      {{ playbook_dir }}/../../roles/aap_deploy/tasks/05_detect_existing_install.yml
     aap_deploy_molecule_customizer_path: >-
       {{ playbook_dir }}/../../roles/aap_deploy/tasks/25_customize_prepared_installer.yml
   tasks:
@@ -192,4 +194,46 @@
           - >-
             'aap_deploy_run_installer | bool'
             in aap_deploy_molecule_password_validation_task.when
+        quiet: true
+
+    - name: Read AAP clean-install state guard
+      ansible.builtin.slurp:
+        src: "{{ aap_deploy_molecule_state_guard_path }}"
+      register: aap_deploy_molecule_state_guard_file
+
+    - name: Parse AAP clean-install state guard
+      ansible.builtin.set_fact:
+        aap_deploy_molecule_state_guard_tasks: >-
+          {{ aap_deploy_molecule_state_guard_file.content | b64decode | from_yaml }}
+
+    - name: Select AAP clean-install state tasks
+      ansible.builtin.set_fact:
+        aap_deploy_molecule_state_classifier: >-
+          {{
+            aap_deploy_molecule_state_guard_tasks
+            | selectattr('name', 'equalto', 'Classify existing AAP install state')
+            | first
+          }}
+        aap_deploy_molecule_state_rejection: >-
+          {{
+            aap_deploy_molecule_state_guard_tasks
+            | selectattr('name', 'equalto', 'Reject inconsistent AAP install state')
+            | first
+          }}
+
+    - name: Assert clean, installed, and inconsistent states remain explicit
+      ansible.builtin.assert:
+        that:
+          - >-
+            ' and '
+            in aap_deploy_molecule_state_classifier['ansible.builtin.set_fact'].aap_deploy_existing_install_detected
+          - >-
+            ' != '
+            in aap_deploy_molecule_state_classifier['ansible.builtin.set_fact'].aap_deploy_install_state_inconsistent
+          - >-
+            aap_deploy_molecule_state_rejection['ansible.builtin.assert'].that
+            == ['not (aap_deploy_install_state_inconsistent | bool)']
+          - >-
+            'ansible.containerized_installer.uninstall'
+            in aap_deploy_molecule_state_rejection['ansible.builtin.assert'].fail_msg
         quiet: true

--- a/roles/aap_deploy/README.md
+++ b/roles/aap_deploy/README.md
@@ -40,10 +40,7 @@ Key variables:
 - `aap_deploy_manage_install_tmp_dir`
 - `aap_deploy_install_tmp_dir`
 - `aap_deploy_bundle_dir` (path containing `/bundle`)
-- `aap_deploy_installer_wait`
-- `aap_deploy_installer_async_jid_path`
 - `aap_deploy_installer_async_timeout`
-- `aap_deploy_installer_async_retries`
 - `aap_deploy_installer_async_delay`
 - `aap_deploy_installer_log_dir`
 - `aap_deploy_installer_diagnostics_enabled`
@@ -84,13 +81,6 @@ Key variables:
 - `aap_deploy_manage_download_unpack`
 - `aap_deploy_run_installer`
 - `aap_deploy_run_verify`
-- `aap_deploy_skip_if_installed`
-- `aap_deploy_skip_if_installed_require_runtime` (default: `true`)
-- `aap_deploy_skip_if_installed_runtime_min_matching_containers` (default: `1`)
-- `aap_deploy_skip_if_runtime_active`
-- `aap_deploy_runtime_probe_all_containers` (default: `true`, uses `podman ps -a`)
-- `aap_deploy_runtime_name_regex` (default: `^(automation-|postgresql$|redis-|receptor$)`)
-- `aap_deploy_runtime_min_matching_containers` (default: `1`)
 - `aap_deploy_enforce_min_mem_check` (default: `true`)
 - `aap_deploy_min_mem_mb` (default: `15000`, approximately 16GB)
 - `aap_deploy_growth_inventory_connection` (default: `local`)
@@ -109,9 +99,13 @@ Installer behavior:
 - The prepared Red Hat installer bundle is not rewritten. EDA settings remain
   owned by the upstream installer; this role does not append duplicate keys to
   the generated `/etc/eda.yaml`.
-- Role performs an early existing-install detection (marker and runtime containers).
-- Marker-based skip is runtime-validated by default to avoid stale marker false positives.
-- When detected, host prep, bundle handling, inventory rendering, and installer execution are skipped.
+- Role proceeds only when neither its success marker nor any Podman container
+  owned by the dedicated install user exists.
+- Marker and install-user containers together mean that AAP is installed; host prep, bundle
+  handling, inventory rendering, and installer execution are skipped.
+- A stale marker or markerless install-user container fails closed. Run the official
+  `ansible.containerized_installer.uninstall` playbook and clean the incomplete
+  installation explicitly before reinstalling.
 - Verification still runs (when enabled).
 - Role expects `lit.supplementary.aap_prepare` to stage the setup bundle on the
   managed host at `aap_deploy_setup_archive_path`.
@@ -119,15 +113,8 @@ Installer behavior:
 - In check mode, the role validates all inputs and predicts the setup path but
   does not call the vendor preparation role because that role requires the
   archive extraction result even though Ansible skips extraction in check mode.
-- By default, role runs the prepared containerized installer command directly
-  with controlled async status polling.
-- For CI or other orchestrators that cannot hold one Ansible polling task open
-  for the full installer runtime, set `aap_deploy_installer_wait: false`.
-  The role starts the native installer asynchronously, writes the async job id to
-  `aap_deploy_installer_async_jid_path`, skips the install marker, and skips
-  verification for that run. The orchestrator must poll the async job id with
-  short Ansible calls, fail on a non-zero installer return code, and run
-  verification after the async job finishes successfully.
+- Role runs the prepared containerized installer to completion with controlled
+  async polling before it writes the success marker.
 - Role writes the installer Ansible log below `aap_deploy_installer_log_dir`.
 - On installer failure, role prints redacted diagnostics before returning failure.
 - Default bundle dir is `bundle` (relative to the extracted setup directory).

--- a/roles/aap_deploy/defaults/main.yml
+++ b/roles/aap_deploy/defaults/main.yml
@@ -58,13 +58,9 @@ aap_deploy_debug_install_environment: false
 aap_deploy_manage_install_tmp_dir: false
 aap_deploy_install_tmp_dir: ""
 
-aap_deploy_installer_wait: true
 aap_deploy_installer_async_timeout: 14400
-aap_deploy_installer_async_retries: 720
 aap_deploy_installer_async_delay: 10
 aap_deploy_installer_log_dir: "{{ aap_deploy_install_dir }}/logs"
-aap_deploy_installer_async_jid_path: >-
-  {{ aap_deploy_installer_log_dir }}/aap_installer_async_jid
 aap_deploy_installer_extra_vars_path: >-
   {{ aap_setup_prep_setup_dir | default(aap_deploy_setup_dir, true) }}/aap_deploy_extra_vars.yml
 aap_deploy_installer_diagnostics_enabled: true
@@ -499,15 +495,8 @@ aap_deploy_run_verify: true
 aap_deploy_enforce_min_mem_check: true
 aap_deploy_min_mem_mb: 15000
 
-# Installer idempotency guard
-aap_deploy_skip_if_installed: true
-aap_deploy_skip_if_installed_require_runtime: true
-aap_deploy_skip_if_installed_runtime_min_matching_containers: 1
+# Installer state guard
 aap_deploy_installed_marker_path: "{{ aap_deploy_install_dir }}/.aap_containerized_installed"
-aap_deploy_skip_if_runtime_active: true
-aap_deploy_runtime_probe_all_containers: true
-aap_deploy_runtime_name_regex: '^(automation-|postgresql$|redis-|receptor$)'
-aap_deploy_runtime_min_matching_containers: 1
 
 # Post-install verification
 aap_deploy_verify_gateway_https: false

--- a/roles/aap_deploy/tasks/05_detect_existing_install.yml
+++ b/roles/aap_deploy/tasks/05_detect_existing_install.yml
@@ -4,11 +4,49 @@
     path: "{{ aap_deploy_installed_marker_path }}"
   register: aap_deploy_install_marker_precheck
 
+- name: Resolve install user UID for state guard
+  ansible.builtin.command:
+    cmd: "id -u {{ aap_deploy_install_user }}"
+  register: aap_deploy_install_user_uid_result
+  changed_when: false
+  check_mode: false
+
+- name: Record install user UID fact
+  ansible.builtin.set_fact:
+    aap_deploy_install_user_uid: "{{ aap_deploy_install_user_uid_result.stdout | trim }}"
+  changed_when: false
+
+- name: Enable lingering for install user
+  ansible.builtin.command:
+    cmd: "loginctl enable-linger {{ aap_deploy_install_user }}"
+  args:
+    creates: "/var/lib/systemd/linger/{{ aap_deploy_install_user }}"
+
+- name: Ensure install user systemd manager is running
+  ansible.builtin.systemd:
+    name: "user@{{ aap_deploy_install_user_uid }}.service"
+    state: started
+  register: aap_deploy_install_user_manager
+
+- name: Require active install user runtime for check mode
+  ansible.builtin.assert:
+    that:
+      - >-
+        not ansible_check_mode
+        or not (aap_deploy_install_user_manager.changed | default(false))
+    fail_msg: >-
+      Check mode cannot inspect rootless Podman before the install user runtime
+      is active. Run the base OS preparation once, then repeat the check.
+    quiet: true
+
 - name: List Podman containers for install user
   ansible.builtin.command:
     cmd: "podman ps -a --format {{ '{{.Names}}' }}"
   become: true
   become_user: "{{ aap_deploy_install_user }}"
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ aap_deploy_install_user_uid }}"
+    DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/{{ aap_deploy_install_user_uid }}/bus"
   register: aap_deploy_runtime_probe_cmd
   changed_when: false
   check_mode: false

--- a/roles/aap_deploy/tasks/05_detect_existing_install.yml
+++ b/roles/aap_deploy/tasks/05_detect_existing_install.yml
@@ -4,146 +4,57 @@
     path: "{{ aap_deploy_installed_marker_path }}"
   register: aap_deploy_install_marker_precheck
 
-- name: Decide whether runtime probe is safe before host preparation
-  ansible.builtin.set_fact:
-    aap_deploy_runtime_probe_requested: >-
-      {{
-        (
-          (aap_deploy_skip_if_installed | bool)
-          and (aap_deploy_skip_if_installed_require_runtime | bool)
-          and (aap_deploy_install_marker_precheck.stat.exists | default(false))
-        )
-        or
-        (
-          (aap_deploy_skip_if_runtime_active | bool)
-          and (aap_deploy_install_marker_precheck.stat.exists | default(false))
-        )
-      }}
-  changed_when: false
-
-- name: Check install user exists for runtime probe
+- name: List Podman containers for install user
   ansible.builtin.command:
-    cmd: "getent passwd {{ aap_deploy_install_user }}"
-  register: aap_deploy_install_user_getent
-  changed_when: false
-  failed_when: false
-  when: aap_deploy_runtime_probe_requested | bool
-
-- name: Probe running podman container names for install user
-  ansible.builtin.command:
-    cmd: >-
-      podman ps{% if aap_deploy_runtime_probe_all_containers | bool %} -a{% endif %}
-      --format {{ '{{.Names}}' }}
+    cmd: "podman ps -a --format {{ '{{.Names}}' }}"
   become: true
   become_user: "{{ aap_deploy_install_user }}"
   register: aap_deploy_runtime_probe_cmd
   changed_when: false
-  failed_when: false
-  when:
-    - aap_deploy_runtime_probe_requested | bool
-    - (aap_deploy_install_user_getent.rc | default(1)) == 0
+  check_mode: false
 
-- name: Build runtime detection facts
+- name: Record install user Podman containers
   ansible.builtin.set_fact:
-    aap_deploy_runtime_probe_available: "{{ (aap_deploy_runtime_probe_cmd.rc | default(1)) == 0 }}"
-    aap_deploy_runtime_matching_containers: >-
+    aap_deploy_runtime_containers: >-
       {{
-        (
-          aap_deploy_runtime_probe_cmd.stdout_lines
-          | default([])
-          | map('trim')
-          | reject('equalto', '')
-          | select('match', aap_deploy_runtime_name_regex)
-          | list
-        )
-        if (aap_deploy_runtime_probe_cmd.rc | default(1)) == 0
-        else []
+        aap_deploy_runtime_probe_cmd.stdout_lines
+        | default([])
+        | map('trim')
+        | reject('equalto', '')
+        | list
       }}
   changed_when: false
 
-- name: Compute marker-based skip decision
-  ansible.builtin.set_fact:
-    aap_deploy_marker_skip_allowed: >-
-      {{
-        (aap_deploy_skip_if_installed | bool)
-        and (aap_deploy_install_marker_precheck.stat.exists | default(false))
-        and (
-          not (aap_deploy_skip_if_installed_require_runtime | bool)
-          or (
-            (aap_deploy_runtime_probe_available | default(false))
-            and (
-              (aap_deploy_runtime_matching_containers | length)
-              >= (aap_deploy_skip_if_installed_runtime_min_matching_containers | int)
-            )
-          )
-        )
-      }}
-  changed_when: false
-
-- name: Detect pre-existing AAP deployment
+- name: Classify existing AAP install state
   ansible.builtin.set_fact:
     aap_deploy_existing_install_detected: >-
       {{
-        (aap_deploy_marker_skip_allowed | bool)
-        or (
-          aap_deploy_skip_if_runtime_active | bool
-          and (aap_deploy_runtime_probe_available | default(false))
-          and (
-            (aap_deploy_runtime_matching_containers | length)
-            >= (aap_deploy_runtime_min_matching_containers | int)
-          )
-        )
+        (aap_deploy_install_marker_precheck.stat.exists | default(false) | bool)
+        and (aap_deploy_runtime_containers | length > 0)
       }}
-    aap_deploy_existing_install_reasons: >-
+    aap_deploy_install_state_inconsistent: >-
       {{
-        []
-        + (
-          ['marker=' ~ aap_deploy_installed_marker_path]
-          if (aap_deploy_marker_skip_allowed | bool)
-          else []
-        )
-        + (
-          ['runtime=' ~ (aap_deploy_runtime_matching_containers | join(','))]
-          if (
-            aap_deploy_skip_if_runtime_active | bool
-            and (aap_deploy_runtime_probe_available | default(false))
-            and (
-              (aap_deploy_runtime_matching_containers | length)
-              >= (aap_deploy_runtime_min_matching_containers | int)
-            )
-          )
-          else []
-        )
+        (aap_deploy_install_marker_precheck.stat.exists | default(false) | bool)
+        != (aap_deploy_runtime_containers | length > 0)
       }}
   changed_when: false
 
-- name: Report install detection summary
-  ansible.builtin.debug:
-    msg: >-
-      existing_install_detected={{ aap_deploy_existing_install_detected | bool }};
-      marker_exists={{ aap_deploy_install_marker_precheck.stat.exists | default(false) }};
-      marker_skip_allowed={{ aap_deploy_marker_skip_allowed | default(false) }};
-      runtime_probe_rc={{ aap_deploy_runtime_probe_cmd.rc | default('n/a') }};
-      runtime_probe_all={{ aap_deploy_runtime_probe_all_containers | bool }};
-      runtime_match_count={{ aap_deploy_runtime_matching_containers | length }};
-      runtime_regex={{ aap_deploy_runtime_name_regex }};
-      runtime_match_threshold={{ aap_deploy_runtime_min_matching_containers | int }}.
-  changed_when: false
-
-- name: Report stale marker ignored
-  ansible.builtin.debug:
-    msg: >-
-      Marker file exists at {{ aap_deploy_installed_marker_path }} but runtime match threshold was not met.
-      Ignoring stale marker and continuing with installation workflow.
-  changed_when: false
-  when:
-    - aap_deploy_install_marker_precheck.stat.exists | default(false)
-    - not (aap_deploy_marker_skip_allowed | default(false))
+- name: Reject inconsistent AAP install state
+  ansible.builtin.assert:
+    that:
+      - not (aap_deploy_install_state_inconsistent | bool)
+    fail_msg: >-
+      Inconsistent AAP install state: marker_exists={{
+      aap_deploy_install_marker_precheck.stat.exists | default(false) | bool }},
+      runtime_container_count={{ aap_deploy_runtime_containers | length }}.
+      Run the official ansible.containerized_installer.uninstall playbook,
+      clean the incomplete installation explicitly, and then reinstall.
+    quiet: true
 
 - name: Report install workflow skip decision
   ansible.builtin.debug:
     msg: >-
-      Existing AAP deployment detected ({{ aap_deploy_existing_install_reasons | join('; ') }}).
+      Existing AAP deployment detected (marker and runtime agree).
       Skipping host prep, bundle handling, inventory render, and installer run.
       Verification tasks still execute when enabled.
   changed_when: false

--- a/roles/aap_deploy/tasks/10_host_prep.yml
+++ b/roles/aap_deploy/tasks/10_host_prep.yml
@@ -29,17 +29,6 @@
       shell={{ aap_deploy_install_user_shell }}.
     quiet: true
 
-- name: Resolve install user UID
-  ansible.builtin.command:
-    cmd: "id -u {{ aap_deploy_install_user }}"
-  register: aap_deploy_install_user_uid_result
-  changed_when: false
-
-- name: Record install user UID fact
-  ansible.builtin.set_fact:
-    aap_deploy_install_user_uid: "{{ aap_deploy_install_user_uid_result.stdout | trim }}"
-  changed_when: false
-
 - name: Ensure AAP installer temporary directory exists
   ansible.builtin.file:
     path: "{{ aap_deploy_install_tmp_dir }}"
@@ -51,26 +40,6 @@
   when:
     - aap_deploy_manage_install_tmp_dir | bool
     - aap_deploy_install_tmp_dir | trim | length > 0
-
-- name: Enable lingering for install user
-  ansible.builtin.command:
-    cmd: "loginctl enable-linger {{ aap_deploy_install_user }}"
-  args:
-    creates: "/var/lib/systemd/linger/{{ aap_deploy_install_user }}"
-
-- name: Ensure install user systemd manager is running
-  ansible.builtin.systemd:
-    name: "user@{{ aap_deploy_install_user_uid }}.service"
-    state: started
-  when: not ansible_check_mode
-
-- name: Report planned install user systemd manager startup
-  ansible.builtin.debug:
-    msg: >-
-      Check mode: systemd user manager user@{{ aap_deploy_install_user_uid }}.service
-      would be started for {{ aap_deploy_install_user }}.
-  changed_when: true
-  when: ansible_check_mode
 
 - name: Validate required AAP deploy commands are available
   ansible.builtin.command:

--- a/roles/aap_deploy/tasks/22_build_setup_inventory_vars.yml
+++ b/roles/aap_deploy/tasks/22_build_setup_inventory_vars.yml
@@ -72,3 +72,4 @@
         }}
     aap_deploy_setup_prep_inv_secrets: {}
   changed_when: false
+  no_log: true

--- a/roles/aap_deploy/tasks/40_install.yml
+++ b/roles/aap_deploy/tasks/40_install.yml
@@ -88,6 +88,7 @@
       become: true
       become_user: "{{ aap_deploy_install_user }}"
       environment: "{{ aap_deploy_installer_environment }}"
+      changed_when: true
       no_log: true
   rescue:
     - name: Collect AAP installer failure diagnostics

--- a/roles/aap_deploy/tasks/40_install.yml
+++ b/roles/aap_deploy/tasks/40_install.yml
@@ -52,6 +52,7 @@
         group: "{{ aap_deploy_install_user }}"
         mode: '0600'
         content: "{{ aap_deploy_setup_install_extra_vars | to_nice_yaml }}"
+      no_log: true
       when:
         - (aap_deploy_setup_install_extra_vars | length) > 0
 
@@ -78,82 +79,16 @@
           -e @{{ extra_vars_file.dest | quote }}
           {% endfor %}
 
-    - name: Start native AAP containerized installer
+    - name: Run native AAP containerized installer
       ansible.builtin.command:
         cmd: "{{ aap_deploy_installer_command }}"
         chdir: "{{ aap_setup_prep_setup_dir }}"
       async: "{{ aap_deploy_installer_async_timeout | int }}"
-      poll: 0
+      poll: "{{ aap_deploy_installer_async_delay | int }}"
       become: true
       become_user: "{{ aap_deploy_install_user }}"
       environment: "{{ aap_deploy_installer_environment }}"
-      register: aap_deploy_installer_async_job
-      changed_when: false
-
-    - name: Show native installer async job details
-      ansible.builtin.debug:
-        msg:
-          - "AAP installer async job id: {{ aap_deploy_installer_async_job.ansible_job_id }}"
-          - >-
-            Async result file:
-            {{ aap_deploy_install_user_home }}/.ansible_async/{{ aap_deploy_installer_async_job.ansible_job_id }}
-          - "Installer log directory: {{ aap_deploy_installer_log_dir }}"
-
-    - name: Write native installer async job id
-      ansible.builtin.copy:
-        dest: "{{ aap_deploy_installer_async_jid_path }}"
-        owner: "{{ aap_deploy_install_user }}"
-        group: "{{ aap_deploy_install_user }}"
-        mode: '0640'
-        content: "{{ aap_deploy_installer_async_job.ansible_job_id }}\n"
-
-    - name: Wait for native AAP containerized installer
-      ansible.builtin.async_status:
-        jid: "{{ aap_deploy_installer_async_job.ansible_job_id }}"
-      become: true
-      become_user: "{{ aap_deploy_install_user }}"
-      environment: "{{ aap_deploy_installer_environment }}"
-      register: aap_deploy_installer_async_status
-      until: >-
-        (aap_deploy_installer_async_status.finished | default(false) | bool)
-        or
-        (aap_deploy_installer_async_status.failed | default(false) | bool)
-      retries: "{{ aap_deploy_installer_async_retries | int }}"
-      delay: "{{ aap_deploy_installer_async_delay | int }}"
-      when: aap_deploy_installer_wait | bool
-
-    - name: Fail when native installer failed
-      ansible.builtin.fail:
-        msg: |-
-          Native AAP containerized installer failed.
-          Async job id: {{ aap_deploy_installer_async_job.ansible_job_id }}
-          Async result file:
-          {{ aap_deploy_install_user_home }}/.ansible_async/{{ aap_deploy_installer_async_job.ansible_job_id }}
-          Result message:
-          {{ aap_deploy_installer_async_status.msg | default('n/a', true) }}
-          rc: {{ aap_deploy_installer_async_status.rc | default('n/a', true) }}
-          stdout:
-          {{ aap_deploy_installer_async_status.stdout | default('') | trim }}
-          stderr:
-          {{ aap_deploy_installer_async_status.stderr | default('') | trim }}
-      when:
-        - aap_deploy_installer_wait | bool
-        - >-
-          (aap_deploy_installer_async_status.failed | default(false) | bool)
-          or
-          (
-            (aap_deploy_installer_async_status.finished | default(false) | bool)
-            and
-            ((aap_deploy_installer_async_status.rc | default(0) | int) != 0)
-          )
-
-    - name: Report native installer external polling handoff
-      ansible.builtin.debug:
-        msg: >-
-          Native AAP containerized installer started asynchronously.
-          External polling is required with jid file {{ aap_deploy_installer_async_jid_path }}.
-      when:
-        - not (aap_deploy_installer_wait | bool)
+      no_log: true
   rescue:
     - name: Collect AAP installer failure diagnostics
       ansible.builtin.include_tasks: 45_installer_diagnostics.yml
@@ -175,4 +110,3 @@
       installed=true
       setup_dir={{ aap_setup_prep_setup_dir | default(aap_deploy_setup_dir, true) }}
       playbook=ansible.containerized_installer.install
-  when: aap_deploy_installer_wait | bool

--- a/roles/aap_deploy/tasks/assert.yml
+++ b/roles/aap_deploy/tasks/assert.yml
@@ -34,16 +34,11 @@
       - aap_deploy_run_installer is boolean
       - aap_deploy_run_verify is boolean
       - aap_deploy_enforce_min_mem_check is boolean
-      - aap_deploy_skip_if_installed is boolean
-      - aap_deploy_skip_if_installed_require_runtime is boolean
-      - aap_deploy_skip_if_runtime_active is boolean
-      - aap_deploy_runtime_probe_all_containers is boolean
       - aap_deploy_force_unpack is boolean
       - aap_deploy_validate_archive_format is boolean
       - aap_deploy_setup_download_containerized is boolean
       - aap_deploy_setup_prepare_process_template is boolean
       - aap_deploy_setup_install_force is boolean
-      - aap_deploy_installer_wait is boolean
       - aap_deploy_install_environment is mapping
       - aap_deploy_debug_install_environment is boolean
       - aap_deploy_manage_install_tmp_dir is boolean
@@ -66,13 +61,10 @@
       - aap_deploy_setup_install_extra_vars is mapping
       - aap_deploy_setup_install_extra_vars_files is sequence
       - aap_deploy_setup_install_extra_vars_files is not string
-      - aap_deploy_installer_async_jid_path | trim | length > 0
-      - aap_deploy_installer_async_jid_path.startswith('/')
+      - aap_deploy_installer_async_timeout | int > 0
+      - aap_deploy_installer_async_delay | int > 0
       - aap_deploy_min_mem_mb | int > 0
       - aap_deploy_validate_archive_min_size_bytes | int >= 0
-      - aap_deploy_skip_if_installed_runtime_min_matching_containers | int > 0
-      - aap_deploy_runtime_name_regex | default('', true) | trim | length > 0
-      - aap_deploy_runtime_min_matching_containers | int > 0
       - aap_deploy_redis_mode in ['cluster', 'standalone']
       - aap_deploy_redis_hosts is sequence
       - aap_deploy_redis_hosts is not string

--- a/roles/aap_deploy/tasks/main.yml
+++ b/roles/aap_deploy/tasks/main.yml
@@ -104,10 +104,6 @@
     - aap_deploy_enabled | bool
     - aap_deploy_run_verify | bool
     - >-
-      aap_deploy_existing_install_detected | default(false)
-      or (aap_deploy_installer_wait | bool)
-      or not (aap_deploy_run_installer | bool)
-    - >-
       not ansible_check_mode
       or (aap_deploy_existing_install_detected | default(false))
   tags:

--- a/tests/unit/test_aap_install_state_contracts.py
+++ b/tests/unit/test_aap_install_state_contracts.py
@@ -99,11 +99,30 @@ class AapInstallStateContractsTests(unittest.TestCase):
                     self.assertNotIn(variable, content)
 
     def test_runtime_probe_fails_closed_and_runs_in_check_mode(self) -> None:
+        uid_probe = task_named(self.tasks, "Resolve install user UID for state guard")
+        manager = task_named(self.tasks, "Ensure install user systemd manager is running")
+        check_guard = task_named(self.tasks, "Require active install user runtime for check mode")
         probe = task_named(self.tasks, "List Podman containers for install user")
 
+        self.assertLess(self.tasks.index(uid_probe), self.tasks.index(probe))
+        self.assertLess(self.tasks.index(manager), self.tasks.index(probe))
+        self.assertLess(self.tasks.index(check_guard), self.tasks.index(probe))
+        self.assertIs(uid_probe["check_mode"], False)
+        self.assertNotIn("when", manager)
+        self.assertIn(
+            "ansible_check_mode",
+            check_guard["ansible.builtin.assert"]["that"][0],
+        )
         self.assertIs(probe["check_mode"], False)
         self.assertNotIn("failed_when", probe)
         self.assertNotIn("ignore_errors", probe)
+        self.assertEqual(
+            probe["environment"],
+            {
+                "XDG_RUNTIME_DIR": "/run/user/{{ aap_deploy_install_user_uid }}",
+                "DBUS_SESSION_BUS_ADDRESS": ("unix:path=/run/user/{{ aap_deploy_install_user_uid }}/bus"),
+            },
+        )
 
     def test_installer_always_waits_before_writing_marker(self) -> None:
         tasks = yaml.safe_load((ROOT / "roles/aap_deploy/tasks/40_install.yml").read_text(encoding="utf-8"))
@@ -112,6 +131,7 @@ class AapInstallStateContractsTests(unittest.TestCase):
         marker = task_named(tasks, "Write installation marker")
 
         self.assertNotEqual(installer["poll"], 0)
+        self.assertIs(installer["changed_when"], True)
         self.assertIs(installer["no_log"], True)
         self.assertNotIn("when", marker)
 

--- a/tests/unit/test_aap_install_state_contracts.py
+++ b/tests/unit/test_aap_install_state_contracts.py
@@ -1,0 +1,134 @@
+"""Regression tests for the strict AAP clean-install state guard."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jinja2 import Environment
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def task_named(tasks: list[dict[str, Any]], name: str) -> dict[str, Any]:
+    """Return one task by its exact name."""
+    return next(task for task in tasks if task.get("name") == name)
+
+
+class AapInstallStateContractsTests(unittest.TestCase):
+    """Require clean, installed, and inconsistent states to stay distinct."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tasks = yaml.safe_load(
+            (ROOT / "roles/aap_deploy/tasks/05_detect_existing_install.yml").read_text(encoding="utf-8")
+        )
+        classifier = task_named(cls.tasks, "Classify existing AAP install state")
+        cls.classifier = classifier["ansible.builtin.set_fact"]
+        cls.jinja = Environment(autoescape=True)
+        cls.jinja.filters["bool"] = bool
+
+    def render_state(self, marker_exists: bool, runtime_exists: bool) -> tuple[bool, bool]:
+        """Render the role's exact state expressions for one probe result."""
+        context = {
+            "aap_deploy_install_marker_precheck": {
+                "stat": {"exists": marker_exists},
+            },
+            "aap_deploy_runtime_containers": (["automation-controller"] if runtime_exists else []),
+        }
+
+        installed = yaml.safe_load(
+            self.jinja.from_string(self.classifier["aap_deploy_existing_install_detected"]).render(context)
+        )
+        inconsistent = yaml.safe_load(
+            self.jinja.from_string(self.classifier["aap_deploy_install_state_inconsistent"]).render(context)
+        )
+        return installed, inconsistent
+
+    def test_clean_state_proceeds(self) -> None:
+        self.assertEqual(self.render_state(False, False), (False, False))
+
+    def test_complete_install_is_detected(self) -> None:
+        self.assertEqual(self.render_state(True, True), (True, False))
+
+    def test_both_inconsistent_states_fail_closed(self) -> None:
+        for marker_exists, runtime_exists in ((True, False), (False, True)):
+            with self.subTest(
+                marker_exists=marker_exists,
+                runtime_exists=runtime_exists,
+            ):
+                self.assertEqual(
+                    self.render_state(marker_exists, runtime_exists),
+                    (False, True),
+                )
+
+        rejection = task_named(self.tasks, "Reject inconsistent AAP install state")
+        self.assertEqual(
+            rejection["ansible.builtin.assert"]["that"],
+            ["not (aap_deploy_install_state_inconsistent | bool)"],
+        )
+        self.assertIn(
+            "ansible.containerized_installer.uninstall",
+            rejection["ansible.builtin.assert"]["fail_msg"],
+        )
+
+    def test_obsolete_detection_modes_are_absent(self) -> None:
+        files = (
+            ROOT / "roles/aap_deploy/defaults/main.yml",
+            ROOT / "roles/aap_deploy/tasks/assert.yml",
+            ROOT / "roles/aap_deploy/tasks/05_detect_existing_install.yml",
+            ROOT / "roles/aap_deploy/README.md",
+        )
+        obsolete = (
+            "aap_deploy_skip_if_installed",
+            "aap_deploy_skip_if_runtime_active",
+            "aap_deploy_runtime_probe_all_containers",
+            "aap_deploy_runtime_min_matching_containers",
+            "aap_deploy_runtime_name_regex",
+            "aap_deploy_installer_wait",
+            "aap_deploy_installer_async_retries",
+            "aap_deploy_installer_async_jid_path",
+        )
+
+        for path in files:
+            content = path.read_text(encoding="utf-8")
+            for variable in obsolete:
+                with self.subTest(path=path, variable=variable):
+                    self.assertNotIn(variable, content)
+
+    def test_runtime_probe_fails_closed_and_runs_in_check_mode(self) -> None:
+        probe = task_named(self.tasks, "List Podman containers for install user")
+
+        self.assertIs(probe["check_mode"], False)
+        self.assertNotIn("failed_when", probe)
+        self.assertNotIn("ignore_errors", probe)
+
+    def test_installer_always_waits_before_writing_marker(self) -> None:
+        tasks = yaml.safe_load((ROOT / "roles/aap_deploy/tasks/40_install.yml").read_text(encoding="utf-8"))
+        install_block = task_named(tasks, "Run AAP containerized installer with diagnostics")
+        installer = task_named(install_block["block"], "Run native AAP containerized installer")
+        marker = task_named(tasks, "Write installation marker")
+
+        self.assertNotEqual(installer["poll"], 0)
+        self.assertIs(installer["no_log"], True)
+        self.assertNotIn("when", marker)
+
+        assertions = yaml.safe_load((ROOT / "roles/aap_deploy/tasks/assert.yml").read_text(encoding="utf-8"))
+        switch_validation = task_named(assertions, "Validate aap_deploy role switches and mode")
+        contracts = switch_validation["ansible.builtin.assert"]["that"]
+        self.assertIn("aap_deploy_installer_async_timeout | int > 0", contracts)
+        self.assertIn("aap_deploy_installer_async_delay | int > 0", contracts)
+
+    def test_secret_inventory_fact_is_not_logged(self) -> None:
+        tasks = yaml.safe_load(
+            (ROOT / "roles/aap_deploy/tasks/22_build_setup_inventory_vars.yml").read_text(encoding="utf-8")
+        )
+        secret_fact = task_named(tasks, "Build setup inventory variables")
+
+        self.assertIs(secret_fact["no_log"], True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- replace configurable marker/runtime heuristics with a strict three-state guard
- proceed only when the dedicated install user owns no Podman containers and no success marker exists
- skip installer work only when both the success marker and install-user containers exist
- fail closed for every inconsistent or unprobeable state; never repair or delete automatically
- remove detached installer handoff and wait for the official installer before writing the marker
- suppress setup inventory and installer output that can contain credentials

## Why

Continuing over a partial AAP installation caused misleading Hub, TLS, and registry failures. A clean install must use the official Red Hat installer from a known-empty state. Recovery and destructive cleanup stay outside `aap_deploy`.

## Release impact

This deliberately removes unsafe public switches and detached handoff behavior. The repository release resolver therefore selects `3.0.0`.

## Validation

- 194 repository unit tests passed
- 7 focused strict-state tests passed
- `aap-deploy-basic` Molecule syntax/converge/idempotence/verify passed
- production-profile ansible-lint passed
- collection smoke passed
- Galaxy verification passed
- changelog policy and `git diff --check` passed
- independent final review: no remaining findings
