### PR TITLE
fix(test): keep collection light gates rootless

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,7 @@
 ---
+default_language_version:
+  python: python3.12
+
 repos:
   # >>> BEGIN shared-assets-lit pre-commit
   - repo: local

--- a/changelogs/fragments/mlx90-optional-tiny-result.yml
+++ b/changelogs/fragments/mlx90-optional-tiny-result.yml
@@ -13,7 +13,3 @@ bugfixes:
   - >-
     Keep protected-main release evidence bound to the exact local candidate while central Heavy and Application
     Acceptance validation remains asynchronous and therefore does not block publication from the source repository.
-  - >-
-    Run repository-local pre-commit Python hooks with Python 3.12 so the pinned mypy toolchain remains installable.
-  - >-
-    Keep local Molecule and unit-test harnesses portable across numeric container users and macOS temporary paths.

--- a/changelogs/fragments/mlx90-optional-tiny-result.yml
+++ b/changelogs/fragments/mlx90-optional-tiny-result.yml
@@ -10,3 +10,10 @@ bugfixes:
   - >-
     Synchronize the centrally managed quality-policy validator so current policy lint passes without weakening
     boolean or integer validation.
+  - >-
+    Keep protected-main release evidence bound to the exact local candidate while central Heavy and Application
+    Acceptance validation remains asynchronous and therefore does not block publication from the source repository.
+  - >-
+    Run repository-local pre-commit Python hooks with Python 3.12 so the pinned mypy toolchain remains installable.
+  - >-
+    Keep local Molecule and unit-test harnesses portable across numeric container users and macOS temporary paths.

--- a/changelogs/fragments/rootless-light-gates.yml
+++ b/changelogs/fragments/rootless-light-gates.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Run repository-local pre-commit Python hooks with Python 3.12 so the pinned mypy toolchain remains installable.
+  - >-
+    Keep local Molecule and unit-test harnesses portable across numeric container users and macOS temporary paths.

--- a/molecule/aap-tls-basic/converge.yml
+++ b/molecule/aap-tls-basic/converge.yml
@@ -9,6 +9,9 @@
     aap_tls_selfsigned_delegate_to: localhost
     aap_tls_selfsigned_output_dir: "{{ aap_tls_molecule_root }}/generated"
     aap_tls_selfsigned_ca_trust_path: "{{ aap_tls_molecule_root }}/trust/aap-selfsigned-ca.crt"
+    aap_tls_selfsigned_ca_trust_owner: "{{ lookup('pipe', 'id -u') }}"
+    aap_tls_selfsigned_ca_trust_group: "{{ lookup('pipe', 'id -g') }}"
+    aap_tls_selfsigned_ca_trust_become: false
     aap_tls_selfsigned_common_name: localhost
     aap_tls_selfsigned_dns_names:
       - localhost

--- a/molecule/artifacts-basic/converge.yml
+++ b/molecule/artifacts-basic/converge.yml
@@ -25,8 +25,8 @@
   roles:
     - role: lit.supplementary.artifacts
       vars:
-        artifacts_default_owner: "{{ lookup('ansible.builtin.pipe', 'id -un') }}"
-        artifacts_default_group: "{{ lookup('ansible.builtin.pipe', 'id -gn') }}"
+        artifacts_default_owner: "{{ lookup('ansible.builtin.pipe', 'id -u') }}"
+        artifacts_default_group: "{{ lookup('ansible.builtin.pipe', 'id -g') }}"
         artifacts_items:
           - name: molecule-local-artifact
             source: local

--- a/molecule/cloudflare-warp-basic/converge.yml
+++ b/molecule/cloudflare-warp-basic/converge.yml
@@ -11,6 +11,8 @@
     cloudflare_warp_connection_state: ignore
     cloudflare_warp_mdm_path: >-
       {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/cloudflare-warp/mdm.xml
+    cloudflare_warp_mdm_owner: "{{ lookup('pipe', 'id -u') }}"
+    cloudflare_warp_mdm_group: "{{ lookup('pipe', 'id -g') }}"
     cloudflare_warp_organization: molecule-test-team
     cloudflare_warp_auth_client_id: molecule-auth-client-id
     cloudflare_warp_auth_client_secret: molecule-placeholder-not-a-real-secret

--- a/molecule/cloudflare-warp-basic/verify.yml
+++ b/molecule/cloudflare-warp-basic/verify.yml
@@ -6,6 +6,8 @@
   vars:
     cloudflare_warp_mdm_path: >-
       {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/cloudflare-warp/mdm.xml
+    cloudflare_warp_expected_uid: "{{ lookup('pipe', 'id -u') | int }}"
+    cloudflare_warp_expected_gid: "{{ lookup('pipe', 'id -g') | int }}"
   tasks:
     - name: Inspect rendered Cloudflare WARP MDM profile
       ansible.builtin.stat:
@@ -29,6 +31,12 @@
           - cloudflare_warp_mdm_stat.stat.isreg | default(false)
           - not (cloudflare_warp_mdm_stat.stat.islnk | default(false))
           - cloudflare_warp_mdm_stat.stat.mode == '0600'
+          - >-
+            (cloudflare_warp_mdm_stat.stat.uid | int)
+            == (cloudflare_warp_expected_uid | int)
+          - >-
+            (cloudflare_warp_mdm_stat.stat.gid | int)
+            == (cloudflare_warp_expected_gid | int)
           - cloudflare_warp_mdm_stat.stat.checksum is match('^[0-9a-f]{64}$')
           - >-
             (cloudflare_warp_mdm_content.content | b64decode)

--- a/molecule/vault-bootstrap-basic/converge.yml
+++ b/molecule/vault-bootstrap-basic/converge.yml
@@ -26,6 +26,8 @@
       {{ vault_bootstrap_molecule_controller_root }}/scoped-ca.pem
     vault_bootstrap_molecule_scoped_document: >-
       {{ vault_bootstrap_molecule_controller_dir }}/scoped-approle.vault.yml
+    vault_bootstrap_target_escrow_owner: "{{ lookup('pipe', 'id -u') }}"
+    vault_bootstrap_target_escrow_group: "{{ lookup('pipe', 'id -g') }}"
   tasks:
     - name: Normalize canonical persisted init payload
       ansible.builtin.include_role:

--- a/molecule/vault-raft-snapshot-basic/converge.yml
+++ b/molecule/vault-raft-snapshot-basic/converge.yml
@@ -62,8 +62,10 @@
     # This scenario exercises the role locally inside the capability-minimized
     # devtools container. Keep its fake runtime directories owned by the
     # invoking container user; production targets retain the role defaults.
-    vault_raft_snapshot_restore_run_as_user: 0
-    vault_raft_snapshot_restore_run_as_group: 0
+    vault_raft_snapshot_restore_work_root_owner: "{{ lookup('pipe', 'id -u') }}"
+    vault_raft_snapshot_restore_work_root_group: "{{ lookup('pipe', 'id -g') }}"
+    vault_raft_snapshot_restore_run_as_user: "{{ lookup('pipe', 'id -u') }}"
+    vault_raft_snapshot_restore_run_as_group: "{{ lookup('pipe', 'id -g') }}"
     vault_raft_snapshot_production_cert_dir: "{{ vault_raft_snapshot_molecule_root }}"
     vault_raft_snapshot_restore_node_id: molecule-restore
     vault_raft_snapshot_restore_unseal_keys:

--- a/roles/aap_tls/defaults/main.yml
+++ b/roles/aap_tls/defaults/main.yml
@@ -18,3 +18,6 @@ aap_tls_selfsigned_key_size: 4096
 aap_tls_selfsigned_force: false
 aap_tls_selfsigned_install_ca_trust: true
 aap_tls_selfsigned_ca_trust_path: /etc/pki/ca-trust/source/anchors/aap-selfsigned-ca.crt
+aap_tls_selfsigned_ca_trust_owner: root
+aap_tls_selfsigned_ca_trust_group: root
+aap_tls_selfsigned_ca_trust_become: true

--- a/roles/aap_tls/handlers/main.yml
+++ b/roles/aap_tls/handlers/main.yml
@@ -2,5 +2,5 @@
 - name: Refresh system CA trust after installing temporary AAP CA
   ansible.builtin.command:
     cmd: update-ca-trust extract
-  become: true
+  become: "{{ aap_tls_selfsigned_ca_trust_become | bool }}"
   changed_when: true

--- a/roles/aap_tls/tasks/main.yml
+++ b/roles/aap_tls/tasks/main.yml
@@ -178,10 +178,10 @@
   ansible.builtin.copy:
     content: "{{ aap_tls_selfsigned_ca_content.content | b64decode }}"
     dest: "{{ aap_tls_selfsigned_ca_trust_path }}"
-    owner: root
-    group: root
+    owner: "{{ aap_tls_selfsigned_ca_trust_owner }}"
+    group: "{{ aap_tls_selfsigned_ca_trust_group }}"
     mode: "0644"
-  become: true
+  become: "{{ aap_tls_selfsigned_ca_trust_become | bool }}"
   notify: Refresh system CA trust after installing temporary AAP CA
   when:
     - aap_tls_selfsigned_enabled | bool

--- a/roles/vault_bootstrap/defaults/main.yml
+++ b/roles/vault_bootstrap/defaults/main.yml
@@ -42,6 +42,8 @@ vault_bootstrap_init_file_path: >-
 vault_bootstrap_require_controller_escrow: false
 vault_bootstrap_controller_escrow_root_path: ""
 vault_bootstrap_controller_init_file_path: ""
+vault_bootstrap_target_escrow_owner: 0
+vault_bootstrap_target_escrow_group: 0
 
 # Prefer the controller's existing password-file integration. The plaintext fallback
 # remains for compatibility with inventories that still provide vault_ansible_vault_pw.

--- a/roles/vault_bootstrap/tasks/controller_escrow_sync.yml
+++ b/roles/vault_bootstrap/tasks/controller_escrow_sync.yml
@@ -15,8 +15,12 @@
     that:
       - vault_bootstrap_target_persist_dir_stat.stat.isdir | default(false)
       - not (vault_bootstrap_target_persist_dir_stat.stat.islnk | default(false))
-      - vault_bootstrap_target_persist_dir_stat.stat.uid | default(-1) | int == 0
-      - vault_bootstrap_target_persist_dir_stat.stat.gid | default(-1) | int == 0
+      - >-
+        vault_bootstrap_target_persist_dir_stat.stat.uid | default(-1) | int
+        == vault_bootstrap_target_escrow_owner | int
+      - >-
+        vault_bootstrap_target_persist_dir_stat.stat.gid | default(-1) | int
+        == vault_bootstrap_target_escrow_group | int
       - vault_bootstrap_target_persist_dir_stat.stat.mode | default('') == '0700'
     fail_msg: "The existing target secondary escrow directory has unsafe metadata."
     quiet: true
@@ -27,8 +31,8 @@
   ansible.builtin.file:
     path: "{{ vault_bootstrap_persist_dir }}"
     state: directory
-    owner: root
-    group: root
+    owner: "{{ vault_bootstrap_target_escrow_owner }}"
+    group: "{{ vault_bootstrap_target_escrow_group }}"
     mode: "0700"
   when: not (vault_bootstrap_target_persist_dir_stat.stat.exists | default(false))
   no_log: true
@@ -49,8 +53,12 @@
     that:
       - vault_bootstrap_target_init_file_stat.stat.isreg | default(false)
       - not (vault_bootstrap_target_init_file_stat.stat.islnk | default(false))
-      - vault_bootstrap_target_init_file_stat.stat.uid | default(-1) | int == 0
-      - vault_bootstrap_target_init_file_stat.stat.gid | default(-1) | int == 0
+      - >-
+        vault_bootstrap_target_init_file_stat.stat.uid | default(-1) | int
+        == vault_bootstrap_target_escrow_owner | int
+      - >-
+        vault_bootstrap_target_init_file_stat.stat.gid | default(-1) | int
+        == vault_bootstrap_target_escrow_group | int
       - vault_bootstrap_target_init_file_stat.stat.mode | default('') == '0600'
       - vault_bootstrap_target_init_file_stat.stat.nlink | default(0) | int == 1
       - vault_bootstrap_target_init_file_stat.stat.size | default(0) | int > 0
@@ -65,8 +73,8 @@
   ansible.builtin.copy:
     src: "{{ vault_bootstrap_controller_init_file_path }}"
     dest: "{{ vault_bootstrap_init_file_path }}"
-    owner: root
-    group: root
+    owner: "{{ vault_bootstrap_target_escrow_owner }}"
+    group: "{{ vault_bootstrap_target_escrow_group }}"
     mode: "0600"
     force: false
     decrypt: false
@@ -91,8 +99,12 @@
       - vault_bootstrap_target_init_file_verified.stat.exists | default(false)
       - vault_bootstrap_target_init_file_verified.stat.isreg | default(false)
       - not (vault_bootstrap_target_init_file_verified.stat.islnk | default(false))
-      - vault_bootstrap_target_init_file_verified.stat.uid | default(-1) | int == 0
-      - vault_bootstrap_target_init_file_verified.stat.gid | default(-1) | int == 0
+      - >-
+        vault_bootstrap_target_init_file_verified.stat.uid | default(-1) | int
+        == vault_bootstrap_target_escrow_owner | int
+      - >-
+        vault_bootstrap_target_init_file_verified.stat.gid | default(-1) | int
+        == vault_bootstrap_target_escrow_group | int
       - vault_bootstrap_target_init_file_verified.stat.mode | default('') == '0600'
       - vault_bootstrap_target_init_file_verified.stat.nlink | default(0) | int == 1
       - >-

--- a/roles/vault_raft_snapshot/defaults/main.yml
+++ b/roles/vault_raft_snapshot/defaults/main.yml
@@ -29,6 +29,8 @@ vault_raft_snapshot_restore_tls_hostname: localhost
 vault_raft_snapshot_restore_api_port: 18201
 vault_raft_snapshot_restore_cluster_port: 18202
 vault_raft_snapshot_restore_work_root: /run/lit-vault-restore-drill
+vault_raft_snapshot_restore_work_root_owner: root
+vault_raft_snapshot_restore_work_root_group: root
 vault_raft_snapshot_restore_container_name: vault-restore-drill
 vault_raft_snapshot_restore_node_id: ""
 vault_raft_snapshot_restore_run_as_user: 100

--- a/roles/vault_raft_snapshot/tasks/restore_drill.yml
+++ b/roles/vault_raft_snapshot/tasks/restore_drill.yml
@@ -148,8 +148,8 @@
     mode: "{{ item.mode }}"
   loop:
     - path: "{{ vault_raft_snapshot_restore_work_root }}"
-      owner: root
-      group: root
+      owner: "{{ vault_raft_snapshot_restore_work_root_owner }}"
+      group: "{{ vault_raft_snapshot_restore_work_root_group }}"
       mode: "0700"
     - path: "{{ vault_raft_snapshot_restore_work_root }}/data"
       owner: "{{ vault_raft_snapshot_restore_run_as_user }}"

--- a/tests/unit/test_security_release_evidence.py
+++ b/tests/unit/test_security_release_evidence.py
@@ -17,7 +17,10 @@ SCRIPT = ROOT / "scripts/generate-security-release-evidence.py"
 class ProducerEvidenceTests(unittest.TestCase):
     def test_evidence_binds_every_release_asset(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
+            # macOS exposes /var as a system symlink to /private/var. Resolve
+            # that trusted temporary root so the test still detects only
+            # symlink components created below its own boundary.
+            root = Path(tmp).resolve()
             files = {}
             for name in ("artifact", "signature", "sbom", "provenance"):
                 files[name] = root / name

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -659,7 +659,7 @@ class WorkflowSecurityTests(unittest.TestCase):
             )
 
             subprocess.run(  # noqa: S603 -- execute the repository-owned wrapper under test.
-                ["/usr/bin/bash", str(wrapper), "true"],
+                ["/bin/bash", str(wrapper), "true"],
                 cwd=ROOT,
                 env=environment,
                 check=True,


### PR DESCRIPTION
## Summary
- keep AAP TLS, Vault Raft snapshot, Vault bootstrap, artifacts, and Cloudflare WARP light scenarios runnable as the host UID/GID
- retain secure root-owned production defaults while parameterizing ownership only where required
- pin local pre-commit Python hooks to Python 3.12 and keep macOS-compatible test paths and Bash lookup
- add UID/GID regression assertions for Cloudflare WARP

## Validation
- pre-commit run --all-files: all code and repository gates passed; galaxy-verify was retried unchanged after a transient Galaxy API response and then passed
- full molecule-light suite: passed
- targeted cloudflare-warp-basic: converge, idempotence, and verify passed
- targeted aap-tls-basic, vault-raft-snapshot-basic, and vault-bootstrap-basic passed during diagnosis
- git diff --check: passed

Follow-up to #595: that PR was merged by automation while the final local full-suite run was still discovering these rootless portability defects.