### PR TITLE
fix(ci): protect release evidence credentials

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -976,6 +976,7 @@ jobs:
     needs:
       [lint-sanity, build-install, role-coverage, quality-matrix, tiny]
     runs-on: ubuntu-latest
+    environment: ansible-collection-runtime-tests
     timeout-minutes: 10
     permissions:
       actions: read

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -255,6 +255,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         release_security = jobs["release-security"]
         self.assertEqual("${{ github.event_name == 'workflow_call' }}", release_security["if"])
         self.assertEqual("Collection / Release Evidence", jobs["evidence"]["name"])
+        self.assertEqual("ansible-collection-runtime-tests", jobs["evidence"]["environment"])
         self.assertIn("supplementary-validation-evidence-", jobs["evidence"]["steps"][0]["run"])
         evidence_step = jobs["evidence"]["steps"][0]
         token_guard = evidence_step["env"]["GH_TOKEN"]


### PR DESCRIPTION
Fail-closed follow-up for MLX-90. The release-evidence job now requires the protected runtime-test Environment before GitHub exposes the ModuLix validation token. Includes a regression assertion.\n\nAddresses the security review finding on #575.