### PR TITLE
fix(release): reject symlinked evidence outputs

### DIFF
--- a/scripts/generate-security-release-evidence.py
+++ b/scripts/generate-security-release-evidence.py
@@ -26,6 +26,16 @@ def file_ref(path: Path, url: str):
     return {"url": url, "digest": sha256(path)}
 
 
+def has_symlink_component(path: Path):
+    current = path
+    while True:
+        if current.is_symlink():
+            return True
+        if current == current.parent:
+            return False
+        current = current.parent
+
+
 def timestamp(value: str, field: str):
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
@@ -62,6 +72,8 @@ def main():
     for path in (a.artifact, a.signature, a.sbom, a.provenance):
         if path.is_symlink() or not path.is_file():
             p.error(f"release asset must be a regular non-symlink file: {path}")
+    if has_symlink_component(a.output):
+        p.error(f"evidence output must not contain symlink components: {a.output}")
     if not SHA.fullmatch(a.source_sha) or not SHA.fullmatch(a.workflow_ref):
         p.error("source/workflow refs must be full SHAs")
     for field in (a.artifact_url, a.signature_url, a.sbom_url, a.provenance_url):

--- a/tests/unit/test_security_release_evidence.py
+++ b/tests/unit/test_security_release_evidence.py
@@ -64,6 +64,24 @@ class ProducerEvidenceTests(unittest.TestCase):
             self.assertEqual(value["status"], "approved")
             self.assertNotIn("delivery", value)
 
+            output_arg = cmd.index("--output") + 1
+            target = root / "target.json"
+            linked_output = root / "linked-output.json"
+            linked_output.symlink_to(target)
+            cmd[output_arg] = str(linked_output)
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)  # noqa: S603
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must not contain symlink components", result.stderr)
+
+            real_directory = root / "real-directory"
+            real_directory.mkdir()
+            linked_directory = root / "linked-directory"
+            linked_directory.symlink_to(real_directory, target_is_directory=True)
+            cmd[output_arg] = str(linked_directory / "evidence.json")
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)  # noqa: S603
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must not contain symlink components", result.stderr)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_security_release_evidence.py
+++ b/tests/unit/test_security_release_evidence.py
@@ -72,6 +72,7 @@ class ProducerEvidenceTests(unittest.TestCase):
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)  # noqa: S603
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("must not contain symlink components", result.stderr)
+            self.assertFalse(target.exists())
 
             real_directory = root / "real-directory"
             real_directory.mkdir()
@@ -81,6 +82,7 @@ class ProducerEvidenceTests(unittest.TestCase):
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)  # noqa: S603
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("must not contain symlink components", result.stderr)
+            self.assertFalse((real_directory / "evidence.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_security_release_evidence.py
+++ b/tests/unit/test_security_release_evidence.py
@@ -69,7 +69,7 @@ class ProducerEvidenceTests(unittest.TestCase):
             linked_output = root / "linked-output.json"
             linked_output.symlink_to(target)
             cmd[output_arg] = str(linked_output)
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)  # noqa: S603
+            result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=30)  # noqa: S603
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("must not contain symlink components", result.stderr)
             self.assertFalse(target.exists())
@@ -79,7 +79,7 @@ class ProducerEvidenceTests(unittest.TestCase):
             linked_directory = root / "linked-directory"
             linked_directory.symlink_to(real_directory, target_is_directory=True)
             cmd[output_arg] = str(linked_directory / "evidence.json")
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)  # noqa: S603
+            result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=30)  # noqa: S603
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("must not contain symlink components", result.stderr)
             self.assertFalse((real_directory / "evidence.json").exists())


### PR DESCRIPTION
Fail-closed follow-up for MLX-90. Rejects an output file or any existing output-path component that is a symlink, with regression coverage for both cases.\n\nAddresses the security review finding on #575.