### PR TITLE
fix(aap): use public Gateway URL and repair v3.0.0 release

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -77,6 +77,7 @@ jobs:
           BASE_SHA: ${{ env.COMPARE_BASE_SHA }}
           CI: "true"
           HEAD_SHA: ${{ env.SOURCE_SHA }}
+          WUNDER_CONTAINER_ENGINE: docker
           LABELS_JSON: >-
             ${{ github.event_name == 'pull_request' &&
             toJson(github.event.pull_request.labels.*.name) || '[]' }}

--- a/changelogs/fragments/aap-deploy-public-gateway-default.yml
+++ b/changelogs/fragments/aap-deploy-public-gateway-default.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Default the AAP containerized installer ``gateway_main_url`` to the public
+    Envoy HTTPS endpoint so Hub readiness and image seeding do not target the
+    internal Gateway Nginx listener.

--- a/molecule/aap-deploy-basic/converge.yml
+++ b/molecule/aap-deploy-basic/converge.yml
@@ -10,7 +10,7 @@
     aap_deploy_molecule_fixture_dir: >-
       {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/prepared-installer
     aap_setup_prep_setup_dir: "{{ aap_deploy_molecule_fixture_dir }}"
-    aap_deploy_gateway_main_url: https://aap.example.test
+    aap_fqdn: aap.example.test
     aap_deploy_molecule_vendor_files:
       - collections/ansible_collections/ansible/containerized_installer/playbooks/install.yml
       - collections/ansible_collections/ansible/containerized_installer/roles/automationhub/tasks/upload_images.yml

--- a/roles/aap_deploy/README.md
+++ b/roles/aap_deploy/README.md
@@ -58,8 +58,8 @@ Key variables:
 - `aap_deploy_automationmetrics_secret_key`
 - `aap_deploy_automationmetrics_resource_server`
 - `aap_deploy_setup_prep_inv_nodes_extra`
-- `aap_deploy_gateway_main_url` (optional public installer `gateway_main_url`;
-  use the Envoy endpoint, normally `https://<aap-fqdn>` on port 443)
+- `aap_deploy_gateway_main_url` (public installer `gateway_main_url`; defaults
+  to the Envoy endpoint `https://<aap-fqdn>` on port 443)
 - `aap_deploy_gateway_nginx_http_port` / `aap_deploy_gateway_nginx_https_port`
 - `aap_deploy_envoy_http_port` / `aap_deploy_envoy_https_port`
 - `aap_deploy_postgresql_admin_username` (default: `postgres`)

--- a/roles/aap_deploy/defaults/main.yml
+++ b/roles/aap_deploy/defaults/main.yml
@@ -332,8 +332,9 @@ aap_deploy_enterprise_inventory_hostvars_extra: ""
 aap_deploy_setup_prep_inv_nodes_extra: {}
 
 # Gateway public URL and listener ports for the containerized installer
-# inventory. Leave aap_deploy_gateway_main_url empty to use upstream defaults.
-aap_deploy_gateway_main_url: ""
+# inventory. Post-install clients must use the public Envoy endpoint rather
+# than the internal Gateway Nginx listener.
+aap_deploy_gateway_main_url: "https://{{ aap_fqdn }}"
 aap_deploy_gateway_nginx_http_port: 8083
 aap_deploy_gateway_nginx_https_port: 8446
 aap_deploy_gateway_nginx_disable_https: false

--- a/roles/aap_deploy/tasks/22_build_setup_inventory_vars.yml
+++ b/roles/aap_deploy/tasks/22_build_setup_inventory_vars.yml
@@ -47,6 +47,7 @@
             'automationmetrics_resource_server': "'" ~ aap_deploy_automationmetrics_resource_server ~ "'",
             'pg_admin_password': "'" ~ aap_deploy_postgresql_admin_password_effective ~ "'",
             'redis_mode': "'" ~ aap_deploy_redis_mode ~ "'",
+            'gateway_main_url': "'" ~ aap_deploy_gateway_main_url ~ "'",
             'gateway_nginx_http_port': (aap_deploy_gateway_nginx_http_port | int),
             'gateway_nginx_https_port': (aap_deploy_gateway_nginx_https_port | int),
             'gateway_nginx_disable_https': (aap_deploy_gateway_nginx_disable_https | bool),
@@ -57,14 +58,6 @@
             'hub_seed_collections': (aap_deploy_hub_seed_collections | bool),
             'bundle_dir': aap_deploy_bundle_dir_effective
           }
-          | combine(
-              (
-                {'gateway_main_url': "'" ~ aap_deploy_gateway_main_url ~ "'"}
-                if (aap_deploy_gateway_main_url | trim | length > 0)
-                else {}
-              ),
-              recursive=true
-            )
           | combine(
               aap_deploy_tls_inventory_vars | default({}, true),
               recursive=true

--- a/tests/unit/test_aap_gateway_contracts.py
+++ b/tests/unit/test_aap_gateway_contracts.py
@@ -55,10 +55,15 @@ class AapGatewayContractsTests(unittest.TestCase):
         self.assertNotIn("settings.yaml.j2", inventory_vars)
 
     def test_local_execution_uses_public_envoy_url(self) -> None:
+        defaults = (ROOT / "roles/aap_deploy/defaults/main.yml").read_text(encoding="utf-8")
         template = (
             ROOT / "roles/aap_local_execution/templates/aap-local/inventories/group_vars/aaps/aap.yml.j2"
         ).read_text(encoding="utf-8")
 
+        self.assertIn(
+            'aap_deploy_gateway_main_url: "https://{{ aap_fqdn }}"',
+            defaults,
+        )
         self.assertIn(
             'aap_deploy_gateway_main_url: "https://{{ aap_fqdn }}"',
             template,


### PR DESCRIPTION
## What changed

- force static pre-commit container hooks to use Docker on GitHub-hosted runners
- default the AAP containerized installer `gateway_main_url` to the public
  Envoy HTTPS endpoint
- always render the supported upstream `gateway_main_url` inventory variable
- cover the default without a customer inventory override

## Root cause

Without an explicit `gateway_main_url`, the upstream installer derived
post-install Hub readiness from the internal Gateway Nginx listener on port
8446. The public `/pulp/...` route is served through Envoy on HTTPS port 443,
so readiness returned HTTP 404.

The hosted runner image also exposed Podman with an incompatible `crun`,
preventing static validation before collection tests could run.

## Impact

Clean AAP installs use `https://<aap_fqdn>` for public Gateway routing without
patching Red Hat installer content or requiring customer-specific component
URLs.

## Validation

- AAP gateway contract unit tests: 7 passed
- ansible-lint container hook: passed
- Molecule `aap-deploy-basic`: syntax, converge, idempotence, and verify passed
- upstream installer fixtures remain byte-identical
- `git diff --check`

## Release settings

- GitHub release creation: `true`
- Galaxy publishing: `true`
