### PR TITLE
feat(object-storage): prepare lit.cloud migration

### DIFF
--- a/changelogs/fragments/hetzner-object-storage-cloud-migration.yml
+++ b/changelogs/fragments/hetzner-object-storage-cloud-migration.yml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - >-
+    Stabilize the Hetzner Object Storage compatibility role with deterministic
+    separate-project admin, writer, reader, and reviewer bucket policies and a
+    complete migration manifest for lit.cloud.

--- a/docs/migrations/hetzner-object-storage-to-lit-cloud.yml
+++ b/docs/migrations/hetzner-object-storage-to-lit-cloud.yml
@@ -1,0 +1,46 @@
+---
+schema_version: 1
+source:
+  collection: lit.supplementary
+  role: hetzner_object_storage_cac
+  fqcn: lit.supplementary.hetzner_object_storage_cac
+target:
+  collection: lit.cloud
+  role: hetzner_object_storage
+  fqcn: lit.cloud.hetzner_object_storage
+contract:
+  preserve:
+    - plan-audit-reconcile actions
+    - endpoint and region validation
+    - private bucket, versioning, Object Lock, retention, and multipart cleanup
+    - explicit or HashiCorp Vault-backed administration credentials
+  required_target_behavior:
+    - separate-project external principals
+    - fixed admin, writer, reader, and reviewer profiles
+    - sanitized result and policy digest
+    - fail-closed same-project and unknown-profile validation
+files:
+  role:
+    - roles/hetzner_object_storage_cac
+  tiny_tests:
+    - molecule/hetzner-object-storage-tiny
+  heavy_contract:
+    - lightning-it/modulix-validation#137
+  documentation:
+    - roles/hetzner_object_storage_cac/README.md
+  changelog:
+    - changelogs/fragments/hetzner-object-storage-cloud-migration.yml
+fqcn_changes:
+  - from: lit.supplementary.hetzner_object_storage_cac
+    to: lit.cloud.hetzner_object_storage
+compatibility:
+  shim: Keep the source role operational until the replacement is released.
+  deprecation: Announce removal only with a future supplementary major version.
+  removal_preconditions:
+    - released and Heavy-accepted lit.cloud replacement
+    - consumer migration and rollback validation
+    - announced major-version removal window
+secret_boundary:
+  - never move or copy productive credentials
+  - preserve separate administration and external-principal Vault paths
+  - never include access or secret keys in evidence

--- a/molecule/hetzner-object-storage-tiny/converge.yml
+++ b/molecule/hetzner-object-storage-tiny/converge.yml
@@ -9,6 +9,20 @@
     hetzner_object_storage_cac_region: fsn1
     hetzner_object_storage_cac_bucket: example-production-backup
     hetzner_object_storage_cac_prefix: host01
+    hetzner_object_storage_cac_bucket_project_id: "10001"
+    hetzner_object_storage_cac_external_principals:
+      - name: backup-writer
+        project_id: "20001"
+        access_key: WRITERKEY00000001
+        profile: writer
+      - name: backup-reader
+        project_id: "20002"
+        access_key: READERKEY00000001
+        profile: reader
+      - name: evidence-reviewer
+        project_id: "20003"
+        access_key: REVIEWERKEY000001
+        profile: reviewer
   tasks:
     - name: Run the real safe planning path
       ansible.builtin.include_role:
@@ -19,6 +33,33 @@
         dest: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/hetzner-object-storage-plan.yml"
         content: "{{ hetzner_object_storage_cac_result | to_nice_yaml }}"
         mode: "0600"
+
+    - name: Verify the documented Hetzner principal ARN format
+      ansible.builtin.assert:
+        that:
+          - >-
+            _hetzner_object_storage_cac_bucket_policy.Statement[0].Principal.AWS
+            == 'arn:aws:iam:::user/p20001:WRITERKEY00000001'
+        quiet: true
+
+    - name: Prove a compatibility plan needs no external principals
+      ansible.builtin.include_role:
+        name: lit.supplementary.hetzner_object_storage_cac
+      vars:
+        hetzner_object_storage_cac_bucket_project_id: ""
+        hetzner_object_storage_cac_external_principals: []
+
+    - name: Verify the compatibility plan remains non-mutating
+      ansible.builtin.assert:
+        that:
+          - hetzner_object_storage_cac_result.action == 'plan'
+          - not hetzner_object_storage_cac_result.changed | bool
+          - hetzner_object_storage_cac_result.principal_profiles == []
+        quiet: true
+
+    - name: Restore the external-principal planning contract
+      ansible.builtin.include_role:
+        name: lit.supplementary.hetzner_object_storage_cac
 
     - name: Prove an insecure endpoint is rejected
       block:
@@ -52,6 +93,46 @@
           ansible.builtin.set_fact:
             _hetzner_object_storage_cac_disabled_lock_rejected: true
 
+    - name: Prove a same-project role key is rejected
+      block:
+        - name: Run the role with a same-project Writer
+          ansible.builtin.include_role:
+            name: lit.supplementary.hetzner_object_storage_cac
+          vars:
+            hetzner_object_storage_cac_external_principals:
+              - name: unsafe-writer
+                project_id: "10001"
+                access_key: UNSAFEKEY00000001
+                profile: writer
+
+        - name: Reject an accepted same-project Writer
+          ansible.builtin.fail:
+            msg: The role accepted a same-project role key as least privilege.
+      rescue:
+        - name: Record same-project rejection
+          ansible.builtin.set_fact:
+            _hetzner_object_storage_cac_same_project_rejected: true
+
+    - name: Prove custom over-privileged profiles are rejected
+      block:
+        - name: Run the role with an undefined profile
+          ansible.builtin.include_role:
+            name: lit.supplementary.hetzner_object_storage_cac
+          vars:
+            hetzner_object_storage_cac_external_principals:
+              - name: unsafe-profile
+                project_id: "20004"
+                access_key: UNSAFEKEY00000002
+                profile: writer-with-delete
+
+        - name: Reject an accepted custom profile
+          ansible.builtin.fail:
+            msg: The role accepted an undefined permission profile.
+      rescue:
+        - name: Record over-privileged profile rejection
+          ansible.builtin.set_fact:
+            _hetzner_object_storage_cac_overprivileged_profile_rejected: true
+
     - name: Persist negative safety results
       ansible.builtin.copy:
         dest: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/hetzner-object-storage-safety.yml"
@@ -59,7 +140,10 @@
           {{
             {
               'disabled_lock_rejected': _hetzner_object_storage_cac_disabled_lock_rejected | default(false),
-              'insecure_endpoint_rejected': _hetzner_object_storage_cac_insecure_endpoint_rejected | default(false)
+              'insecure_endpoint_rejected': _hetzner_object_storage_cac_insecure_endpoint_rejected | default(false),
+              'overprivileged_profile_rejected':
+                _hetzner_object_storage_cac_overprivileged_profile_rejected | default(false),
+              'same_project_rejected': _hetzner_object_storage_cac_same_project_rejected | default(false)
             } | to_nice_yaml
           }}
         mode: "0600"

--- a/molecule/hetzner-object-storage-tiny/converge.yml
+++ b/molecule/hetzner-object-storage-tiny/converge.yml
@@ -38,8 +38,34 @@
       ansible.builtin.assert:
         that:
           - >-
-            _hetzner_object_storage_cac_bucket_policy.Statement[0].Principal.AWS
+            (
+              _hetzner_object_storage_cac_bucket_policy.Statement
+              | selectattr('Sid', 'equalto', 'BackupWriterBucket')
+              | map(attribute='Principal.AWS')
+              | first
+            )
             == 'arn:aws:iam:::user/p20001:WRITERKEY00000001'
+        quiet: true
+
+    - name: Preserve the canonical policy digest
+      ansible.builtin.set_fact:
+        _hetzner_object_storage_cac_expected_policy_sha256: >-
+          {{ hetzner_object_storage_cac_result.policy_sha256 }}
+        _hetzner_object_storage_cac_reordered_principals: >-
+          {{ hetzner_object_storage_cac_external_principals | reverse | list }}
+
+    - name: Replan with the same principals in reverse order
+      ansible.builtin.include_role:
+        name: lit.supplementary.hetzner_object_storage_cac
+      vars:
+        hetzner_object_storage_cac_external_principals: "{{ _hetzner_object_storage_cac_reordered_principals }}"
+
+    - name: Verify principal order does not change the policy digest
+      ansible.builtin.assert:
+        that:
+          - >-
+            hetzner_object_storage_cac_result.policy_sha256
+            == _hetzner_object_storage_cac_expected_policy_sha256
         quiet: true
 
     - name: Prove a compatibility plan needs no external principals

--- a/molecule/hetzner-object-storage-tiny/verify.yml
+++ b/molecule/hetzner-object-storage-tiny/verify.yml
@@ -24,6 +24,10 @@
           - _hetzner_object_storage_cac_plan.object_lock_mode == 'GOVERNANCE'
           - _hetzner_object_storage_cac_plan.object_lock_retention_days | int == 30
           - _hetzner_object_storage_cac_plan.versioning | bool
+          - _hetzner_object_storage_cac_plan.principal_profiles == ['reader', 'reviewer', 'writer']
+          - _hetzner_object_storage_cac_plan.policy_sha256 | length == 64
           - _hetzner_object_storage_cac_safety.insecure_endpoint_rejected | bool
           - _hetzner_object_storage_cac_safety.disabled_lock_rejected | bool
+          - _hetzner_object_storage_cac_safety.same_project_rejected | bool
+          - _hetzner_object_storage_cac_safety.overprivileged_profile_rejected | bool
         quiet: true

--- a/roles/hetzner_object_storage_cac/README.md
+++ b/roles/hetzner_object_storage_cac/README.md
@@ -5,9 +5,10 @@ S3-compatible API. The role is fail-closed around HTTPS endpoints, versioning,
 Object Lock at bucket creation, default retention, and incomplete multipart
 upload cleanup. It never creates S3 credentials.
 
-Classification: configuration as code. Maturity: experimental. Tiny contract
-coverage is available; Heavy and Application Acceptance remain blocked on a
-protected paid Hetzner Object Storage project.
+Classification: configuration as code. Maturity: compatibility role pending
+migration to `lit.cloud.hetzner_object_storage`. Tiny contract coverage is
+available; Heavy and Application Acceptance are centrally owned by
+`lightning-it/modulix-validation`.
 
 ## Requirements
 
@@ -23,6 +24,35 @@ See `defaults/main.yml` for the complete contract. Important inputs are
 `hetzner_object_storage_cac_action`, `endpoint`, `region`, `bucket`, `prefix`,
 the Object Lock and lifecycle settings, and exactly one credential source.
 Actions are `plan`, `audit`, and `reconcile`.
+
+`bucket_project_id` identifies the project that owns the bucket.
+`external_principals` is an optional list whose entries contain exactly
+`name`, `project_id`, `access_key`, and `profile`. Principal projects must be
+different from the bucket project. Hetzner documents that same-project keys
+have default read/write access to every current and future bucket in that
+project; this role therefore rejects them as non-least-privilege.
+
+Profiles are fixed and cannot be extended through inventory:
+
+- `admin`: bucket and object administration (`s3:*`), for separately protected
+  administrative identities only.
+- `writer`: upload and multipart completion/cleanup; it cannot read or delete
+  objects and cannot read or change bucket policy or retention.
+- `reader`: list and read current/versioned objects; it cannot write, delete,
+  change policy, or change retention.
+- `reviewer`: inspect bucket versioning/Object Lock state and object
+  retention/legal-hold metadata; it cannot read object bodies or mutate
+  objects, policy, or retention.
+
+An empty list preserves the original bucket-only Plan/Audit/Reconcile contract
+and does not manage a bucket policy. When principals are declared, the role
+renders one deterministic bucket policy with the Hetzner-documented principal
+form `arn:aws:iam:::user/p<project_id>:<access_key>`. Sanitized results expose
+only the selected profile names and a policy SHA-256 digest, never secrets or
+the access keys embedded in the policy.
+
+Principal syntax and the separate-project least-privilege model follow the
+[Hetzner S3 credentials FAQ](https://docs.hetzner.com/storage/object-storage/faq/s3-credentials/).
 
 `plan` performs no API call. `audit` confirms that the bucket is visible.
 `reconcile` creates or updates the private bucket, including Object Lock,
@@ -52,12 +82,26 @@ The role uses `amazon.aws`, `community.aws`, and optionally
         hetzner_object_storage_cac_region: fsn1
         hetzner_object_storage_cac_bucket: example-production-backup
         hetzner_object_storage_cac_prefix: host01
+        hetzner_object_storage_cac_bucket_project_id: "10001"
+        hetzner_object_storage_cac_external_principals:
+          - name: backup-writer
+            project_id: "20001"
+            access_key: "{{ protected_writer_access_key }}"
+            profile: writer
         hetzner_object_storage_cac_use_vault: true
         hetzner_object_storage_cac_vault_addr: https://vault.example.com
         hetzner_object_storage_cac_vault_token: "{{ protected_vault_token }}"
         hetzner_object_storage_cac_vault_kv_mount: infrastructure
         hetzner_object_storage_cac_vault_kv_path: object-storage/host01
 ```
+
+## Compatibility and deprecation
+
+The public variables, action behavior, sanitized result, Vault lookup contract,
+and fail-closed validation documented here are frozen for migration. The old
+FQCN remains supported until a released `lit.cloud.hetzner_object_storage`
+replacement exists and a major-version removal window has been announced. It
+must not be removed or silently redirected before that window.
 
 ## License
 

--- a/roles/hetzner_object_storage_cac/defaults/main.yml
+++ b/roles/hetzner_object_storage_cac/defaults/main.yml
@@ -6,6 +6,8 @@ hetzner_object_storage_cac_endpoint: ""
 hetzner_object_storage_cac_region: ""
 hetzner_object_storage_cac_bucket: ""
 hetzner_object_storage_cac_prefix: ""
+hetzner_object_storage_cac_bucket_project_id: ""
+hetzner_object_storage_cac_external_principals: []
 
 hetzner_object_storage_cac_access_key: ""
 hetzner_object_storage_cac_secret_key: ""

--- a/roles/hetzner_object_storage_cac/tasks/assert.yml
+++ b/roles/hetzner_object_storage_cac/tasks/assert.yml
@@ -20,6 +20,15 @@
       - "'..' not in hetzner_object_storage_cac_bucket"
       - "'.-' not in hetzner_object_storage_cac_bucket"
       - "'-.' not in hetzner_object_storage_cac_bucket"
+      - hetzner_object_storage_cac_bucket_project_id is string
+      - >-
+        hetzner_object_storage_cac_bucket_project_id | length == 0
+        or hetzner_object_storage_cac_bucket_project_id is match('^[1-9][0-9]*$')
+      - hetzner_object_storage_cac_external_principals is sequence
+      - hetzner_object_storage_cac_external_principals is not string
+      - >-
+        hetzner_object_storage_cac_external_principals | length == 0
+        or hetzner_object_storage_cac_bucket_project_id | length > 0
       - hetzner_object_storage_cac_prefix is string
       - not hetzner_object_storage_cac_prefix.startswith('/')
       - not hetzner_object_storage_cac_prefix.endswith('/')
@@ -38,6 +47,44 @@
       supported HTTPS location endpoint, a private DNS-compatible bucket name,
       versioning, Object Lock, positive retention, and TLS verification.
     quiet: true
+
+- name: Validate separate-project Hetzner S3 principals
+  ansible.builtin.assert:
+    that:
+      - item is mapping
+      - item.keys() | list | sort == ['access_key', 'name', 'profile', 'project_id']
+      - item.name is string
+      - item.name is match('^[a-z][a-z0-9-]{1,31}$')
+      - item.project_id is string
+      - item.project_id is match('^[1-9][0-9]*$')
+      - item.project_id != hetzner_object_storage_cac_bucket_project_id
+      - item.access_key is string
+      - item.access_key is match('^[A-Za-z0-9]{16,64}$')
+      - item.profile in _hetzner_object_storage_cac_permission_profiles
+    fail_msg: >-
+      Every principal must contain only name, external project_id, access_key,
+      and one fixed admin/writer/reader/reviewer profile. Same-project keys are
+      not least privilege and are rejected.
+    quiet: true
+  loop: "{{ hetzner_object_storage_cac_external_principals }}"
+  loop_control:
+    label: "{{ item.name | default('invalid-principal') }}"
+  no_log: true
+
+- name: Validate unique Hetzner S3 principal identities
+  ansible.builtin.assert:
+    that:
+      - >-
+        hetzner_object_storage_cac_external_principals
+        | map(attribute='name') | list | unique | length
+        == hetzner_object_storage_cac_external_principals | length
+      - >-
+        hetzner_object_storage_cac_external_principals
+        | map(attribute='access_key') | list | unique | length
+        == hetzner_object_storage_cac_external_principals | length
+    fail_msg: Principal names and access keys must be unique.
+    quiet: true
+  no_log: true
 
 - name: Validate explicit Hetzner S3 credentials
   ansible.builtin.assert:

--- a/roles/hetzner_object_storage_cac/tasks/audit.yml
+++ b/roles/hetzner_object_storage_cac/tasks/audit.yml
@@ -21,6 +21,30 @@
     fail_msg: The declared Hetzner Object Storage bucket is absent or not uniquely visible.
     quiet: true
 
+- name: Check the declared bucket policy without mutation
+  amazon.aws.s3_bucket:
+    name: "{{ hetzner_object_storage_cac_bucket }}"
+    state: present
+    endpoint_url: "{{ hetzner_object_storage_cac_endpoint }}"
+    region: "{{ hetzner_object_storage_cac_region }}"
+    access_key: "{{ _hetzner_object_storage_cac_access_key }}"
+    secret_key: "{{ _hetzner_object_storage_cac_secret_key }}"
+    policy: "{{ _hetzner_object_storage_cac_bucket_policy }}"
+    validate_certs: "{{ hetzner_object_storage_cac_validate_certs }}"
+  check_mode: true
+  register: _hetzner_object_storage_cac_policy_audit
+  delegate_to: "{{ hetzner_object_storage_cac_delegate_to }}"
+  when: hetzner_object_storage_cac_external_principals | length > 0
+  no_log: true
+
+- name: Reject Hetzner Object Storage bucket-policy drift
+  ansible.builtin.assert:
+    that:
+      - not _hetzner_object_storage_cac_policy_audit.changed | bool
+    fail_msg: The live bucket policy differs from the declared external-principal policy.
+    quiet: true
+  when: hetzner_object_storage_cac_external_principals | length > 0
+
 - name: Publish sanitized Hetzner Object Storage audit result
   ansible.builtin.set_fact:
     hetzner_object_storage_cac_result:
@@ -30,4 +54,8 @@
       endpoint: "{{ hetzner_object_storage_cac_endpoint }}"
       exists: true
       prefix: "{{ hetzner_object_storage_cac_prefix }}"
+      principal_profiles: >-
+        {{ hetzner_object_storage_cac_external_principals | map(attribute='profile') | unique | sort | list }}
+      policy_sha256: >-
+        {{ _hetzner_object_storage_cac_bucket_policy | to_json | hash('sha256') }}
       region: "{{ hetzner_object_storage_cac_region }}"

--- a/roles/hetzner_object_storage_cac/tasks/audit.yml
+++ b/roles/hetzner_object_storage_cac/tasks/audit.yml
@@ -57,5 +57,5 @@
       principal_profiles: >-
         {{ hetzner_object_storage_cac_external_principals | map(attribute='profile') | unique | sort | list }}
       policy_sha256: >-
-        {{ _hetzner_object_storage_cac_bucket_policy | to_json | hash('sha256') }}
+        {{ _hetzner_object_storage_cac_bucket_policy_json | hash('sha256') }}
       region: "{{ hetzner_object_storage_cac_region }}"

--- a/roles/hetzner_object_storage_cac/tasks/main.yml
+++ b/roles/hetzner_object_storage_cac/tasks/main.yml
@@ -3,6 +3,48 @@
   ansible.builtin.import_tasks: assert.yml
   tags: always
 
+- name: Initialize the least-privilege external-principal bucket policy
+  ansible.builtin.set_fact:
+    _hetzner_object_storage_cac_bucket_policy:
+      Version: "2012-10-17"
+      Statement: []
+
+- name: Add fixed-profile external principals to the bucket policy
+  ansible.builtin.set_fact:
+    _hetzner_object_storage_cac_bucket_policy: >-
+      {{
+        _hetzner_object_storage_cac_bucket_policy
+        | combine(
+            {
+              'Statement': _hetzner_object_storage_cac_bucket_policy.Statement
+              + [
+                  {
+                    'Sid': (item.name | replace('-', ' ') | title | replace(' ', '')) ~ 'Bucket',
+                    'Effect': 'Allow',
+                    'Principal': {
+                      'AWS': 'arn:aws:iam:::user/p' ~ item.project_id ~ ':' ~ item.access_key
+                    },
+                    'Action': _hetzner_object_storage_cac_permission_profiles[item.profile].bucket_actions,
+                    'Resource': 'arn:aws:s3:::' ~ hetzner_object_storage_cac_bucket
+                  },
+                  {
+                    'Sid': (item.name | replace('-', ' ') | title | replace(' ', '')) ~ 'Objects',
+                    'Effect': 'Allow',
+                    'Principal': {
+                      'AWS': 'arn:aws:iam:::user/p' ~ item.project_id ~ ':' ~ item.access_key
+                    },
+                    'Action': _hetzner_object_storage_cac_permission_profiles[item.profile].object_actions,
+                    'Resource': 'arn:aws:s3:::' ~ hetzner_object_storage_cac_bucket ~ '/*'
+                  }
+                ]
+            }
+          )
+      }}
+  loop: "{{ hetzner_object_storage_cac_external_principals }}"
+  loop_control:
+    label: "{{ item.name }}"
+  no_log: true
+
 - name: Publish the sanitized Hetzner Object Storage plan
   ansible.builtin.set_fact:
     hetzner_object_storage_cac_result:
@@ -15,6 +57,10 @@
       object_lock_mode: "{{ hetzner_object_storage_cac_object_lock_mode }}"
       object_lock_retention_days: "{{ hetzner_object_storage_cac_object_lock_retention_days | int }}"
       prefix: "{{ hetzner_object_storage_cac_prefix }}"
+      principal_profiles: >-
+        {{ hetzner_object_storage_cac_external_principals | map(attribute='profile') | unique | sort | list }}
+      policy_sha256: >-
+        {{ _hetzner_object_storage_cac_bucket_policy | to_json | hash('sha256') }}
       region: "{{ hetzner_object_storage_cac_region }}"
       versioning: "{{ hetzner_object_storage_cac_versioning | bool }}"
   when: hetzner_object_storage_cac_action == 'plan'

--- a/roles/hetzner_object_storage_cac/tasks/main.yml
+++ b/roles/hetzner_object_storage_cac/tasks/main.yml
@@ -52,6 +52,7 @@
         _hetzner_object_storage_cac_bucket_policy
         | to_json(sort_keys=true, separators=[',', ':'])
       }}
+  no_log: true
 
 - name: Publish the sanitized Hetzner Object Storage plan
   ansible.builtin.set_fact:

--- a/roles/hetzner_object_storage_cac/tasks/main.yml
+++ b/roles/hetzner_object_storage_cac/tasks/main.yml
@@ -40,10 +40,18 @@
             }
           )
       }}
-  loop: "{{ hetzner_object_storage_cac_external_principals }}"
+  loop: "{{ hetzner_object_storage_cac_external_principals | sort(attribute='access_key') }}"
   loop_control:
     label: "{{ item.name }}"
   no_log: true
+
+- name: Canonicalize the external-principal bucket policy
+  ansible.builtin.set_fact:
+    _hetzner_object_storage_cac_bucket_policy_json: >-
+      {{
+        _hetzner_object_storage_cac_bucket_policy
+        | to_json(sort_keys=true, separators=[',', ':'])
+      }}
 
 - name: Publish the sanitized Hetzner Object Storage plan
   ansible.builtin.set_fact:
@@ -60,7 +68,7 @@
       principal_profiles: >-
         {{ hetzner_object_storage_cac_external_principals | map(attribute='profile') | unique | sort | list }}
       policy_sha256: >-
-        {{ _hetzner_object_storage_cac_bucket_policy | to_json | hash('sha256') }}
+        {{ _hetzner_object_storage_cac_bucket_policy_json | hash('sha256') }}
       region: "{{ hetzner_object_storage_cac_region }}"
       versioning: "{{ hetzner_object_storage_cac_versioning | bool }}"
   when: hetzner_object_storage_cac_action == 'plan'

--- a/roles/hetzner_object_storage_cac/tasks/reconcile.yml
+++ b/roles/hetzner_object_storage_cac/tasks/reconcile.yml
@@ -59,6 +59,6 @@
       principal_profiles: >-
         {{ hetzner_object_storage_cac_external_principals | map(attribute='profile') | unique | sort | list }}
       policy_sha256: >-
-        {{ _hetzner_object_storage_cac_bucket_policy | to_json | hash('sha256') }}
+        {{ _hetzner_object_storage_cac_bucket_policy_json | hash('sha256') }}
       region: "{{ hetzner_object_storage_cac_region }}"
       versioning: "{{ hetzner_object_storage_cac_versioning | bool }}"

--- a/roles/hetzner_object_storage_cac/tasks/reconcile.yml
+++ b/roles/hetzner_object_storage_cac/tasks/reconcile.yml
@@ -13,6 +13,12 @@
       mode: "{{ hetzner_object_storage_cac_object_lock_mode }}"
       days: "{{ hetzner_object_storage_cac_object_lock_retention_days }}"
     versioning: "{{ hetzner_object_storage_cac_versioning }}"
+    policy: >-
+      {{
+        _hetzner_object_storage_cac_bucket_policy
+        if hetzner_object_storage_cac_external_principals | length > 0
+        else omit
+      }}
     validate_certs: "{{ hetzner_object_storage_cac_validate_certs }}"
   register: _hetzner_object_storage_cac_bucket_result
   delegate_to: "{{ hetzner_object_storage_cac_delegate_to }}"
@@ -50,5 +56,9 @@
       object_lock_mode: "{{ hetzner_object_storage_cac_object_lock_mode }}"
       object_lock_retention_days: "{{ hetzner_object_storage_cac_object_lock_retention_days | int }}"
       prefix: "{{ hetzner_object_storage_cac_prefix }}"
+      principal_profiles: >-
+        {{ hetzner_object_storage_cac_external_principals | map(attribute='profile') | unique | sort | list }}
+      policy_sha256: >-
+        {{ _hetzner_object_storage_cac_bucket_policy | to_json | hash('sha256') }}
       region: "{{ hetzner_object_storage_cac_region }}"
       versioning: "{{ hetzner_object_storage_cac_versioning | bool }}"

--- a/roles/hetzner_object_storage_cac/vars/main.yml
+++ b/roles/hetzner_object_storage_cac/vars/main.yml
@@ -1,0 +1,31 @@
+---
+_hetzner_object_storage_cac_permission_profiles:
+  admin:
+    bucket_actions:
+      - s3:*
+    object_actions:
+      - s3:*
+  writer:
+    bucket_actions:
+      - s3:ListBucketMultipartUploads
+    object_actions:
+      - s3:AbortMultipartUpload
+      - s3:ListMultipartUploadParts
+      - s3:PutObject
+  reader:
+    bucket_actions:
+      - s3:GetBucketLocation
+      - s3:ListBucket
+      - s3:ListBucketVersions
+    object_actions:
+      - s3:GetObject
+      - s3:GetObjectVersion
+  reviewer:
+    bucket_actions:
+      - s3:GetBucketLocation
+      - s3:GetBucketObjectLockConfiguration
+      - s3:GetBucketVersioning
+      - s3:ListBucketVersions
+    object_actions:
+      - s3:GetObjectLegalHold
+      - s3:GetObjectRetention


### PR DESCRIPTION
Closes #567

## Summary

- stabilize the legacy Hetzner Object Storage CaC role with deterministic least-privilege profiles
- validate external principals, reject same-project access keys, and audit remote bucket-policy drift
- preserve the empty-principal compatibility path while documenting the lit.cloud migration contract
- add machine-readable migration metadata and Tiny positive/negative regression coverage

## Validation

- targeted Molecule scenario `hetzner-object-storage-tiny`: PASS
- `yamllint-ee`: PASS
- changelog policy: PASS
- `git diff --check`: PASS
- local Copilot review findings addressed: compatibility, literal ARN coverage, and remote-policy audit

## AI task profile

- Work item: #567 — stabilize Hetzner role and prepare migration to lit.cloud
- Complexity: high
- Risk: high (provider credentials, bucket policies, backward compatibility)
- Model: current Codex model plus focused local Copilot review
- Escalation: architecture/security findings or repeated required-gate failure
