### PR TITLE
fix(ci): validate safe fast-lane path prefixes

### DIFF
--- a/scripts/select-quality-impact.py
+++ b/scripts/select-quality-impact.py
@@ -16,7 +16,6 @@ from typing import TypedDict
 
 import yaml
 
-
 ZERO_SHA = "0" * 40
 SHA = re.compile(r"^[0-9a-f]{40}$")
 PROFILES = {"tiny", "heavy", "application_acceptance"}
@@ -80,6 +79,17 @@ def _registry(path: str) -> tuple[dict[str, FamilyPolicy], list[str]]:
         raise ValueError("quality impact registry must declare at least one family")
     if not isinstance(safe_prefixes, list) or not all(isinstance(item, str) for item in safe_prefixes):
         raise ValueError("quality impact registry must declare safe Fast-Lane path prefixes")
+    for prefix in safe_prefixes:
+        path = PurePosixPath(prefix)
+        if (
+            prefix != prefix.strip()
+            or not prefix
+            or prefix == "."
+            or path.is_absolute()
+            or ".." in path.parts
+            or "\0" in prefix
+        ):
+            raise ValueError(f"unsafe safe Fast-Lane path prefix: {prefix!r}")
     normalized: dict[str, FamilyPolicy] = {}
     for name, policy in families.items():
         if not isinstance(name, str) or not isinstance(policy, dict):

--- a/scripts/select-quality-impact.py
+++ b/scripts/select-quality-impact.py
@@ -80,14 +80,15 @@ def _registry(path: str) -> tuple[dict[str, FamilyPolicy], list[str]]:
     if not isinstance(safe_prefixes, list) or not all(isinstance(item, str) for item in safe_prefixes):
         raise ValueError("quality impact registry must declare safe Fast-Lane path prefixes")
     for prefix in safe_prefixes:
-        path = PurePosixPath(prefix)
+        if "\0" in prefix:
+            raise ValueError(f"unsafe safe Fast-Lane path prefix: {prefix!r}")
+        prefix_path = PurePosixPath(prefix)
         if (
             prefix != prefix.strip()
             or not prefix
             or prefix == "."
-            or path.is_absolute()
-            or ".." in path.parts
-            or "\0" in prefix
+            or prefix_path.is_absolute()
+            or ".." in prefix_path.parts
         ):
             raise ValueError(f"unsafe safe Fast-Lane path prefix: {prefix!r}")
     normalized: dict[str, FamilyPolicy] = {}

--- a/tests/unit/test_select_quality_impact.py
+++ b/tests/unit/test_select_quality_impact.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -240,14 +241,14 @@ families:
             SELECTOR.select(arguments(registry=temporary.name, changed_file=["roles/invalid/tasks/main.yml"]))
 
     def test_registry_rejects_unsafe_safe_fast_lane_prefixes(self) -> None:
-        for prefix in ("", ".", "/", "../", "docs/../", " docs/"):
+        for prefix in ("", ".", "/", "../", "docs/../", " docs/", "\0"):
             with self.subTest(prefix=prefix):
                 temporary = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False)
                 self.addCleanup(lambda path=temporary.name: Path(path).unlink(missing_ok=True))
                 temporary.write(
                     f"""---
 schema_version: 2
-safe_fast_lane_path_prefixes: [{prefix!r}]
+safe_fast_lane_path_prefixes: [{json.dumps(prefix)}]
 families:
   valid:
     profiles: [tiny]

--- a/tests/unit/test_select_quality_impact.py
+++ b/tests/unit/test_select_quality_impact.py
@@ -239,6 +239,26 @@ families:
         with self.assertRaisesRegex(ValueError, "requires heavy when it declares application_acceptance"):
             SELECTOR.select(arguments(registry=temporary.name, changed_file=["roles/invalid/tasks/main.yml"]))
 
+    def test_registry_rejects_unsafe_safe_fast_lane_prefixes(self) -> None:
+        for prefix in ("", ".", "/", "../", "docs/../", " docs/"):
+            with self.subTest(prefix=prefix):
+                temporary = tempfile.NamedTemporaryFile(mode="w", encoding="utf-8", delete=False)
+                self.addCleanup(lambda path=temporary.name: Path(path).unlink(missing_ok=True))
+                temporary.write(
+                    f"""---
+schema_version: 2
+safe_fast_lane_path_prefixes: [{prefix!r}]
+families:
+  valid:
+    profiles: [tiny]
+    path_prefixes: [roles/valid/]
+"""
+                )
+                temporary.close()
+
+                with self.assertRaisesRegex(ValueError, "unsafe safe Fast-Lane path prefix"):
+                    SELECTOR.select(arguments(registry=temporary.name, changed_file=["README.md"]))
+
     def test_unreadable_dependency_inventory_only_selects_tiny(self) -> None:
         result = SELECTOR.select(
             arguments(


### PR DESCRIPTION
Fail-closed MLX-90 follow-up. Rejects empty, dot, absolute, parent-traversing, NUL-containing, and whitespace-padded safe Fast-Lane prefixes before impact selection. Includes table-driven negative coverage.\n\nAddresses the security review finding on #575.