### PR TITLE
fix(ci): pin transition controller to main

### DIFF
--- a/changelogs/fragments/586-transition-controller-main.yml
+++ b/changelogs/fragments/586-transition-controller-main.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    Dispatch transitional release validation to the stable
+    modulix-validation main workflow by default.

--- a/scripts/dispatch-transition-validation.py
+++ b/scripts/dispatch-transition-validation.py
@@ -38,7 +38,7 @@ def main() -> int:
     parser.add_argument("--version", required=True)
     parser.add_argument("--artifact-name", required=True)
     parser.add_argument("--artifact-sha256", required=True)
-    parser.add_argument("--ref", default="develop")
+    parser.add_argument("--ref", default="main")
     args = parser.parse_args()
 
     repository = validated(args.source_repository, REPOSITORY_RE, "source repository")

--- a/scripts/dispatch-transition-validation.py
+++ b/scripts/dispatch-transition-validation.py
@@ -16,6 +16,7 @@ DIGEST_RE = re.compile(r"[0-9a-f]{64}\Z")
 VERSION_RE = re.compile(
     r"[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\Z"
 )
+REF_RE = re.compile(r"[0-9A-Za-z][0-9A-Za-z._/-]*\Z")
 ARTIFACT_RE = re.compile(
     r"[a-z0-9_]+-[a-z0-9_]+-[0-9A-Za-z.-]+\.tar\.gz\Z"
 )
@@ -46,6 +47,7 @@ def main() -> int:
     version = validated(args.version, VERSION_RE, "version")
     artifact_name = validated(args.artifact_name, ARTIFACT_RE, "artifact name")
     artifact_sha256 = validated(args.artifact_sha256, DIGEST_RE, "artifact SHA-256")
+    controller_ref = validated(args.ref, REF_RE, "controller ref")
     if PurePath(artifact_name).name != artifact_name or not artifact_name.endswith(
         f"-{version}.tar.gz"
     ):
@@ -60,7 +62,7 @@ def main() -> int:
         "POST",
         WORKFLOW_ENDPOINT,
         "-f",
-        f"ref={args.ref}",
+        f"ref={controller_ref}",
         "-f",
         f"inputs[source_repository]={repository}",
         "-f",

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -705,6 +705,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("collection-release-transition.yml/dispatches", dispatcher)
         self.assertIn("inputs[artifact_sha256]", dispatcher)
         self.assertIn("inputs[artifact_name]", dispatcher)
+        self.assertIn('default="main"', dispatcher)
         self.assertIn(
             r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\Z",
             dispatcher,

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -705,7 +705,14 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("collection-release-transition.yml/dispatches", dispatcher)
         self.assertIn("inputs[artifact_sha256]", dispatcher)
         self.assertIn("inputs[artifact_name]", dispatcher)
-        self.assertIn('default="main"', dispatcher)
+        self.assertRegex(
+            dispatcher,
+            r'add_argument\("--ref", default="main"\)',
+        )
+        self.assertIn(
+            'controller_ref = validated(args.ref, REF_RE, "controller ref")',
+            dispatcher,
+        )
         self.assertIn(
             r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?\Z",
             dispatcher,


### PR DESCRIPTION
## Summary

- dispatch transition validation to modulix-validation@main by default
- retain an explicit ref override for controlled diagnostics
- guard the stable default with a workflow security unit test

Addresses the final operational review on promotion PR #586 and tracks #554 / LI-118.