### PR TITLE
fix(ci): account for Chrome Linux security release

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -681,6 +681,8 @@ jobs:
       - name: Preserve the applied vulnerability-exploitability statement
         if: always()
         run: |
+          set -euo pipefail
+          mkdir -p artifacts/evidence/security
           cp \
             security/vex/chrome-linux-151.0.7922.71.openvex.json \
             artifacts/evidence/security/chrome-linux.openvex.json

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -673,10 +673,17 @@ jobs:
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7
         with:
           sbom: artifacts/evidence/security/sbom.cdx.json
+          vex: security/vex/chrome-linux-151.0.7922.71.openvex.json
           output-format: json
           output-file: artifacts/evidence/security/vulnerability-report.json
           fail-build: true
           severity-cutoff: high
+      - name: Preserve the applied vulnerability-exploitability statement
+        if: always()
+        run: |
+          cp \
+            security/vex/chrome-linux-151.0.7922.71.openvex.json \
+            artifacts/evidence/security/chrome-linux.openvex.json
       - name: Scan the exact collection candidate for secret-like content
         if: always()
         run: |

--- a/changelogs/fragments/chrome-linux-security-vex.yml
+++ b/changelogs/fragments/chrome-linux-security-vex.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    Bind release vulnerability scans to an exact-version OpenVEX statement for
+    the Chrome 151.0.7922.71 Linux security release, avoiding Windows/macOS
+    version comparisons being applied to the Linux browser artifact.

--- a/changelogs/fragments/chrome-linux-security-vex.yml
+++ b/changelogs/fragments/chrome-linux-security-vex.yml
@@ -1,3 +1,4 @@
+---
 bugfixes:
   - >-
     Bind release vulnerability scans to an exact-version OpenVEX statement for

--- a/scripts/enrich-cyclonedx-sbom.py
+++ b/scripts/enrich-cyclonedx-sbom.py
@@ -654,6 +654,7 @@ def enrich_sbom(
                     "name": "chromium",
                     "version": browser_version,
                     "bom-ref": browser_reference,
+                    "purl": f"pkg:generic/google-chrome@{browser_version}",
                     "cpe": f"cpe:2.3:a:google:chrome:{browser_version}:*:*:*:*:*:*:*",
                     "hashes": [{"alg": "SHA-256", "content": executable_digest}],
                     "properties": common_properties

--- a/security/vex/chrome-linux-151.0.7922.71.openvex.json
+++ b/security/vex/chrome-linux-151.0.7922.71.openvex.json
@@ -1,0 +1,118 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://github.com/lightning-it/ansible-collection-supplementary/security/vex/chrome-linux-151.0.7922.71",
+  "author": "https://github.com/lightning-it",
+  "role": "Document Creator",
+  "timestamp": "2026-07-31T00:00:00Z",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-17950"
+      },
+      "products": [
+        {
+          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "Google's Stable Channel Update for Desktop publishes 151.0.7922.71 as the fixed Linux release; 151.0.7922.72 applies only to Windows and macOS. Source: https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0887107924.html"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-17952"
+      },
+      "products": [
+        {
+          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "Google's Stable Channel Update for Desktop publishes 151.0.7922.71 as the fixed Linux release; 151.0.7922.72 applies only to Windows and macOS. Source: https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0887107924.html"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-17956"
+      },
+      "products": [
+        {
+          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "Google's Stable Channel Update for Desktop publishes 151.0.7922.71 as the fixed Linux release; 151.0.7922.72 applies only to Windows and macOS. Source: https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0887107924.html"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-17969"
+      },
+      "products": [
+        {
+          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "Google's Stable Channel Update for Desktop publishes 151.0.7922.71 as the fixed Linux release; 151.0.7922.72 applies only to Windows and macOS. Source: https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0887107924.html"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-17979"
+      },
+      "products": [
+        {
+          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "Google's Stable Channel Update for Desktop publishes 151.0.7922.71 as the fixed Linux release; 151.0.7922.72 applies only to Windows and macOS. Source: https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0887107924.html"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-17989"
+      },
+      "products": [
+        {
+          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "Google's Stable Channel Update for Desktop publishes 151.0.7922.71 as the fixed Linux release; 151.0.7922.72 applies only to Windows and macOS. Source: https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0887107924.html"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-17993"
+      },
+      "products": [
+        {
+          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "Google's Stable Channel Update for Desktop publishes 151.0.7922.71 as the fixed Linux release; 151.0.7922.72 applies only to Windows and macOS. Source: https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0887107924.html"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-18012"
+      },
+      "products": [
+        {
+          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "Google's Stable Channel Update for Desktop publishes 151.0.7922.71 as the fixed Linux release; 151.0.7922.72 applies only to Windows and macOS. Source: https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0887107924.html"
+    },
+    {
+      "vulnerability": {
+        "name": "CVE-2026-18017"
+      },
+      "products": [
+        {
+          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+        }
+      ],
+      "status": "fixed",
+      "status_notes": "Google's Stable Channel Update for Desktop publishes 151.0.7922.71 as the fixed Linux release; 151.0.7922.72 applies only to Windows and macOS. Source: https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0887107924.html"
+    }
+  ]
+}

--- a/security/vex/chrome-linux-151.0.7922.71.openvex.json
+++ b/security/vex/chrome-linux-151.0.7922.71.openvex.json
@@ -12,7 +12,7 @@
       },
       "products": [
         {
-          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+          "@id": "pkg:generic/google-chrome@151.0.7922.71"
         }
       ],
       "status": "fixed",
@@ -24,7 +24,7 @@
       },
       "products": [
         {
-          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+          "@id": "pkg:generic/google-chrome@151.0.7922.71"
         }
       ],
       "status": "fixed",
@@ -36,7 +36,7 @@
       },
       "products": [
         {
-          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+          "@id": "pkg:generic/google-chrome@151.0.7922.71"
         }
       ],
       "status": "fixed",
@@ -48,7 +48,7 @@
       },
       "products": [
         {
-          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+          "@id": "pkg:generic/google-chrome@151.0.7922.71"
         }
       ],
       "status": "fixed",
@@ -60,7 +60,7 @@
       },
       "products": [
         {
-          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+          "@id": "pkg:generic/google-chrome@151.0.7922.71"
         }
       ],
       "status": "fixed",
@@ -72,7 +72,7 @@
       },
       "products": [
         {
-          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+          "@id": "pkg:generic/google-chrome@151.0.7922.71"
         }
       ],
       "status": "fixed",
@@ -84,7 +84,7 @@
       },
       "products": [
         {
-          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+          "@id": "pkg:generic/google-chrome@151.0.7922.71"
         }
       ],
       "status": "fixed",
@@ -96,7 +96,7 @@
       },
       "products": [
         {
-          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+          "@id": "pkg:generic/google-chrome@151.0.7922.71"
         }
       ],
       "status": "fixed",
@@ -108,7 +108,7 @@
       },
       "products": [
         {
-          "@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"
+          "@id": "pkg:generic/google-chrome@151.0.7922.71"
         }
       ],
       "status": "fixed",

--- a/tests/unit/test_enrich_cyclonedx_sbom.py
+++ b/tests/unit/test_enrich_cyclonedx_sbom.py
@@ -493,6 +493,10 @@ class EnrichCycloneDxSbomTests(unittest.TestCase):
                 "cpe:2.3:a:google:chrome:140.0.7339.16:*:*:*:*:*:*:*",
                 chromium["cpe"],
             )
+            self.assertEqual(
+                "pkg:generic/google-chrome@140.0.7339.16",
+                chromium["purl"],
+            )
             properties = {item["name"]: item["value"] for item in chromium["properties"]}
             self.assertEqual("chrome", properties["lit:dependency:browser-channel"])
             self.assertTrue(

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -639,7 +639,7 @@ class WorkflowSecurityTests(unittest.TestCase):
             self.assertEqual(statement["status"], "fixed")
             self.assertEqual(
                 statement["products"],
-                [{"@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"}],
+                [{"@id": "pkg:generic/google-chrome@151.0.7922.71"}],
             )
             self.assertIn("chromereleases.googleblog.com", statement["status_notes"])
 

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -602,6 +602,40 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn('git show "$SOURCE_SHA:meta/source-dependencies.yml"', ci)
         self.assertIn("artifacts/evidence/security/source-dependencies.yml", ci)
         self.assertIn("cmp --silent", ci)
+        self.assertIn(
+            "vex: security/vex/chrome-linux-151.0.7922.71.openvex.json",
+            ci,
+        )
+        self.assertIn(
+            "artifacts/evidence/security/chrome-linux.openvex.json",
+            ci,
+        )
+
+        vex = json.loads(
+            (ROOT / "security" / "vex" / "chrome-linux-151.0.7922.71.openvex.json").read_text(encoding="utf-8")
+        )
+        expected_cves = {
+            "CVE-2026-17950",
+            "CVE-2026-17952",
+            "CVE-2026-17956",
+            "CVE-2026-17969",
+            "CVE-2026-17979",
+            "CVE-2026-17989",
+            "CVE-2026-17993",
+            "CVE-2026-18012",
+            "CVE-2026-18017",
+        }
+        self.assertEqual(
+            {statement["vulnerability"]["name"] for statement in vex["statements"]},
+            expected_cves,
+        )
+        for statement in vex["statements"]:
+            self.assertEqual(statement["status"], "fixed")
+            self.assertEqual(
+                statement["products"],
+                [{"@id": "cpe:2.3:a:google:chrome:151.0.7922.71:*:*:*:*:*:*:*"}],
+            )
+            self.assertIn("chromereleases.googleblog.com", statement["status_notes"])
 
         publish = (WORKFLOWS / "collection-publish.yml").read_text(encoding="utf-8")
         self.assertIn("dist/release/SHA256SUMS.sigstore.json", publish)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -610,16 +610,17 @@ class WorkflowSecurityTests(unittest.TestCase):
             "artifacts/evidence/security/chrome-linux.openvex.json",
             ci,
         )
-        preserve_vex = ci.split(
-            "- name: Preserve the applied vulnerability-exploitability statement",
-            maxsplit=1,
-        )[1].split("- name:", maxsplit=1)[0]
+        step_marker = "- name: Preserve the applied vulnerability-exploitability statement"
+        before_step, marker, after_step = ci.partition(step_marker)
+        self.assertTrue(before_step)
+        self.assertEqual(step_marker, marker)
+        preserve_vex, next_marker, _ = after_step.partition("- name:")
+        self.assertEqual("- name:", next_marker)
         self.assertIn("set -euo pipefail", preserve_vex)
         self.assertIn("mkdir -p artifacts/evidence/security", preserve_vex)
 
-        vex = json.loads(
-            (ROOT / "security" / "vex" / "chrome-linux-151.0.7922.71.openvex.json").read_text(encoding="utf-8")
-        )
+        vex_path = ROOT / "security" / "vex" / "chrome-linux-151.0.7922.71.openvex.json"
+        vex = json.loads(vex_path.read_text(encoding="utf-8"))
         expected_cves = {
             "CVE-2026-17950",
             "CVE-2026-17952",

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -610,6 +610,12 @@ class WorkflowSecurityTests(unittest.TestCase):
             "artifacts/evidence/security/chrome-linux.openvex.json",
             ci,
         )
+        preserve_vex = ci.split(
+            "- name: Preserve the applied vulnerability-exploitability statement",
+            maxsplit=1,
+        )[1].split("- name:", maxsplit=1)[0]
+        self.assertIn("set -euo pipefail", preserve_vex)
+        self.assertIn("mkdir -p artifacts/evidence/security", preserve_vex)
 
         vex = json.loads(
             (ROOT / "security" / "vex" / "chrome-linux-151.0.7922.71.openvex.json").read_text(encoding="utf-8")

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -614,8 +614,9 @@ class WorkflowSecurityTests(unittest.TestCase):
         before_step, marker, after_step = ci.partition(step_marker)
         self.assertTrue(before_step)
         self.assertEqual(step_marker, marker)
-        preserve_vex, next_marker, _ = after_step.partition("- name:")
+        preserve_vex, next_marker, remaining_steps = after_step.partition("- name:")
         self.assertEqual("- name:", next_marker)
+        self.assertTrue(remaining_steps)
         self.assertIn("set -euo pipefail", preserve_vex)
         self.assertIn("mkdir -p artifacts/evidence/security", preserve_vex)
 


### PR DESCRIPTION
## Summary

- apply an exact-version OpenVEX statement to the Chrome 151.0.7922.71 Linux browser component
- preserve the VEX statement with release evidence
- keep high-severity scanning fail-closed for every other component and vulnerability

## Rationale

Google publishes 151.0.7922.71 as the Linux security release, while 151.0.7922.72 is the corresponding Windows/macOS version. The generic NVD Chrome CPE incorrectly compares the Linux artifact against the Windows/macOS patch number.

Official source: https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0887107924.html

## Validation

- 
- JSON syntax validation
- 