### PR TITLE
fix(ci): mint validation evidence token

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -984,6 +984,9 @@ jobs:
     steps:
       - name: Mint least-privilege validation evidence token
         id: validation-app
+        if: >-
+          github.ref == 'refs/heads/main' ||
+          github.event.pull_request.base.ref == 'main'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -984,9 +984,7 @@ jobs:
     steps:
       - name: Mint least-privilege validation evidence token
         id: validation-app
-        if: >-
-          github.ref == 'refs/heads/main' ||
-          github.event.pull_request.base.ref == 'main'
+        if: github.ref == 'refs/heads/main'
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
           client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
@@ -998,11 +996,10 @@ jobs:
       - name: Enforce exact-SHA evidence for every authorized runtime
         env:
           GH_TOKEN: >-
-            ${{ (github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main') &&
-                steps.validation-app.outputs.token || '' }}
+            ${{ github.ref == 'refs/heads/main' &&
+            steps.validation-app.outputs.token || '' }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_REF: ${{ github.ref }}
-          PR_BASE: ${{ github.event.pull_request.base.ref || '' }}
           SOURCE_SHA: ${{ env.SOURCE_SHA }}
           LINT_RESULT: ${{ needs.lint-sanity.result }}
           BUILD_RESULT: ${{ needs.build-install.result }}
@@ -1026,7 +1023,7 @@ jobs:
             esac
           fi
           requires_central=false
-          if [ "$EVENT_REF" = refs/heads/main ] || [ "$PR_BASE" = main ]; then
+          if [ "$EVENT_REF" = refs/heads/main ]; then
             requires_central=true
           fi
           if [ "$requires_central" = true ]; then

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -982,11 +982,21 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Mint least-privilege validation evidence token
+        id: validation-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: modulix-validation
+          permission-actions: read
+
       - name: Enforce exact-SHA evidence for every authorized runtime
         env:
           GH_TOKEN: >-
             ${{ (github.ref == 'refs/heads/main' || github.event.pull_request.base.ref == 'main') &&
-                secrets.MODULIX_VALIDATION_READ_TOKEN || '' }}
+                steps.validation-app.outputs.token || '' }}
           EVENT_NAME: ${{ github.event_name }}
           EVENT_REF: ${{ github.ref }}
           PR_BASE: ${{ github.event.pull_request.base.ref || '' }}

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -268,8 +268,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         evidence_step = next(
             step
             for step in jobs["evidence"]["steps"]
-            if step["name"]
-            == "Enforce exact-SHA evidence for every authorized runtime"
+            if step["name"] == "Enforce exact-SHA evidence for every authorized runtime"
         )
         self.assertIn("supplementary-validation-evidence-", evidence_step["run"])
         token_guard = evidence_step["env"]["GH_TOKEN"]

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -256,11 +256,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertEqual("${{ github.event_name == 'workflow_call' }}", release_security["if"])
         self.assertEqual("Collection / Release Evidence", jobs["evidence"]["name"])
         self.assertEqual("ansible-collection-runtime-tests", jobs["evidence"]["environment"])
-        token_step = next(
-            step
-            for step in jobs["evidence"]["steps"]
-            if step.get("id") == "validation-app"
-        )
+        token_step = next(step for step in jobs["evidence"]["steps"] if step.get("id") == "validation-app")
         self.assertEqual("modulix-validation", token_step["with"]["repositories"])
         self.assertEqual("read", token_step["with"]["permission-actions"])
         self.assertIn("github.ref == 'refs/heads/main'", token_step["if"])

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -256,10 +256,14 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertEqual("${{ github.event_name == 'workflow_call' }}", release_security["if"])
         self.assertEqual("Collection / Release Evidence", jobs["evidence"]["name"])
         self.assertEqual("ansible-collection-runtime-tests", jobs["evidence"]["environment"])
-        self.assertIn("supplementary-validation-evidence-", jobs["evidence"]["steps"][0]["run"])
-        evidence_step = jobs["evidence"]["steps"][0]
+        token_step = jobs["evidence"]["steps"][0]
+        self.assertEqual("modulix-validation", token_step["with"]["repositories"])
+        self.assertEqual("read", token_step["with"]["permission-actions"])
+        evidence_step = jobs["evidence"]["steps"][1]
+        self.assertIn("supplementary-validation-evidence-", evidence_step["run"])
         token_guard = evidence_step["env"]["GH_TOKEN"]
-        self.assertIn("secrets.MODULIX_VALIDATION_READ_TOKEN", token_guard)
+        self.assertIn("steps.validation-app.outputs.token", token_guard)
+        self.assertNotIn("MODULIX_VALIDATION_READ_TOKEN", token_guard)
         self.assertNotIn("github.token", token_guard)
         self.assertIn("pull_request.base.ref == 'main'", token_guard)
         self.assertIn('test -n "$GH_TOKEN"', evidence_step["run"])

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -256,10 +256,21 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertEqual("${{ github.event_name == 'workflow_call' }}", release_security["if"])
         self.assertEqual("Collection / Release Evidence", jobs["evidence"]["name"])
         self.assertEqual("ansible-collection-runtime-tests", jobs["evidence"]["environment"])
-        token_step = jobs["evidence"]["steps"][0]
+        token_step = next(
+            step
+            for step in jobs["evidence"]["steps"]
+            if step.get("id") == "validation-app"
+        )
         self.assertEqual("modulix-validation", token_step["with"]["repositories"])
         self.assertEqual("read", token_step["with"]["permission-actions"])
-        evidence_step = jobs["evidence"]["steps"][1]
+        self.assertIn("github.ref == 'refs/heads/main'", token_step["if"])
+        self.assertIn("pull_request.base.ref == 'main'", token_step["if"])
+        evidence_step = next(
+            step
+            for step in jobs["evidence"]["steps"]
+            if step["name"]
+            == "Enforce exact-SHA evidence for every authorized runtime"
+        )
         self.assertIn("supplementary-validation-evidence-", evidence_step["run"])
         token_guard = evidence_step["env"]["GH_TOKEN"]
         self.assertIn("steps.validation-app.outputs.token", token_guard)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -264,7 +264,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertEqual("modulix-validation", token_step["with"]["repositories"])
         self.assertEqual("read", token_step["with"]["permission-actions"])
         self.assertIn("github.ref == 'refs/heads/main'", token_step["if"])
-        self.assertIn("pull_request.base.ref == 'main'", token_step["if"])
+        self.assertNotIn("pull_request", token_step["if"])
         evidence_step = next(
             step
             for step in jobs["evidence"]["steps"]
@@ -276,7 +276,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("steps.validation-app.outputs.token", token_guard)
         self.assertNotIn("MODULIX_VALIDATION_READ_TOKEN", token_guard)
         self.assertNotIn("github.token", token_guard)
-        self.assertIn("pull_request.base.ref == 'main'", token_guard)
+        self.assertNotIn("pull_request", token_guard)
         self.assertIn('test -n "$GH_TOKEN"', evidence_step["run"])
         self.assertIn("per_page=100", evidence_step["run"])
         self.assertIn('ZipFile("evidence.zip")', evidence_step["run"])


### PR DESCRIPTION
## Summary

- mint a repository-scoped Release Automation App token for central validation evidence
- grant only Actions read access to `modulix-validation`
- remove the undeclared long-lived `MODULIX_VALIDATION_READ_TOKEN` dependency
- cover the token scope and source with a workflow security regression test

## Validation

- `python3 -m unittest tests.unit.test_workflow_security.WorkflowSecurityTests.test_release_credentials_are_outside_pull_request_jobs`

Follow-up for #567.