### PR TITLE
fix(ci): isolate release evidence from runtime gate

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -976,7 +976,6 @@ jobs:
     needs:
       [lint-sanity, build-install, role-coverage, quality-matrix, tiny]
     runs-on: ubuntu-latest
-    environment: ansible-collection-runtime-tests
     timeout-minutes: 10
     permissions:
       actions: read

--- a/changelogs/fragments/589-release-evidence-environment.yml
+++ b/changelogs/fragments/589-release-evidence-environment.yml
@@ -1,5 +1,6 @@
 ---
 bugfixes:
   - >-
-    Keep release-evidence assembly outside the managed runtime-test
-    environment so only Tiny runtime jobs require that approval gate.
+    Keep release-evidence assembly outside the managed
+    ansible-collection-runtime-tests environment so only Tiny runtime jobs
+    require that approval gate.

--- a/changelogs/fragments/589-release-evidence-environment.yml
+++ b/changelogs/fragments/589-release-evidence-environment.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    Keep release-evidence assembly outside the managed runtime-test
+    environment so only Tiny runtime jobs require that approval gate.

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -255,7 +255,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         release_security = jobs["release-security"]
         self.assertEqual("${{ github.event_name == 'workflow_call' }}", release_security["if"])
         self.assertEqual("Collection / Release Evidence", jobs["evidence"]["name"])
-        self.assertEqual("ansible-collection-runtime-tests", jobs["evidence"]["environment"])
+        self.assertNotIn("environment", jobs["evidence"])
         token_step = next(step for step in jobs["evidence"]["steps"] if step.get("id") == "validation-app")
         self.assertEqual("modulix-validation", token_step["with"]["repositories"])
         self.assertEqual("read", token_step["with"]["permission-actions"])


### PR DESCRIPTION
Removes the managed runtime environment from the release-evidence assembler. Only Tiny runtime jobs retain the protected runtime approval, matching the final collection governance contract. Updates the structural regression test and changelog.