### PR TITLE
fix(ci): authenticate public central evidence reads

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -985,7 +985,7 @@ jobs:
         env:
           GH_TOKEN: >-
             ${{ (github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main') &&
-                secrets.MODULIX_VALIDATION_READ_TOKEN || '' }}
+                (secrets.MODULIX_VALIDATION_READ_TOKEN || github.token) || '' }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_REF: ${{ github.ref }}
           PR_BASE: ${{ github.event.pull_request.base.ref || '' }}

--- a/changelogs/fragments/554-central-validation.yml
+++ b/changelogs/fragments/554-central-validation.yml
@@ -2,4 +2,5 @@
 minor_changes:
   - >-
     Move protected Heavy and Application Acceptance validation to the central ModuLix validation controller and
-    require SHA-bound evidence for main promotion.
+    require SHA-bound evidence for main promotion, using the short-lived workflow token for public controller
+    artifacts when no dedicated read token is configured.

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -259,6 +259,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         evidence_step = jobs["evidence"]["steps"][0]
         token_guard = evidence_step["env"]["GH_TOKEN"]
         self.assertIn("secrets.MODULIX_VALIDATION_READ_TOKEN", token_guard)
+        self.assertIn("secrets.MODULIX_VALIDATION_READ_TOKEN || github.token", token_guard)
         self.assertIn("pull_request.base.ref == 'main'", token_guard)
         self.assertIn('test -n "$GH_TOKEN"', evidence_step["run"])
         self.assertIn("per_page=100", evidence_step["run"])


### PR DESCRIPTION
## Summary
- retain the optional dedicated ModuLix evidence read token
- fall back to the short-lived, `actions: read` workflow token because the controller repository is public
- keep the token unavailable outside main/main-target validation

## Tracking
- Fixes the Release Evidence failure observed while completing #554 / LI-118

## AI task profile
Work item: LI-118/#554. Risk: high. Capability: balanced with fail-closed CI and review verification. Escalation: private controller or broader token permissions.

## Verification
- actionlint passed
- focused workflow-security unit test passed
- `git diff --check` passed
- full local hook exposed unrelated Python 3.9 and `/usr/bin/bash` host incompatibilities; CI uses the supported runtime