### PR TITLE
fix(changelog): document smblds digest update

### DIFF
--- a/changelogs/fragments/smblds-image-digest.yml
+++ b/changelogs/fragments/smblds-image-digest.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    Update the pinned ``smblds/smblds`` container image digest used by the
+    Samba deployment role and the authoritative source-dependency inventory.


### PR DESCRIPTION
## Summary

- add the missing changelog fragment for the merged smblds image digest update
- restore the develop-to-main changelog policy invariant

## Validation

- `git diff --check`
- `pre-commit run changelog-policy-ee --all-files`

This fixes the promotion failure in Collection CI run 30630013277.