### PR TITLE
fix(aap): complete clean AAP deployment and CaC contract

### DIFF
--- a/changelogs/fragments/aap-cac-complete-example.yml
+++ b/changelogs/fragments/aap-cac-complete-example.yml
@@ -1,0 +1,10 @@
+---
+minor_changes:
+  - >-
+    Add a complete, populated AAP configuration-as-code inventory example
+    covering every resource family dispatched by the aap_cac role.
+bugfixes:
+  - >-
+    Pass the canonical AAP hostname, username, password, and certificate
+    validation settings explicitly to Gateway and Private Automation Hub
+    configuration tasksets.

--- a/changelogs/fragments/aap-cac-gateway-from-fqdn.yml
+++ b/changelogs/fragments/aap-cac-gateway-from-fqdn.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - >-
+    Default aap_cac_gateway_hostname to the public HTTPS endpoint derived from
+    aap_fqdn so inventories do not need to repeat the AAP gateway hostname.

--- a/changelogs/fragments/aap-cac-organization-list-default.yml
+++ b/changelogs/fragments/aap-cac-organization-list-default.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - >-
+    Keep the default AAP CaC organization collection as an empty list and
+    validate organization input types before taskset execution. This prevents
+    an unset organization inventory from reaching an Ansible loop as an empty
+    string.

--- a/changelogs/fragments/aap-cac-shared-auth.yml
+++ b/changelogs/fragments/aap-cac-shared-auth.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - >-
+    Resolve AAP configuration-as-code authentication from the canonical shared
+    Gateway admin password input instead of requiring the legacy
+    ``aap_username`` and ``aap_password`` inventory aliases. This also makes
+    CaC-only reruns work after an existing AAP installation.

--- a/changelogs/fragments/aap-cac-validate-certs-recursion.yml
+++ b/changelogs/fragments/aap-cac-validate-certs-recursion.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Make the AAP CaC certificate-validation default a literal boolean so nested
+    configuration roles cannot create a recursive variable alias with
+    ``aap_validate_certs``.

--- a/changelogs/fragments/aap-tls-target-ca-trust.yml
+++ b/changelogs/fragments/aap-tls-target-ca-trust.yml
@@ -1,0 +1,7 @@
+---
+bugfixes:
+  - >-
+    Install generated AAP self-signed CA certificates in the managed AAP
+    host's system trust store instead of the controller-side generation host,
+    and enable that trust installation by default. This allows verified
+    Gateway API requests from subsequent configuration-as-code runs.

--- a/docs/testing/role-coverage.md
+++ b/docs/testing/role-coverage.md
@@ -1665,7 +1665,7 @@ promotion input only and never satisfy the release-required supported-target mat
 | Scenario | Profile | State | Implementation | Reported roles | Exercised dependencies | Test application mode | Application claims | Application policy rationale | JUnit | Allure | Evidence |
 |---|---|---|---|---|---|---|---|---|---:|---:|---:|
 | aap-basic | Tiny | experimental | partial | aap | — | not-applicable | — | Scenario exercises controller-side role behavior without deploying an independently versioned application. | False | False | False |
-| aap-cac-basic | Tiny | experimental | stub | aap_cac | — | not-applicable | — | Scenario is a role contract or assertion stub and does not deploy an independently versioned application. | False | False | False |
+| aap-cac-basic | Tiny | experimental | partial | aap_cac | — | not-applicable | — | Scenario executes the AAP CaC authentication contract and shared password resolution without deploying an independently versioned application. | False | False | False |
 | aap-deploy-basic | Tiny | experimental | stub | aap_deploy | — | not-applicable | — | Scenario is a role contract or assertion stub and does not deploy an independently versioned application. | False | False | False |
 | aap-destroy-basic | Tiny | experimental | stub | aap_destroy | — | not-applicable | — | Scenario is a role contract or assertion stub and does not deploy an independently versioned application. | False | False | False |
 | aap-host-prepare-basic | Tiny | experimental | partial | aap_host_prepare | — | not-applicable | — | Scenario exercises host-preparation role contracts without deploying an independently versioned application. | False | False | False |

--- a/docs/testing/role-coverage.md
+++ b/docs/testing/role-coverage.md
@@ -7,13 +7,13 @@ Authoritative source: [`meta/role-coverage.yml`](../../meta/role-coverage.yml).
 ## Summary
 
 - Roles: 96
-- Root Molecule scenarios: 57
+- Root Molecule scenarios: 58
 - Production roles: 2
 - Experimental roles: 93
 - Deprecated roles: 1
 - Runtime-container application policies: 6
 - Declared-evidence application policies: 5
-- Reviewed not-applicable application policies: 46
+- Reviewed not-applicable application policies: 47
 
 Profile states are dispositions, not inferred test results. Only `supported` profiles backed by real,
 evidence-producing scenarios are release-eligible.
@@ -36,7 +36,7 @@ promotion input only and never satisfy the release-required supported-target mat
 | aap_preflight | aap | validator | experimental | — | rhel-9, rhel-10 | experimental | blocked-external-license | not-applicable | parent_component_validation | — | Red Hat Ansible Automation Platform entitlement and installer artifacts, Red Hat subscription-backed RHEL test targets | Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix. | aap-preflight-basic |
 | aap_prepare | aap | infrastructure | experimental | — | rhel-9, rhel-10 | experimental | blocked-external-license | not-applicable | parent_component_artifact_staging | artifacts | Red Hat Ansible Automation Platform entitlement and installer artifacts, Red Hat subscription-backed RHEL test targets | Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix. | aap-prepare-basic |
 | aap_secrets | aap | secret_management | experimental | — | rhel-9, rhel-10 | experimental | blocked-external-license | not-applicable | parent_component_secret_resolution | — | Red Hat Ansible Automation Platform entitlement and installer artifacts, Red Hat subscription-backed RHEL test targets | Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix. | — |
-| aap_tls | aap | infrastructure | experimental | — | rhel-9, rhel-10 | experimental | blocked-external-license | not-applicable | parent_component_tls_bootstrap | — | Red Hat Ansible Automation Platform entitlement and installer artifacts, Red Hat subscription-backed RHEL test targets | Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix. | — |
+| aap_tls | aap | infrastructure | experimental | — | rhel-9, rhel-10 | experimental | blocked-external-license | not-applicable | parent_component_tls_bootstrap | — | Red Hat Ansible Automation Platform entitlement and installer artifacts, Red Hat subscription-backed RHEL test targets | Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix. | aap-tls-basic |
 | alertmanager_deploy | observability | monitoring_service | experimental | — | ubuntu-22.04, ubuntu-24.04, rhel-9 | experimental | experimental | experimental | deliver_and_verify_a_real_alert | lit.foundational.podman_systemd | — | Current Incus scenario verifies service and port state, not alert delivery. | atlas-observability-incus_heavy |
 | alloy_deploy | observability | agent | experimental | — | ubuntu-22.04, ubuntu-24.04, rhel-9 | experimental | experimental | experimental | generate_deliver_and_query_source_data | lit.foundational.kubeplay, lit.foundational.podman_systemd, loki_deploy | — | Current Incus scenario does not query delivered data from Loki. | atlas-observability-incus_heavy, wunderbox-monitoring-logging-basic |
 | artifacts | artifacts | infrastructure | experimental | — | rhel-9, ubuntu-24.04 | experimental | experimental | experimental | stage_verify_and_consume_a_real_artifact | — | — | Current scenario covers only a local source, not URL or managed-host sources. | artifacts-basic |
@@ -325,7 +325,7 @@ promotion input only and never satisfy the release-required supported-target mat
 - Role dependencies: —; exercised scenario dependencies: —.
 - External dependencies/blockers: Red Hat Ansible Automation Platform entitlement and installer artifacts, Red Hat subscription-backed RHEL test targets.
 - Required-secret policy: Protected non-production credentials or licensed inputs are required for the declared external dependencies.
-- Local execution: —; CI matrix execution: not mandatory until a profile is supported, real, and production-eligible.
+- Local execution: `molecule test -s aap-tls-basic`; CI matrix execution: not mandatory until a profile is supported, real, and production-eligible.
 - Candidate-target execution: no runnable candidate matrix is currently declared.
 - Reports/evidence: —. Failed mandatory runs remain failures or infrastructure errors.
 - Backup/restore and upgrade behavior are support claims only when the acceptance surface or an executed scenario proves them.
@@ -1673,6 +1673,7 @@ promotion input only and never satisfy the release-required supported-target mat
 | aap-ops-basic | Tiny | experimental | stub | aap_ops | — | not-applicable | — | Scenario is a role contract or assertion stub and does not deploy an independently versioned application. | False | False | False |
 | aap-preflight-basic | Tiny | experimental | stub | aap_preflight | — | not-applicable | — | Scenario is a role contract or assertion stub and does not deploy an independently versioned application. | False | False | False |
 | aap-prepare-basic | Tiny | experimental | stub | aap_prepare | — | not-applicable | — | Scenario is a role contract or assertion stub and does not deploy an independently versioned application. | False | False | False |
+| aap-tls-basic | Tiny | experimental | partial | aap_tls | — | not-applicable | — | Scenario generates an ephemeral AAP CA and verifies transfer to the managed host trust anchor without deploying AAP. | False | False | False |
 | artifacts-basic | Tiny | experimental | partial | artifacts | — | not-applicable | — | Scenario exercises controller-side role behavior without deploying an independently versioned application. | False | False | False |
 | atlas-observability-incus_heavy | Heavy | experimental | partial | alertmanager_deploy, alloy_deploy, checkmk_deploy, grafana_deploy, loki_deploy, prometheus_deploy, rsyslog_deploy | — | runtime-container | — | Scenario exercises real service containers and must report immutable runtime digests when enabled. | False | False | False |
 | cloudflare-warp-basic | Tiny | experimental | partial | cloudflare_warp | — | not-applicable | — | Scenario is a role contract or assertion stub and does not deploy an independently versioned application. | False | False | False |

--- a/examples/aap-cac.yml
+++ b/examples/aap-cac.yml
@@ -13,7 +13,7 @@
 # lit.supplementary.aap_prepare at the path below.
 
 # Role connection and authentication contract.
-aap_cac_gateway_hostname: "https://aap.demo.example.invalid"
+aap_fqdn: "aap.demo.example.invalid"
 aap_cac_gateway_username: "admin"
 aap_cac_gateway_password: "{{ vault_demo_aap_admin_password }}"
 aap_cac_gateway_validate_certs: true
@@ -274,7 +274,8 @@ controller_execution_environments:
   - name: "Demo Execution Environment"
     description: "Execution environment managed through CaC"
     organization: "Demo Organization"
-    image: "quay.io/ansible/awx-ee:latest"
+    image: >-
+      quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2@sha256:58d5d45f7ea7405394edb00d4a77bf3e5d770532377fba6d80e8f641d27576b0
     pull: "missing"
     state: "present"
 

--- a/examples/aap-cac.yml
+++ b/examples/aap-cac.yml
@@ -1,0 +1,518 @@
+---
+# Complete AAP configuration-as-code example for lit.supplementary.aap_cac.
+#
+# WARNING:
+# This file demonstrates every resource family currently dispatched by the
+# role. It is intentionally not a production inventory. Review names, URLs,
+# IDs, schedules, credentials, and the operational job/filetree/EE-builder
+# sections before applying it. Job launch/cancel, repository sync, project
+# update, filetree export/import, and EE builder resources perform actions.
+#
+# Keep the referenced vault_* variables in an encrypted Ansible Vault file.
+# The subscription manifest must be a genuine Red Hat manifest ZIP staged by
+# lit.supplementary.aap_prepare at the path below.
+
+# Role connection and authentication contract.
+aap_cac_gateway_hostname: "https://aap.demo.example.invalid"
+aap_cac_gateway_username: "admin"
+aap_cac_gateway_password: "{{ vault_demo_aap_admin_password }}"
+aap_cac_gateway_validate_certs: true
+aap_cac_token_description: "aap-cac-complete-demo"
+aap_cac_token_request_retries: 10
+aap_cac_token_request_delay: 3
+aap_cac_gateway_ready_check: true
+aap_cac_gateway_ready_path: "/api/gateway/v1/ping/"
+aap_cac_gateway_ready_status_codes:
+  - 200
+  - 401
+  - 403
+aap_cac_gateway_ready_retries: 60
+aap_cac_gateway_ready_delay: 5
+aap_cac_controller_ready_check: true
+aap_cac_controller_ready_path: "/api/controller/v2/ping/"
+aap_cac_controller_ready_status_codes:
+  - 200
+  - 401
+  - 403
+aap_cac_controller_ready_retries: 120
+aap_cac_controller_ready_delay: 5
+
+# Controller subscription manifest activation.
+aap_cac_controller_license_required: true
+aap_cac_controller_license_state: "present"
+aap_cac_controller_license_force: false
+aap_cac_controller_license_secure_logging: true
+aap_cac_controller_license_manifest_remote_src: >-
+  {{
+    aap_prepare_manifest_dest_effective
+    | default(
+        aap_prepare_manifest_dest
+        | default('/opt/aap/manifest.zip', true),
+        true
+      )
+  }}
+
+# Gateway settings.
+gateway_settings:
+  password_min_length: 12
+  password_min_digits: 1
+  password_min_upper: 1
+  password_min_special: 1
+  allow_admins_to_set_insecure: false
+
+# Gateway and Controller organizations.
+aap_cac_controller_organizations:
+  - name: "Demo Organization"
+    description: "Organization managed by the complete CaC example"
+    state: "present"
+
+# Gateway users.
+aap_user_accounts:
+  - username: "demo.operator"
+    password: "{{ vault_demo_operator_password }}"
+    email: "demo.operator@example.invalid"
+    first_name: "Demo"
+    last_name: "Operator"
+    is_superuser: false
+    is_platform_auditor: false
+    update_secrets: false
+    state: "present"
+
+# Gateway and Controller teams.
+aap_teams:
+  - name: "Demo Automation Team"
+    description: "Team managed by the complete CaC example"
+    organization: "Demo Organization"
+    state: "present"
+
+# Gateway role assignment.
+gateway_role_user_assignments:
+  - role_definition: "Organization Admin"
+    user: "demo.operator"
+    object_ids:
+      - "Demo Organization"
+    state: "present"
+
+# Controller settings.
+controller_settings:
+  - name: "AWX_ISOLATION_SHOW_PATHS"
+    value:
+      - "/tmp"
+  - name: "AWX_TASK_ENV"
+    value:
+      DEMO_CAC_ENVIRONMENT: "complete-example"
+
+# Controller custom credential type.
+controller_credential_types:
+  - name: "Demo API Credential"
+    description: "Example API username and token"
+    kind: "cloud"
+    inputs:
+      fields:
+        - id: "demo_username"
+          type: "string"
+          label: "Demo username"
+        - id: "demo_token"
+          type: "string"
+          label: "Demo token"
+          secret: true
+      required:
+        - "demo_username"
+        - "demo_token"
+    injectors:
+      env:
+        DEMO_API_USERNAME: "{% raw %}{{ demo_username }}{% endraw %}"
+        DEMO_API_TOKEN: "{% raw %}{{ demo_token }}{% endraw %}"
+    state: "present"
+
+# Controller label.
+controller_labels:
+  - name: "demo"
+    organization: "Demo Organization"
+    state: "present"
+
+# Controller credentials.
+controller_credentials:
+  - name: "Demo API Credential"
+    description: "Credential populated from encrypted inventory values"
+    organization: "Demo Organization"
+    credential_type: "Demo API Credential"
+    inputs:
+      demo_username: "demo-api-user"
+      demo_token: "{{ vault_demo_api_token }}"
+    state: "present"
+  - name: "Demo Machine Credential"
+    description: "Machine credential for demo inventory hosts"
+    organization: "Demo Organization"
+    credential_type: "Machine"
+    inputs:
+      username: "demo-automation"
+      password: "{{ vault_demo_machine_password }}"
+      become_method: "sudo"
+      become_username: "root"
+      become_password: "{{ vault_demo_become_password }}"
+    state: "present"
+  - name: "Demo Source Control Credential"
+    description: "SCM credential used by the demo project"
+    organization: "Demo Organization"
+    credential_type: "Source Control"
+    inputs:
+      username: "demo-scm-user"
+      password: "{{ vault_demo_scm_token }}"
+    state: "present"
+  - name: "Demo External Secret Lookup"
+    description: "External lookup credential used by input source demo"
+    organization: "Demo Organization"
+    credential_type: "CyberArk Central Credential Provider Lookup"
+    inputs:
+      url: "https://secrets.demo.example.invalid"
+      app_id: "demo-aap-cac"
+      client_key: "{{ vault_demo_external_lookup_client_key }}"
+    state: "present"
+
+# Controller credential input source.
+controller_credential_input_sources:
+  - source_credential: "Demo External Secret Lookup"
+    target_credential: "Demo Source Control Credential"
+    input_field_name: "password"
+    metadata:
+      object_query: "Safe=DEMO_SAFE;Object=DEMO_SCM_TOKEN"
+      object_query_format: "Exact"
+    description: "Populate the demo SCM token from an external secret backend"
+    state: "present"
+
+# Controller project.
+controller_projects:
+  - name: "Demo CaC Project"
+    description: "Public demo project managed through CaC"
+    organization: "Demo Organization"
+    scm_type: "git"
+    scm_url: "https://github.com/ansible/ansible-examples.git"
+    scm_branch: "master"
+    scm_clean: true
+    credential: "Demo Source Control Credential"
+    update_project: false
+    wait: true
+    state: "present"
+
+# Controller instance group.
+controller_instance_groups:
+  - name: "Demo Instance Group"
+    policy_instance_percentage: 100
+    policy_instance_minimum: 0
+    max_concurrent_jobs: 10
+    max_forks: 50
+    state: "present"
+
+# Controller inventory and inventory source.
+controller_inventories:
+  - name: "Demo Inventory"
+    description: "Inventory managed by the complete CaC example"
+    organization: "Demo Organization"
+    variables:
+      demo_environment: "example"
+      ansible_connection: "local"
+    state: "present"
+
+controller_inventory_sources:
+  - name: "Demo SCM Inventory Source"
+    description: "Inventory source from the demo project"
+    inventory: "Demo Inventory"
+    organization: "Demo Organization"
+    source: "scm"
+    source_project: "Demo CaC Project"
+    source_path: "lamp_haproxy/hosts"
+    overwrite: true
+    overwrite_vars: true
+    update_on_launch: false
+    update_project: false
+    wait: true
+    state: "present"
+
+# Controller hosts, groups, bulk hosts, and execution instance.
+controller_hosts:
+  - name: "demo-host.example.invalid"
+    description: "Host managed by the complete CaC example"
+    inventory: "Demo Inventory"
+    variables:
+      ansible_host: "192.0.2.10"
+      demo_role: "application"
+    enabled: true
+    state: "present"
+
+controller_groups:
+  - name: "demo_application"
+    description: "Demo application group"
+    inventory: "Demo Inventory"
+    hosts:
+      - "demo-host.example.invalid"
+    variables:
+      demo_tier: "application"
+    state: "present"
+
+controller_bulk_hosts:
+  - inventory: "Demo Inventory"
+    hosts:
+      - name: "demo-bulk-host.example.invalid"
+        description: "Host created by bulk_host_create"
+        enabled: true
+        variables:
+          ansible_host: "192.0.2.11"
+          demo_role: "bulk"
+
+controller_instances:
+  - hostname: "demo-execution-node.example.invalid"
+    capacity_adjustment: 1.0
+    listener_port: 27199
+    enabled: true
+    managed_by_policy: true
+    node_type: "execution"
+    state: "present"
+
+# Controller execution environment.
+controller_execution_environments:
+  - name: "Demo Execution Environment"
+    description: "Execution environment managed through CaC"
+    organization: "Demo Organization"
+    image: "quay.io/ansible/awx-ee:latest"
+    pull: "missing"
+    state: "present"
+
+# Controller job template and workflow template.
+controller_templates:
+  - name: "Demo CaC Job Template"
+    description: "Job template managed by the complete CaC example"
+    organization: "Demo Organization"
+    job_type: "run"
+    inventory: "Demo Inventory"
+    project: "Demo CaC Project"
+    playbook: "lamp_haproxy/site.yml"
+    credentials:
+      - "Demo Machine Credential"
+    execution_environment: "Demo Execution Environment"
+    labels:
+      - "demo"
+    verbosity: 1
+    ask_limit_on_launch: true
+    ask_variables_on_launch: true
+    extra_vars:
+      demo_message: "Hello from AAP CaC"
+    state: "present"
+
+controller_workflows:
+  - name: "Demo CaC Workflow"
+    description: "Workflow managed by the complete CaC example"
+    organization: "Demo Organization"
+    allow_simultaneous: false
+    ask_variables_on_launch: true
+    extra_vars:
+      demo_workflow_value: "complete-example"
+    simplified_workflow_nodes:
+      - identifier: "run-demo-job"
+        unified_job_template: "Demo CaC Job Template"
+        all_parents_must_converge: false
+    state: "present"
+
+# Controller OAuth application.
+controller_applications:
+  - name: "Demo CaC Application"
+    description: "OAuth application managed by the complete CaC example"
+    organization: "Demo Organization"
+    authorization_grant_type: "authorization-code"
+    client_type: "confidential"
+    redirect_uris:
+      - "https://client.demo.example.invalid/oauth/callback"
+    skip_authorization: false
+    state: "present"
+
+# Controller notification template.
+controller_notifications:
+  - name: "Demo Email Notification"
+    description: "Email notification managed by the complete CaC example"
+    organization: "Demo Organization"
+    notification_type: "email"
+    notification_configuration:
+      host: "smtp.demo.example.invalid"
+      port: 587
+      username: "demo-smtp-user"
+      password: "{{ vault_demo_smtp_password }}"
+      sender: "aap@example.invalid"
+      recipients:
+        - "aap-operators@example.invalid"
+      use_tls: true
+      use_ssl: false
+    state: "present"
+
+# Controller RBAC role.
+controller_roles:
+  - team: "Demo Automation Team"
+    job_template: "Demo CaC Job Template"
+    roles:
+      - "read"
+      - "execute"
+    state: "present"
+
+# Controller schedule.
+controller_schedules:
+  - name: "Demo Daily Schedule"
+    description: "Daily demonstration schedule"
+    unified_job_template: "Demo CaC Job Template"
+    rrule: "DTSTART:20300101T010000Z RRULE:FREQ=DAILY;INTERVAL=1"
+    enabled: false
+    extra_data:
+      demo_scheduled_value: "complete-example"
+    state: "present"
+
+# Dispatcher, global operation translation, and object-diff resources.
+controller_configuration_dispatcher_roles:
+  - role: "settings"
+    var: "controller_settings"
+    tags: "settings"
+  - role: "organizations"
+    var: "controller_organizations"
+    tags: "organizations"
+
+operation_translate:
+  present:
+    verb: "Create or update"
+    action: "creation or update"
+  absent:
+    verb: "Remove"
+    action: "deletion"
+
+controller_configuration_object_diff_tasks:
+  - name: "projects"
+    var: "controller_projects"
+    tags: "projects"
+  - name: "job_templates"
+    var: "controller_templates"
+    tags: "job_templates"
+
+# Private Automation Hub collection remote, repository, sync, and group role.
+aap_cac_hub_collection_remotes:
+  - name: "demo-community"
+    url: "https://galaxy.ansible.com/api/"
+    policy: "on_demand"
+    requirements:
+      - name: "community.general"
+        version: ">=10.0.0"
+    tls_validation: true
+    download_concurrency: 4
+    rate_limit: 4
+    signed_only: false
+    sync_dependencies: true
+    state: "present"
+
+aap_cac_hub_collection_repositories:
+  - name: "demo-community"
+    description: "Demo repository connected to Galaxy"
+    retain_repo_versions: 3
+    pulp_labels:
+      pipeline: "demo"
+      hide_from_search: false
+    distribution:
+      name: "demo-community"
+      state: "present"
+    private: false
+    remote: "demo-community"
+    update_repo: true
+    wait: true
+    interval: 2
+    timeout: 600
+    state: "present"
+
+aap_cac_hub_group_roles:
+  - groups:
+      - "Demo Automation Team"
+    role_list:
+      - roles:
+          - "galaxy.ansible_repository_owner"
+        targets:
+          collection_repositories:
+            - "demo-community"
+
+# Filetree create and read resources.
+output_path: "/tmp/aap-cac-demo-export"
+input_tag:
+  - "all"
+dir_orgs_vars: "/tmp/aap-cac-demo-input"
+orgs:
+  - "Demo Organization"
+
+# Operational resources below execute or cancel jobs when the complete file is
+# applied. Replace IDs and review all objects before enabling them in a target.
+controller_ad_hoc_commands:
+  - job_type: "run"
+    inventory: "Demo Inventory"
+    credential: "Demo Machine Credential"
+    module_name: "ansible.builtin.ping"
+    limit: "demo-host.example.invalid"
+    wait: true
+
+controller_ad_hoc_commands_cancel:
+  - id: 900001
+    fail_if_not_running: false
+    interval: 1
+    timeout: 10
+
+controller_bulk_launch_jobs:
+  - name: "Demo Bulk Job Launch"
+    organization: "Demo Organization"
+    jobs:
+      - unified_job_template: "Demo CaC Job Template"
+
+controller_launch_jobs:
+  - name: "Demo CaC Job Template"
+    limit: "demo-host.example.invalid"
+    extra_vars:
+      demo_launch_value: "complete-example"
+    wait: false
+
+controller_cancel_jobs:
+  - id: 900002
+    fail_if_not_running: false
+    interval: 1
+    timeout: 10
+
+controller_workflow_launch_jobs:
+  - name: "Demo CaC Workflow"
+    extra_vars:
+      demo_workflow_launch_value: "complete-example"
+    wait: false
+
+# Execution Environment builder resource. This creates a local build context
+# and image; configure registry credentials separately when push is required.
+ee_list:
+  - name: "demo_cac_ee"
+    alt_name: "Demo CaC EE"
+    tags:
+      - "1.0.0"
+    dependencies:
+      system:
+        - "git"
+      python:
+        - "jmespath>=1.0.1"
+      galaxy:
+        collections:
+          - name: "ansible.posix"
+            version: ">=1.5.4"
+          - name: "community.general"
+            version: ">=10.0.0"
+    build_steps:
+      prepend_final:
+        - "RUN echo 'Building Demo CaC EE'"
+      append_final:
+        - "RUN ansible --version"
+
+# Required encrypted variables: store these in an Ansible Vault file.
+# They are listed here as non-secret documentation values and must not be
+# committed with real credentials.
+aap_cac_demo_required_vault_variables:
+  vault_demo_aap_admin_password: "REPLACE_IN_ANSIBLE_VAULT"
+  vault_demo_operator_password: "REPLACE_IN_ANSIBLE_VAULT"
+  vault_demo_api_token: "REPLACE_IN_ANSIBLE_VAULT"
+  vault_demo_machine_password: "REPLACE_IN_ANSIBLE_VAULT"
+  vault_demo_become_password: "REPLACE_IN_ANSIBLE_VAULT"
+  vault_demo_scm_token: "REPLACE_IN_ANSIBLE_VAULT"
+  vault_demo_external_lookup_client_key: "REPLACE_IN_ANSIBLE_VAULT"
+  vault_demo_smtp_password: "REPLACE_IN_ANSIBLE_VAULT"

--- a/meta/role-coverage.yml
+++ b/meta/role-coverage.yml
@@ -2343,7 +2343,7 @@ scenarios:
   aap-cac-basic:
     profile: "tiny"
     state: "experimental"
-    implementation: "stub"
+    implementation: "partial"
     roles:
       - "aap_cac"
     junit: false
@@ -2352,8 +2352,8 @@ scenarios:
     test_application:
       mode: "not-applicable"
       reason: >-
-        Scenario is a role contract or assertion stub and does not deploy an independently versioned
-        application.
+        Scenario executes the AAP CaC authentication contract and shared password
+        resolution without deploying an independently versioned application.
       dependencies: []
   aap-deploy-basic:
     profile: "tiny"

--- a/meta/role-coverage.yml
+++ b/meta/role-coverage.yml
@@ -387,7 +387,8 @@ roles:
       - "Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix."
     deprecation_state: "active"
     scenario_support:
-      tiny: []
+      tiny:
+        - "aap-tls-basic"
       heavy: []
       application_acceptance: []
   alertmanager_deploy:
@@ -2444,6 +2445,21 @@ scenarios:
       reason: >-
         Scenario is a role contract or assertion stub and does not deploy an independently versioned
         application.
+      dependencies: []
+  aap-tls-basic:
+    profile: "tiny"
+    state: "experimental"
+    implementation: "partial"
+    roles:
+      - "aap_tls"
+    junit: false
+    allure: false
+    evidence: false
+    test_application:
+      mode: "not-applicable"
+      reason: >-
+        Scenario generates an ephemeral AAP CA and verifies transfer to the
+        managed host trust anchor without deploying AAP.
       dependencies: []
   artifacts-basic:
     profile: "tiny"

--- a/meta/source-dependencies.yml
+++ b/meta/source-dependencies.yml
@@ -80,6 +80,7 @@ container_images:
       - "roles/keycloak_deploy/defaults/main.yml"
   - reference: "quay.io/l-it/ee-wunder-devtools-ubi9:v1.9.2@sha256:58d5d45f7ea7405394edb00d4a77bf3e5d770532377fba6d80e8f641d27576b0"
     locations:
+      - "examples/aap-cac.yml"
       - "scripts/wunder-devtools-ee.sh"
   - reference: "quay.io/minio/mc:latest@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727"
     locations:

--- a/molecule/aap-cac-basic/converge.yml
+++ b/molecule/aap-cac-basic/converge.yml
@@ -1,24 +1,37 @@
 ---
-- name: Converge aap cac syntax coverage
+- name: Converge aap cac authentication contract
   hosts: localhost
   connection: local
   gather_facts: false
   vars:
-    aap_cac_molecule_execute_role: false
+    aap_username: ""
+    aap_password: ""
+    aap_gateway_admin_password_input:
+      active: gateway-active-password
+      next: gateway-next-password
+    aap_controller_admin_password_input: controller-password
+    aap_hub_admin_password_input: hub-password
+    aap_eda_admin_password_input: eda-password
+    aap_postgresql_admin_password_input: postgresql-password
     aap_cac_molecule_marker_path: >-
       {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/aap-cac-coverage-mode
   tasks:
-    - name: Import lit.supplementary.aap_cac for syntax coverage
-      ansible.builtin.import_role:
+    - name: Resolve lit.supplementary.aap_cac authentication inputs
+      ansible.builtin.include_role:
         name: lit.supplementary.aap_cac
-      when: aap_cac_molecule_execute_role | bool
+        tasks_from: assert.yml
+        public: true
 
-    - name: Record lit.supplementary.aap_cac Molecule coverage mode
-      ansible.builtin.set_fact:
-        aap_cac_molecule_coverage_mode: syntax_stub
+    - name: Assert canonical AAP CaC authentication resolution
+      ansible.builtin.assert:
+        that:
+          - aap_cac_gateway_username == 'admin'
+          - aap_cac_gateway_password == 'gateway-active-password'
+          - aap_gateway_admin_password_effective == 'gateway-active-password'
+        quiet: true
 
     - name: Persist lit.supplementary.aap_cac Molecule coverage mode
       ansible.builtin.copy:
         dest: "{{ aap_cac_molecule_marker_path }}"
-        content: "syntax_stub\n"
+        content: "authentication_contract\n"
         mode: "0644"

--- a/molecule/aap-cac-basic/converge.yml
+++ b/molecule/aap-cac-basic/converge.yml
@@ -6,6 +6,7 @@
   vars:
     aap_username: ""
     aap_password: ""
+    aap_validate_certs: false
     aap_gateway_admin_password_input:
       active: gateway-active-password
       next: gateway-next-password
@@ -30,6 +31,8 @@
           - aap_gateway_admin_password_effective == 'gateway-active-password'
           - (aap_cac_controller_organizations | type_debug) == 'list'
           - aap_cac_controller_organizations | length == 0
+          - (aap_cac_gateway_validate_certs | type_debug) == 'bool'
+          - aap_cac_gateway_validate_certs
         quiet: true
 
     - name: Persist lit.supplementary.aap_cac Molecule coverage mode

--- a/molecule/aap-cac-basic/converge.yml
+++ b/molecule/aap-cac-basic/converge.yml
@@ -28,6 +28,8 @@
           - aap_cac_gateway_username == 'admin'
           - aap_cac_gateway_password == 'gateway-active-password'
           - aap_gateway_admin_password_effective == 'gateway-active-password'
+          - (aap_cac_controller_organizations | type_debug) == 'list'
+          - aap_cac_controller_organizations | length == 0
         quiet: true
 
     - name: Persist lit.supplementary.aap_cac Molecule coverage mode

--- a/molecule/aap-cac-basic/verify.yml
+++ b/molecule/aap-cac-basic/verify.yml
@@ -1,5 +1,5 @@
 ---
-- name: Verify aap cac syntax coverage
+- name: Verify aap cac authentication contract
   hosts: localhost
   connection: local
   gather_facts: false
@@ -12,8 +12,10 @@
         src: "{{ aap_cac_molecule_marker_path }}"
       register: aap_cac_molecule_marker
 
-    - name: Assert lit.supplementary.aap_cac coverage stub ran
+    - name: Assert lit.supplementary.aap_cac authentication contract ran
       ansible.builtin.assert:
         that:
-          - aap_cac_molecule_marker.content | b64decode | trim == 'syntax_stub'
+          - >-
+            aap_cac_molecule_marker.content | b64decode | trim
+            == 'authentication_contract'
         quiet: true

--- a/molecule/aap-tls-basic/converge.yml
+++ b/molecule/aap-tls-basic/converge.yml
@@ -1,0 +1,55 @@
+---
+- name: Converge AAP TLS target trust contract
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    aap_tls_molecule_root: >-
+      {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/aap-tls
+    aap_tls_selfsigned_delegate_to: localhost
+    aap_tls_selfsigned_output_dir: "{{ aap_tls_molecule_root }}/generated"
+    aap_tls_selfsigned_ca_trust_path: "{{ aap_tls_molecule_root }}/trust/aap-selfsigned-ca.crt"
+    aap_tls_selfsigned_common_name: localhost
+    aap_tls_selfsigned_dns_names:
+      - localhost
+    aap_tls_selfsigned_key_size: 2048
+  environment:
+    PATH: >-
+      {{ aap_tls_molecule_root }}/bin:{{ lookup('env', 'PATH') }}
+  tasks:
+    - name: Ensure AAP TLS Molecule directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        mode: "0755"
+      loop:
+        - "{{ aap_tls_molecule_root }}/bin"
+        - "{{ aap_tls_molecule_root }}/trust"
+
+    - name: Install fake update-ca-trust command
+      ansible.builtin.copy:
+        dest: "{{ aap_tls_molecule_root }}/bin/update-ca-trust"
+        content: |
+          #!/bin/sh
+          printf '%s\n' "$*" > "{{ aap_tls_molecule_root }}/update-ca-trust.marker"
+        mode: "0755"
+
+    - name: Apply lit.supplementary.aap_tls
+      ansible.builtin.include_role:
+        name: lit.supplementary.aap_tls
+
+    - name: Read generated AAP CA
+      ansible.builtin.slurp:
+        src: "{{ aap_tls_selfsigned_output_dir }}/aap-selfsigned-ca.crt"
+      register: aap_tls_molecule_generated_ca
+
+    - name: Read installed AAP trust anchor
+      ansible.builtin.slurp:
+        src: "{{ aap_tls_selfsigned_ca_trust_path }}"
+      register: aap_tls_molecule_installed_ca
+
+    - name: Assert generated AAP CA is installed unchanged
+      ansible.builtin.assert:
+        that:
+          - aap_tls_molecule_generated_ca.content == aap_tls_molecule_installed_ca.content
+        quiet: true

--- a/molecule/aap-tls-basic/molecule.yml
+++ b/molecule/aap-tls-basic/molecule.yml
@@ -1,0 +1,33 @@
+---
+dependency:
+  name: shell
+  command: ":"
+
+driver:
+  name: default
+
+platforms:
+  - name: localhost
+    managed: false
+
+provisioner:
+  name: ansible
+  inventory:
+    host_vars:
+      localhost:
+        ansible_connection: local
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml
+
+scenario:
+  name: aap-tls-basic
+  test_sequence:
+    - dependency
+    - syntax
+    - converge
+    - idempotence
+    - verify
+
+verifier:
+  name: ansible

--- a/molecule/aap-tls-basic/verify.yml
+++ b/molecule/aap-tls-basic/verify.yml
@@ -1,0 +1,27 @@
+---
+- name: Verify AAP TLS target trust contract
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    aap_tls_molecule_root: >-
+      {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/aap-tls
+  tasks:
+    - name: Inspect installed AAP trust anchor
+      ansible.builtin.stat:
+        path: "{{ aap_tls_molecule_root }}/trust/aap-selfsigned-ca.crt"
+      register: aap_tls_molecule_trust_anchor
+
+    - name: Read target trust refresh marker
+      ansible.builtin.slurp:
+        src: "{{ aap_tls_molecule_root }}/update-ca-trust.marker"
+      register: aap_tls_molecule_trust_refresh
+
+    - name: Assert AAP trust anchor is installed
+      ansible.builtin.assert:
+        that:
+          - aap_tls_molecule_trust_anchor.stat.exists
+          - aap_tls_molecule_trust_anchor.stat.isreg
+          - aap_tls_molecule_trust_anchor.stat.mode == '0644'
+          - aap_tls_molecule_trust_refresh.content | b64decode | trim == 'extract'
+        quiet: true

--- a/roles/aap_cac/README.md
+++ b/roles/aap_cac/README.md
@@ -22,7 +22,8 @@ Key variables:
 - `aap_cac_gateway_hostname`
 - `aap_cac_gateway_username` (default: `admin`)
 - `aap_cac_gateway_password` (default: `aap_gateway_admin_password_effective`)
-- `aap_cac_gateway_validate_certs` (defaults to `aap_validate_certs`)
+- `aap_cac_gateway_validate_certs` (default: `true`; set this role-specific
+  variable explicitly only when certificate validation must be disabled)
 - `aap_cac_token_description`
 - `aap_cac_token_request_retries`
 - `aap_cac_token_request_delay`

--- a/roles/aap_cac/README.md
+++ b/roles/aap_cac/README.md
@@ -19,7 +19,7 @@ token. That version target is not a production-support claim.
 See `roles/aap_cac/defaults/main.yml`.
 
 Key variables:
-- `aap_cac_gateway_hostname`
+- `aap_cac_gateway_hostname` (default: `https://{{ aap_fqdn }}`)
 - `aap_cac_gateway_username` (default: `admin`)
 - `aap_cac_gateway_password` (default: `aap_gateway_admin_password_effective`)
 - `aap_cac_gateway_validate_certs` (default: `true`; set this role-specific
@@ -71,7 +71,7 @@ execution. Do not treat a core-only collection install as AAP-runtime ready.
   roles:
     - role: lit.supplementary.aap_cac
       vars:
-        aap_cac_gateway_hostname: "https://{{ inventory_hostname }}"
+        aap_fqdn: "aap.example.invalid"
 ```
 
 Controller license activation via manifest content from inventory:

--- a/roles/aap_cac/README.md
+++ b/roles/aap_cac/README.md
@@ -31,7 +31,8 @@ Key variables:
 - `aap_cac_gateway_ready_status_codes`
 - `aap_cac_gateway_ready_retries`
 - `aap_cac_gateway_ready_delay`
-- `aap_cac_controller_organizations` (default: `[{name: ModuLix}]`)
+- `aap_cac_controller_organizations` (default: `[]`; must be a list of
+  organization mappings)
 - `aap_cac_hub_collection_remotes` (default: `[]`)
 - `aap_cac_hub_collection_repositories` (default: `[]`)
 - `aap_cac_hub_group_roles` (default: `[]`)

--- a/roles/aap_cac/README.md
+++ b/roles/aap_cac/README.md
@@ -44,6 +44,10 @@ Key variables:
 Password and secret input behavior:
 - Inventory is the source of truth.
 - Inventory may provide plain values, Ansible Vault values, or lookup-based values (for example HCP Vault).
+- The role resolves `aap_gateway_admin_password_input` through the shared AAP
+  password contract before authenticating. The legacy `aap_username` and
+  `aap_password` aliases remain fallback inputs for compatibility but are not
+  required.
 - This role does not read or write Vault directly.
 - If `aap_token` is provided by the caller, it must be the raw AAP 2.7 gateway
   token string.

--- a/roles/aap_cac/README.md
+++ b/roles/aap_cac/README.md
@@ -105,6 +105,30 @@ The preferred flow is to run `lit.supplementary.aap_prepare` first. That role
 stages the manifest and publishes `aap_cac_controller_license_manifest_remote_src`
 for this role.
 
+## Complete CaC inventory example
+
+[`examples/aap-cac.yml`](../../examples/aap-cac.yml) contains a populated,
+cross-referenced example for every resource family currently dispatched by
+this role:
+
+- Gateway settings, organizations, users, teams, and role assignments
+- Controller license, settings, credentials, projects, inventories, templates,
+  workflows, runtime objects, and platform operations
+- Private Automation Hub remotes, repositories, synchronization, and roles
+- Controller filetree, job operations, and Execution Environment builder
+
+The manifest path in the example consumes
+`aap_prepare_manifest_dest_effective`, so a manifest staged earlier in the same
+deployment flow is activated automatically. A real Red Hat subscription
+manifest is still required; the example does not contain one.
+
+The complete example is an inventory reference, not a safe production
+configuration. Some populated sections intentionally perform actions, such as
+launching or cancelling jobs, synchronizing repositories, exporting/importing
+a filetree, or building an Execution Environment. Copy only the reviewed
+sections into environment-specific group variables and keep all referenced
+`vault_*` values in an encrypted Ansible Vault file.
+
 Run a single taskset directly:
 
 ```yaml

--- a/roles/aap_cac/defaults/main.yml
+++ b/roles/aap_cac/defaults/main.yml
@@ -1,8 +1,15 @@
 ---
 # Gateway API endpoint used by token helper tasks.
 aap_cac_gateway_hostname: "https://{{ inventory_hostname }}"
-aap_cac_gateway_username: "{{ aap_username }}"
-aap_cac_gateway_password: "{{ aap_password }}"
+aap_cac_gateway_username: "{{ aap_username | default('admin', true) }}"
+aap_cac_gateway_password: >-
+  {{
+    aap_password
+    | default(
+        aap_gateway_admin_password_effective | default('', true),
+        true
+      )
+  }}
 aap_cac_gateway_validate_certs: "{{ aap_validate_certs | default(true) }}"
 aap_cac_token_description: "aap-cac-token"
 aap_cac_token_request_retries: 5

--- a/roles/aap_cac/defaults/main.yml
+++ b/roles/aap_cac/defaults/main.yml
@@ -33,7 +33,7 @@ aap_cac_controller_ready_delay: 5
 
 # Default organizations for gateway/controller organization tasksets.
 # Inventory can override this (for example per environment/tenant).
-aap_cac_controller_organizations: ""
+aap_cac_controller_organizations: []
 
 # Private Automation Hub objects.
 aap_cac_hub_collection_remotes: []

--- a/roles/aap_cac/defaults/main.yml
+++ b/roles/aap_cac/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Gateway API endpoint used by token helper tasks.
-aap_cac_gateway_hostname: "https://{{ inventory_hostname }}"
+aap_cac_gateway_hostname: "https://{{ aap_fqdn }}"
 aap_cac_gateway_username: "{{ aap_username | default('admin', true) }}"
 aap_cac_gateway_password: >-
   {{

--- a/roles/aap_cac/defaults/main.yml
+++ b/roles/aap_cac/defaults/main.yml
@@ -10,7 +10,7 @@ aap_cac_gateway_password: >-
         true
       )
   }}
-aap_cac_gateway_validate_certs: "{{ aap_validate_certs | default(true) }}"
+aap_cac_gateway_validate_certs: true
 aap_cac_token_description: "aap-cac-token"
 aap_cac_token_request_retries: 5
 aap_cac_token_request_delay: 5

--- a/roles/aap_cac/tasks/assert.yml
+++ b/roles/aap_cac/tasks/assert.yml
@@ -21,3 +21,28 @@
     quiet: true
   no_log: true
   tags: always
+
+- name: Validate AAP CaC organization collection input
+  ansible.builtin.assert:
+    that:
+      - (aap_cac_controller_organizations | type_debug) == 'list'
+    fail_msg: >-
+      aap_cac_controller_organizations must be a YAML list of organization
+      mappings, or an empty list when no organizations are managed.
+    quiet: true
+  tags: always
+
+- name: Validate AAP CaC organization entries
+  ansible.builtin.assert:
+    that:
+      - item is mapping
+      - item.name is defined
+      - item.name | default('', true) | string | trim | length > 0
+    fail_msg: >-
+      Each aap_cac_controller_organizations entry must be a mapping with a
+      non-empty name.
+    quiet: true
+  loop: "{{ aap_cac_controller_organizations }}"
+  loop_control:
+    label: "{{ item.name | default('unnamed organization') }}"
+  tags: always

--- a/roles/aap_cac/tasks/assert.yml
+++ b/roles/aap_cac/tasks/assert.yml
@@ -1,0 +1,23 @@
+---
+- name: Resolve shared AAP admin passwords for CaC authentication
+  ansible.builtin.include_role:
+    name: lit.supplementary.aap
+    tasks_from: resolve_admin_passwords.yml
+  when:
+    - aap_cac_gateway_password | default('', true) | string | trim | length == 0
+  tags: always
+
+- name: Validate AAP CaC authentication inputs
+  ansible.builtin.assert:
+    that:
+      - aap_cac_gateway_hostname | default('', true) | trim | length > 0
+      - aap_cac_gateway_username | default('', true) | trim | length > 0
+      - aap_cac_gateway_password | default('', true) | trim | length > 0
+    fail_msg: >-
+      Missing AAP CaC authentication inputs. Provide the canonical
+      aap_gateway_admin_password_input so the shared AAP password resolver can
+      expose aap_gateway_admin_password_effective, or explicitly set
+      aap_cac_gateway_password.
+    quiet: true
+  no_log: true
+  tags: always

--- a/roles/aap_cac/tasks/cac_10_gateway_settings.yml
+++ b/roles/aap_cac/tasks/cac_10_gateway_settings.yml
@@ -6,6 +6,11 @@
       ansible.builtin.include_role:
         name: infra.aap_configuration.dispatch
       vars:
+        aap_hostname: "{{ aap_cac_gateway_hostname }}"
+        aap_username: "{{ aap_cac_gateway_username }}"
+        aap_password: "{{ aap_cac_gateway_password_effective }}"
+        aap_token: "{{ aap_cac_auth_token }}"
+        aap_validate_certs: "{{ aap_cac_gateway_validate_certs | bool }}"
         aap_configuration_dispatcher_roles:
           - role: gateway_settings
             var: gateway_settings

--- a/roles/aap_cac/tasks/cac_12_aap_users.yml
+++ b/roles/aap_cac/tasks/cac_12_aap_users.yml
@@ -6,6 +6,11 @@
       ansible.builtin.include_role:
         name: infra.aap_configuration.dispatch
       vars:
+        aap_hostname: "{{ aap_cac_gateway_hostname }}"
+        aap_username: "{{ aap_cac_gateway_username }}"
+        aap_password: "{{ aap_cac_gateway_password_effective }}"
+        aap_token: "{{ aap_cac_auth_token }}"
+        aap_validate_certs: "{{ aap_cac_gateway_validate_certs | bool }}"
         aap_configuration_dispatcher_roles:
           - role: gateway_users
             var: aap_user_accounts

--- a/roles/aap_cac/tasks/cac_13_aap_teams.yml
+++ b/roles/aap_cac/tasks/cac_13_aap_teams.yml
@@ -6,6 +6,11 @@
       ansible.builtin.include_role:
         name: infra.aap_configuration.dispatch
       vars:
+        aap_hostname: "{{ aap_cac_gateway_hostname }}"
+        aap_username: "{{ aap_cac_gateway_username }}"
+        aap_password: "{{ aap_cac_gateway_password_effective }}"
+        aap_token: "{{ aap_cac_auth_token }}"
+        aap_validate_certs: "{{ aap_cac_gateway_validate_certs | bool }}"
         aap_configuration_dispatcher_roles:
           - role: gateway_teams
             var: aap_teams

--- a/roles/aap_cac/tasks/cac_14_gateway_role_user_assignments.yml
+++ b/roles/aap_cac/tasks/cac_14_gateway_role_user_assignments.yml
@@ -1,15 +1,16 @@
 ---
 # CaC taskset: Configure Ansible Automation Platform (Gateway) role assignments.
 - name: Configure Ansible Automation Platform (Gateway) role assignments
-  environment:
-    GATEWAY_HOST: '{{ inventory_hostname }}'
-    GATEWAY_PASSWORD: '{{ aap_cac_gateway_password }}'
-    GATEWAY_USERNAME: '{{ aap_cac_gateway_username }}'
   block:
     - name: Run role infra.aap_configuration.dispatch  # noqa var-naming[no-role-prefix]
       ansible.builtin.include_role:
         name: infra.aap_configuration.dispatch
       vars:
+        aap_hostname: "{{ aap_cac_gateway_hostname }}"
+        aap_username: "{{ aap_cac_gateway_username }}"
+        aap_password: "{{ aap_cac_gateway_password_effective }}"
+        aap_token: "{{ aap_cac_auth_token }}"
+        aap_validate_certs: "{{ aap_cac_gateway_validate_certs | bool }}"
         aap_configuration_dispatcher_roles:
           - role: gateway_role_user_assignments
             var: gateway_role_user_assignments

--- a/roles/aap_cac/tasks/cac_30_hub_collection_remotes.yml
+++ b/roles/aap_cac/tasks/cac_30_hub_collection_remotes.yml
@@ -5,15 +5,13 @@
     - hub_collection_remote
     - hub_collection_remotes
   block:
-    - name: Set Hub collection remotes
-      ansible.builtin.set_fact:
-        hub_collection_remotes: "{{ aap_cac_hub_collection_remotes }}"
-      changed_when: false
-
     - name: Run role infra.aap_configuration.hub_collection_remote  # noqa var-naming[no-role-prefix]
       ansible.builtin.include_role:
         name: infra.aap_configuration.hub_collection_remote
       vars:
+        hub_collection_remotes: "{{ aap_cac_hub_collection_remotes }}"
+        aap_hostname: "{{ aap_cac_gateway_hostname }}"
+        aap_username: "{{ aap_cac_gateway_username }}"
         aap_password: "{{ aap_cac_hub_password_effective }}"
-        aap_token: "{{ aap_cac_auth_token | default(omit, true) }}"
+        aap_validate_certs: "{{ aap_cac_gateway_validate_certs | bool }}"
       when: aap_cac_hub_collection_remotes | length > 0

--- a/roles/aap_cac/tasks/cac_31_hub_collection_repositories.yml
+++ b/roles/aap_cac/tasks/cac_31_hub_collection_repositories.yml
@@ -5,15 +5,13 @@
     - hub_collection_repository
     - hub_collection_repositories
   block:
-    - name: Set Hub collection repositories
-      ansible.builtin.set_fact:
-        hub_collection_repositories: "{{ aap_cac_hub_collection_repositories }}"
-      changed_when: false
-
     - name: Run role infra.aap_configuration.hub_collection_repository  # noqa var-naming[no-role-prefix]
       ansible.builtin.include_role:
         name: infra.aap_configuration.hub_collection_repository
       vars:
+        hub_collection_repositories: "{{ aap_cac_hub_collection_repositories }}"
+        aap_hostname: "{{ aap_cac_gateway_hostname }}"
+        aap_username: "{{ aap_cac_gateway_username }}"
         aap_password: "{{ aap_cac_hub_password_effective }}"
-        aap_token: "{{ aap_cac_auth_token | default(omit, true) }}"
+        aap_validate_certs: "{{ aap_cac_gateway_validate_certs | bool }}"
       when: aap_cac_hub_collection_repositories | length > 0

--- a/roles/aap_cac/tasks/cac_32_hub_collection_repository_sync.yml
+++ b/roles/aap_cac/tasks/cac_32_hub_collection_repository_sync.yml
@@ -4,15 +4,13 @@
   tags:
     - hub_collection_repository_sync
   block:
-    - name: Set Hub collection repositories for sync
-      ansible.builtin.set_fact:
-        hub_collection_repositories: "{{ aap_cac_hub_collection_repositories }}"
-      changed_when: false
-
     - name: Run role infra.aap_configuration.hub_collection_repository_sync  # noqa var-naming[no-role-prefix]
       ansible.builtin.include_role:
         name: infra.aap_configuration.hub_collection_repository_sync
       vars:
+        hub_collection_repositories: "{{ aap_cac_hub_collection_repositories }}"
+        aap_hostname: "{{ aap_cac_gateway_hostname }}"
+        aap_username: "{{ aap_cac_gateway_username }}"
         aap_password: "{{ aap_cac_hub_password_effective }}"
-        aap_token: "{{ aap_cac_auth_token | default(omit, true) }}"
+        aap_validate_certs: "{{ aap_cac_gateway_validate_certs | bool }}"
       when: aap_cac_hub_collection_repositories | length > 0

--- a/roles/aap_cac/tasks/cac_33_hub_group_roles.yml
+++ b/roles/aap_cac/tasks/cac_33_hub_group_roles.yml
@@ -4,15 +4,13 @@
   tags:
     - hub_group_roles
   block:
-    - name: Set Hub group roles
-      ansible.builtin.set_fact:
-        hub_group_roles: "{{ aap_cac_hub_group_roles }}"
-      changed_when: false
-
     - name: Run role infra.aap_configuration.hub_group_roles  # noqa var-naming[no-role-prefix]
       ansible.builtin.include_role:
         name: infra.aap_configuration.hub_group_roles
       vars:
+        hub_group_roles: "{{ aap_cac_hub_group_roles }}"
+        aap_hostname: "{{ aap_cac_gateway_hostname }}"
+        aap_username: "{{ aap_cac_gateway_username }}"
         aap_password: "{{ aap_cac_hub_password_effective }}"
-        aap_token: "{{ aap_cac_auth_token | default(omit, true) }}"
+        aap_validate_certs: "{{ aap_cac_gateway_validate_certs | bool }}"
       when: aap_cac_hub_group_roles | length > 0

--- a/roles/aap_cac/tasks/create_authentication_token.yml
+++ b/roles/aap_cac/tasks/create_authentication_token.yml
@@ -79,6 +79,8 @@
       ansible.builtin.fail:
         msg: >-
           Failed to create AAP 2.7 gateway token via {{ aap_cac_gateway_hostname }} as
-          user {{ aap_cac_gateway_username }} (validate_certs={{ aap_cac_gateway_validate_certs | bool }}).
+          user {{ aap_cac_gateway_username }}
+          (validate_certs={{ aap_cac_gateway_validate_certs | bool }}).
           Check gateway reachability/readiness, credentials, and certificate trust.
-          For self-signed certs, set aap_validate_certs=false (or aap_cac_gateway_validate_certs=false).
+          Install the issuing CA in the target trust store. Only for an intentional
+          insecure exception, set aap_cac_gateway_validate_certs=false explicitly.

--- a/roles/aap_cac/tasks/main.yml
+++ b/roles/aap_cac/tasks/main.yml
@@ -1,17 +1,10 @@
 ---
+- name: Validate AAP CaC authentication
+  ansible.builtin.import_tasks: assert.yml
+  tags: always
+
 - name: Execute AAP CaC tasksets with shared auth token lifecycle
   block:
-    - name: Validate AAP CaC authentication inputs
-      ansible.builtin.assert:
-        that:
-          - aap_cac_gateway_hostname | default('', true) | trim | length > 0
-          - aap_cac_gateway_username | default('', true) | trim | length > 0
-          - aap_cac_gateway_password | default('', true) | trim | length > 0
-        fail_msg: >-
-          Missing AAP CaC auth inputs.
-          Set aap_cac_gateway_username and aap_cac_gateway_password.
-      tags: always
-
     - name: Record whether an auth token was provided by caller
       ansible.builtin.set_fact:
         aap_cac_preexisting_token: "{{ aap_token is defined }}"
@@ -60,17 +53,17 @@
           }}
         aap_cac_controller_password_effective: >-
           {{
-            aap_controller_admin_password_input
+            aap_controller_admin_password_effective
+            | default(aap_controller_admin_password_input, true)
             | default(aap_cac_gateway_password, true)
-            | default(aap_gateway_admin_password_input | default('', true), true)
             | string
             | trim
           }}
         aap_cac_hub_password_effective: >-
           {{
-            aap_hub_admin_password_input
+            aap_hub_admin_password_effective
+            | default(aap_hub_admin_password_input, true)
             | default(aap_cac_gateway_password, true)
-            | default(aap_gateway_admin_password_input | default('', true), true)
             | string
             | trim
           }}

--- a/roles/aap_tls/README.md
+++ b/roles/aap_tls/README.md
@@ -9,6 +9,9 @@ assets are supplied instead.
 - Ansible and the role dependencies declared by this collection.
 - A writable `aap_tls_selfsigned_output_dir` on the host selected for
   generation.
+- The RHEL `ca-certificates` package and `update-ca-trust` command on the
+  managed AAP host when target trust installation is enabled. The AAP base-OS
+  preparation owns this prerequisite.
 
 ## Variables
 
@@ -20,6 +23,10 @@ assets are supplied instead.
   portable to another host.
 - `aap_tls_selfsigned_enabled`: enables self-signed asset generation; defaults
   to `true`.
+- `aap_tls_selfsigned_install_ca_trust`: installs the generated CA in the
+  managed AAP host trust store and refreshes system trust; defaults to `true`.
+  Generation may remain delegated to the controller because the role transfers
+  the public CA certificate to the managed host before installation.
 
 See [`defaults/main.yml`](defaults/main.yml) for the complete interface.
 

--- a/roles/aap_tls/defaults/main.yml
+++ b/roles/aap_tls/defaults/main.yml
@@ -16,5 +16,5 @@ aap_tls_selfsigned_ca_days: 3650
 aap_tls_selfsigned_cert_days: 825
 aap_tls_selfsigned_key_size: 4096
 aap_tls_selfsigned_force: false
-aap_tls_selfsigned_install_ca_trust: false
+aap_tls_selfsigned_install_ca_trust: true
 aap_tls_selfsigned_ca_trust_path: /etc/pki/ca-trust/source/anchors/aap-selfsigned-ca.crt

--- a/roles/aap_tls/handlers/main.yml
+++ b/roles/aap_tls/handlers/main.yml
@@ -3,5 +3,4 @@
   ansible.builtin.command:
     cmd: update-ca-trust extract
   become: true
-  delegate_to: "{{ aap_tls_selfsigned_delegate_to }}"
   changed_when: true

--- a/roles/aap_tls/tasks/main.yml
+++ b/roles/aap_tls/tasks/main.yml
@@ -163,17 +163,33 @@
     - aap_tls_selfsigned_enabled | bool
     - not ansible_check_mode
 
-- name: Install temporary AAP CA in system trust store
-  ansible.builtin.copy:
+- name: Read temporary AAP CA from generation host
+  ansible.builtin.slurp:
     src: "{{ aap_tls_selfsigned_ca_cert_path }}"
+  register: aap_tls_selfsigned_ca_content
+  delegate_to: "{{ aap_tls_selfsigned_delegate_to }}"
+  changed_when: false
+  when:
+    - aap_tls_selfsigned_enabled | bool
+    - aap_tls_selfsigned_install_ca_trust | bool
+    - not ansible_check_mode
+
+- name: Install temporary AAP CA in target system trust store
+  ansible.builtin.copy:
+    content: "{{ aap_tls_selfsigned_ca_content.content | b64decode }}"
     dest: "{{ aap_tls_selfsigned_ca_trust_path }}"
-    remote_src: true
     owner: root
     group: root
     mode: "0644"
   become: true
-  delegate_to: "{{ aap_tls_selfsigned_delegate_to }}"
   notify: Refresh system CA trust after installing temporary AAP CA
+  when:
+    - aap_tls_selfsigned_enabled | bool
+    - aap_tls_selfsigned_install_ca_trust | bool
+    - not ansible_check_mode
+
+- name: Apply updated target system CA trust
+  ansible.builtin.meta: flush_handlers
   when:
     - aap_tls_selfsigned_enabled | bool
     - aap_tls_selfsigned_install_ca_trust | bool
@@ -183,7 +199,9 @@
   ansible.builtin.debug:
     msg: >-
       Check mode: temporary AAP CA, private keys, CSR, and service certificate
-      would be generated in {{ aap_tls_selfsigned_output_dir }}.
+      would be generated in {{ aap_tls_selfsigned_output_dir }}, and the CA
+      would be installed at {{ aap_tls_selfsigned_ca_trust_path }} on the
+      managed AAP host when target trust installation is enabled.
   changed_when: true
   when:
     - aap_tls_selfsigned_enabled | bool

--- a/tests/test_role_coverage.py
+++ b/tests/test_role_coverage.py
@@ -50,7 +50,7 @@ class RoleCoverageRegistryTests(unittest.TestCase):
 
     def test_registry_exactly_covers_repository(self) -> None:
         self.assertEqual(96, len(self.registry["roles"]))
-        self.assertEqual(57, len(self.registry["scenarios"]))
+        self.assertEqual(58, len(self.registry["scenarios"]))
         self.assertEqual(
             VALIDATOR.discovered_roles(ROOT),
             set(self.registry["roles"]),
@@ -137,7 +137,7 @@ class RoleCoverageRegistryTests(unittest.TestCase):
             },
             declared,
         )
-        self.assertEqual(46, len(not_applicable))
+        self.assertEqual(47, len(not_applicable))
         self.assertEqual(set(self.registry["scenarios"]), runtime | declared | not_applicable)
         for name in declared:
             self.assertEqual(

--- a/tests/unit/test_aap_gateway_contracts.py
+++ b/tests/unit/test_aap_gateway_contracts.py
@@ -109,9 +109,7 @@ class AapGatewayContractsTests(unittest.TestCase):
         self.assertIn("aap_username | default('admin', true)", defaults)
         self.assertIn("aap_gateway_admin_password_effective", defaults)
         self.assertIn(
-            "aap_password\n"
-            "    | default(\n"
-            "        aap_gateway_admin_password_effective | default('', true),",
+            "aap_password\n    | default(\n        aap_gateway_admin_password_effective | default('', true),",
             defaults,
         )
         self.assertNotIn('aap_cac_gateway_password: "{{ aap_password }}"', defaults)
@@ -120,6 +118,20 @@ class AapGatewayContractsTests(unittest.TestCase):
         self.assertLess(
             assertions.index("Resolve shared AAP admin passwords for CaC authentication"),
             assertions.index("Validate AAP CaC authentication inputs"),
+        )
+
+    def test_cac_organization_default_is_loop_safe(self) -> None:
+        defaults = (ROOT / "roles/aap_cac/defaults/main.yml").read_text(encoding="utf-8")
+        assertions = (ROOT / "roles/aap_cac/tasks/assert.yml").read_text(encoding="utf-8")
+
+        self.assertIn("aap_cac_controller_organizations: []", defaults)
+        self.assertIn(
+            "Validate AAP CaC organization collection input",
+            assertions,
+        )
+        self.assertIn(
+            "(aap_cac_controller_organizations | type_debug) == 'list'",
+            assertions,
         )
 
 

--- a/tests/unit/test_aap_gateway_contracts.py
+++ b/tests/unit/test_aap_gateway_contracts.py
@@ -57,6 +57,7 @@ class AapGatewayContractsTests(unittest.TestCase):
         self.assertNotIn("settings.yaml.j2", inventory_vars)
 
     def test_local_execution_uses_public_envoy_url(self) -> None:
+        cac_defaults = (ROOT / "roles/aap_cac/defaults/main.yml").read_text(encoding="utf-8")
         template = (
             ROOT / "roles/aap_local_execution/templates/aap-local/inventories/group_vars/aaps/aap.yml.j2"
         ).read_text(encoding="utf-8")
@@ -68,6 +69,14 @@ class AapGatewayContractsTests(unittest.TestCase):
         self.assertNotIn(
             'aap_deploy_gateway_main_url: "https://{{ aap_fqdn }}:8446"',
             template,
+        )
+        self.assertIn(
+            'aap_cac_gateway_hostname: "https://{{ aap_fqdn }}"',
+            cac_defaults,
+        )
+        self.assertNotIn(
+            'aap_cac_gateway_hostname: "https://{{ inventory_hostname }}"',
+            cac_defaults,
         )
 
     def test_partial_install_autoreset_is_not_supported(self) -> None:

--- a/tests/unit/test_aap_gateway_contracts.py
+++ b/tests/unit/test_aap_gateway_contracts.py
@@ -134,6 +134,15 @@ class AapGatewayContractsTests(unittest.TestCase):
             assertions,
         )
 
+    def test_cac_certificate_validation_default_is_not_recursive(self) -> None:
+        defaults = (ROOT / "roles/aap_cac/defaults/main.yml").read_text(encoding="utf-8")
+
+        self.assertIn("aap_cac_gateway_validate_certs: true", defaults)
+        self.assertNotIn(
+            'aap_cac_gateway_validate_certs: "{{ aap_validate_certs | default(true) }}"',
+            defaults,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_aap_gateway_contracts.py
+++ b/tests/unit/test_aap_gateway_contracts.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -142,6 +144,99 @@ class AapGatewayContractsTests(unittest.TestCase):
             'aap_cac_gateway_validate_certs: "{{ aap_validate_certs | default(true) }}"',
             defaults,
         )
+
+    def test_cac_gateway_and_hub_tasksets_receive_canonical_auth(self) -> None:
+        gateway_tasksets = (
+            "cac_10_gateway_settings.yml",
+            "cac_12_aap_users.yml",
+            "cac_13_aap_teams.yml",
+            "cac_14_gateway_role_user_assignments.yml",
+        )
+        hub_tasksets = (
+            "cac_30_hub_collection_remotes.yml",
+            "cac_31_hub_collection_repositories.yml",
+            "cac_32_hub_collection_repository_sync.yml",
+            "cac_33_hub_group_roles.yml",
+        )
+        common_contract = (
+            'aap_hostname: "{{ aap_cac_gateway_hostname }}"',
+            'aap_username: "{{ aap_cac_gateway_username }}"',
+            'aap_validate_certs: "{{ aap_cac_gateway_validate_certs | bool }}"',
+        )
+
+        for filename in gateway_tasksets:
+            content = (ROOT / "roles/aap_cac/tasks" / filename).read_text(encoding="utf-8")
+            with self.subTest(taskset=filename):
+                for contract in common_contract:
+                    self.assertIn(contract, content)
+                self.assertIn(
+                    'aap_password: "{{ aap_cac_gateway_password_effective }}"',
+                    content,
+                )
+                self.assertIn('aap_token: "{{ aap_cac_auth_token }}"', content)
+
+        for filename in hub_tasksets:
+            content = (ROOT / "roles/aap_cac/tasks" / filename).read_text(encoding="utf-8")
+            with self.subTest(taskset=filename):
+                for contract in common_contract:
+                    self.assertIn(contract, content)
+                self.assertIn(
+                    'aap_password: "{{ aap_cac_hub_password_effective }}"',
+                    content,
+                )
+
+    def test_complete_cac_example_populates_every_dispatched_resource(self) -> None:
+        example = yaml.safe_load((ROOT / "examples/aap-cac.yml").read_text(encoding="utf-8"))
+        expected_inputs = {
+            "aap_cac_controller_organizations",
+            "aap_user_accounts",
+            "aap_teams",
+            "gateway_role_user_assignments",
+            "gateway_settings",
+            "controller_settings",
+            "controller_credential_types",
+            "controller_labels",
+            "controller_credentials",
+            "controller_projects",
+            "controller_instance_groups",
+            "controller_inventories",
+            "controller_inventory_sources",
+            "controller_templates",
+            "aap_cac_hub_collection_remotes",
+            "aap_cac_hub_collection_repositories",
+            "aap_cac_hub_group_roles",
+            "controller_bulk_hosts",
+            "controller_hosts",
+            "controller_groups",
+            "controller_instances",
+            "controller_ad_hoc_commands",
+            "controller_ad_hoc_commands_cancel",
+            "controller_bulk_launch_jobs",
+            "controller_launch_jobs",
+            "controller_cancel_jobs",
+            "controller_workflows",
+            "controller_workflow_launch_jobs",
+            "controller_applications",
+            "controller_credential_input_sources",
+            "controller_configuration_dispatcher_roles",
+            "controller_execution_environments",
+            "operation_translate",
+            "controller_notifications",
+            "controller_configuration_object_diff_tasks",
+            "controller_roles",
+            "controller_schedules",
+            "ee_list",
+            "output_path",
+            "input_tag",
+            "dir_orgs_vars",
+            "orgs",
+            "aap_cac_controller_license_manifest_remote_src",
+        }
+
+        self.assertTrue(expected_inputs.issubset(example))
+        for name in expected_inputs:
+            with self.subTest(variable=name):
+                self.assertNotIn(example[name], (None, "", [], {}))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_aap_gateway_contracts.py
+++ b/tests/unit/test_aap_gateway_contracts.py
@@ -101,6 +101,27 @@ class AapGatewayContractsTests(unittest.TestCase):
             assertions,
         )
 
+    def test_cac_authentication_uses_shared_gateway_password_contract(self) -> None:
+        defaults = (ROOT / "roles/aap_cac/defaults/main.yml").read_text(encoding="utf-8")
+        main = (ROOT / "roles/aap_cac/tasks/main.yml").read_text(encoding="utf-8")
+        assertions = (ROOT / "roles/aap_cac/tasks/assert.yml").read_text(encoding="utf-8")
+
+        self.assertIn("aap_username | default('admin', true)", defaults)
+        self.assertIn("aap_gateway_admin_password_effective", defaults)
+        self.assertIn(
+            "aap_password\n"
+            "    | default(\n"
+            "        aap_gateway_admin_password_effective | default('', true),",
+            defaults,
+        )
+        self.assertNotIn('aap_cac_gateway_password: "{{ aap_password }}"', defaults)
+        self.assertIn("ansible.builtin.import_tasks: assert.yml", main)
+        self.assertIn("tasks_from: resolve_admin_passwords.yml", assertions)
+        self.assertLess(
+            assertions.index("Resolve shared AAP admin passwords for CaC authentication"),
+            assertions.index("Validate AAP CaC authentication inputs"),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_aap_tls_contracts.py
+++ b/tests/unit/test_aap_tls_contracts.py
@@ -1,0 +1,30 @@
+"""Regression tests for AAP self-signed CA trust installation."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class AapTlsContractsTests(unittest.TestCase):
+    """Keep CA generation and target trust ownership separated."""
+
+    def test_generated_ca_is_transferred_to_managed_host_trust(self) -> None:
+        defaults = (ROOT / "roles/aap_tls/defaults/main.yml").read_text(encoding="utf-8")
+        tasks = (ROOT / "roles/aap_tls/tasks/main.yml").read_text(encoding="utf-8")
+        handlers = (ROOT / "roles/aap_tls/handlers/main.yml").read_text(encoding="utf-8")
+
+        self.assertIn("aap_tls_selfsigned_install_ca_trust: true", defaults)
+        self.assertIn("Read temporary AAP CA from generation host", tasks)
+        self.assertIn("aap_tls_selfsigned_ca_content.content | b64decode", tasks)
+        self.assertIn("Install temporary AAP CA in target system trust store", tasks)
+        self.assertNotIn("remote_src: true", tasks)
+        self.assertNotIn("delegate_to:", handlers)
+        self.assertIn("cmd: update-ca-trust extract", handlers)
+        self.assertIn("ansible.builtin.meta: flush_handlers", tasks)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_source_dependencies.py
+++ b/tests/unit/test_source_dependencies.py
@@ -24,7 +24,7 @@ class SourceDependencyTests(unittest.TestCase):
     def _copy_source(self, destination: Path) -> None:
         for filename in ("galaxy.yml", ".pre-commit-config.yaml"):
             shutil.copy2(ROOT / filename, destination / filename)
-        for directory in ("collections", "containerfiles", "manifests", "meta", "roles", "scripts"):
+        for directory in ("collections", "containerfiles", "examples", "manifests", "meta", "roles", "scripts"):
             shutil.copytree(ROOT / directory, destination / directory)
 
     def test_repository_inventory_is_complete(self) -> None:


### PR DESCRIPTION
## Summary
- preserve the supported upstream AAP containerized installer flow
- resolve TLS trust and CaC authentication contracts
- derive the CaC gateway URL from aap_fqdn
- provide a complete CaC inventory example

## Validation
- python3 -m unittest discover -s tests/unit (170 tests)
- git diff --check