### PR TITLE
fix(ci): require cross-repository evidence token

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -986,7 +986,7 @@ jobs:
         env:
           GH_TOKEN: >-
             ${{ (github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main') &&
-                (secrets.MODULIX_VALIDATION_READ_TOKEN || github.token) || '' }}
+                secrets.MODULIX_VALIDATION_READ_TOKEN || '' }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_REF: ${{ github.ref }}
           PR_BASE: ${{ github.event.pull_request.base.ref || '' }}

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -260,7 +260,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         evidence_step = jobs["evidence"]["steps"][0]
         token_guard = evidence_step["env"]["GH_TOKEN"]
         self.assertIn("secrets.MODULIX_VALIDATION_READ_TOKEN", token_guard)
-        self.assertIn("secrets.MODULIX_VALIDATION_READ_TOKEN || github.token", token_guard)
+        self.assertNotIn("github.token", token_guard)
         self.assertIn("pull_request.base.ref == 'main'", token_guard)
         self.assertIn('test -n "$GH_TOKEN"', evidence_step["run"])
         self.assertIn("per_page=100", evidence_step["run"])


### PR DESCRIPTION
Fail-closed MLX-90 follow-up. Removes the repository-scoped github.token fallback for cross-repository ModuLix validation artifacts and requires the protected explicit read token. Includes a regression assertion.\n\nAddresses the security review finding on #575.