### PR TITLE
fix(ci): pin transition controller at call site

### DIFF
--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -1182,7 +1182,8 @@ jobs:
             --source-sha "$RELEASE_SHA" \
             --version "$RELEASE_VERSION" \
             --artifact-name "$CANDIDATE_NAME" \
-            --artifact-sha256 "$candidate_sha"
+            --artifact-sha256 "$candidate_sha" \
+            --ref main
 
       - name: Verify GitHub Release download, install, and smoke
         env:

--- a/changelogs/fragments/586-explicit-transition-controller.yml
+++ b/changelogs/fragments/586-explicit-transition-controller.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Pin the central transition workflow to its protected main revision at the release call site.

--- a/changelogs/fragments/586-explicit-transition-controller.yml
+++ b/changelogs/fragments/586-explicit-transition-controller.yml
@@ -1,2 +1,3 @@
+---
 bugfixes:
   - Pin the central transition workflow to its protected main revision at the release call site.

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -695,9 +695,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         workflow = (WORKFLOWS / "collection-publish.yml").read_text(encoding="utf-8")
         publish_steps = yaml.safe_load(workflow)["jobs"]["publish"]["steps"]
         step_names = [step.get("name") for step in publish_steps]
-        publish_index = step_names.index(
-            "Publish or verify exact artifact on Ansible Galaxy"
-        )
+        publish_index = step_names.index("Publish or verify exact artifact on Ansible Galaxy")
         dispatch_index = step_names.index("Dispatch transitional central validation")
         self.assertGreater(dispatch_index, publish_index)
         self.assertIn("RELEASE_AUTOMATION_APP_CLIENT_ID", workflow)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -693,14 +693,19 @@ class WorkflowSecurityTests(unittest.TestCase):
 
     def test_publish_dispatches_transition_validation_after_galaxy(self) -> None:
         workflow = (WORKFLOWS / "collection-publish.yml").read_text(encoding="utf-8")
-        publish_index = workflow.index("Publish or verify exact artifact on Ansible Galaxy")
-        dispatch_index = workflow.index("Dispatch transitional central validation")
+        publish_steps = yaml.safe_load(workflow)["jobs"]["publish"]["steps"]
+        step_names = [step.get("name") for step in publish_steps]
+        publish_index = step_names.index(
+            "Publish or verify exact artifact on Ansible Galaxy"
+        )
+        dispatch_index = step_names.index("Dispatch transitional central validation")
         self.assertGreater(dispatch_index, publish_index)
         self.assertIn("RELEASE_AUTOMATION_APP_CLIENT_ID", workflow)
         self.assertIn("RELEASE_AUTOMATION_APP_PRIVATE_KEY", workflow)
         self.assertIn("permission-actions: write", workflow)
         self.assertIn("steps.transition-app.outputs.token", workflow)
         self.assertIn("scripts/dispatch-transition-validation.py", workflow)
+        self.assertIn("--ref main", workflow)
         dispatcher = (ROOT / "scripts/dispatch-transition-validation.py").read_text(encoding="utf-8")
         self.assertIn("collection-release-transition.yml/dispatches", dispatcher)
         self.assertIn("inputs[artifact_sha256]", dispatcher)


### PR DESCRIPTION
Addresses the remaining promotion review findings. The release workflow now passes --ref main explicitly, and the ordering test parses the publish job structure instead of searching raw YAML text. The canonical Shared Assets source is being updated in parallel. Local syntax and diff checks pass; the complete repository profile remains enforced by CI.