### PR TITLE
ci: use Docker for hosted-runner lint containers

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -77,6 +77,7 @@ jobs:
           BASE_SHA: ${{ env.COMPARE_BASE_SHA }}
           CI: "true"
           HEAD_SHA: ${{ env.SOURCE_SHA }}
+          WUNDER_CONTAINER_ENGINE: docker
           LABELS_JSON: >-
             ${{ github.event_name == 'pull_request' &&
             toJson(github.event.pull_request.labels.*.name) || '[]' }}


### PR DESCRIPTION
## What changed

- force the repository static pre-commit container hooks to use Docker on GitHub-hosted runners

## Why

GitHub runner image `ubuntu-24.04 20260726.254.1` exposes Podman backed by an incompatible `crun`, causing actionlint and Renovate validation to fail with `crun: unknown version specified` before collection tests can run. GitHub-hosted runners provide a supported Docker daemon.

This is a CI-only change. Collection content and AAP deployment behavior are unchanged.

## Validation

- `pre-commit run github-actions-lint --files .github/workflows/collection-ci.yml`
- YAML safe-load
- `git diff --check`

The Docker-specific execution path is validated by this PR's GitHub Actions run.
