### PR TITLE
feat(release): gate MLX-90 producer evidence

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -1637,6 +1637,7 @@ jobs:
           TINY_RESULT: ${{ needs.tiny.result }}
           HEAVY_RESULT: ${{ needs.heavy.result }}
           ACCEPTANCE_RESULT: ${{ needs.acceptance.result }}
+          RUNTIME_EVIDENCE_RESULT: ${{ needs.runtime-evidence.result }}
           EVIDENCE_RESULT: ${{ needs.evidence.result }}
           UPLOAD_OUTCOME: ${{ steps.release-security-upload.outcome }}
         run: |

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -465,7 +465,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       needs.quality-matrix.outputs.heavy_required == 'true'
     needs: [build-install, quality-matrix]
-    uses: lightning-it/modulix-validation/.github/workflows/collection-quality-profile.yml@ec110a9545dc6b8efe4ed8820b50b27912175111
+    uses: lightning-it/modulix-validation/.github/workflows/collection-quality-profile.yml@154c99eb0d907b01edc10e9b39c94ef4912fd9dd
     with:
       profile: heavy
       matrix-json: ${{ needs.quality-matrix.outputs.heavy }}
@@ -508,7 +508,7 @@ jobs:
     # group. Run acceptance only after the Heavy aggregate completes so the two
     # delegated profiles from this workflow cannot cancel each other.
     needs: [build-install, quality-matrix, heavy]
-    uses: lightning-it/modulix-validation/.github/workflows/collection-quality-profile.yml@ec110a9545dc6b8efe4ed8820b50b27912175111
+    uses: lightning-it/modulix-validation/.github/workflows/collection-quality-profile.yml@154c99eb0d907b01edc10e9b39c94ef4912fd9dd
     with:
       profile: application_acceptance
       matrix-json: ${{ needs.quality-matrix.outputs.acceptance }}

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -1277,6 +1277,7 @@ jobs:
               "tiny": os.environ["TINY_RESULT"] == "success",
               "heavy": os.environ["HEAVY_RESULT"] == "success",
               "application_acceptance": os.environ["ACCEPTANCE_RESULT"] == "success",
+              "runtime_evidence": os.environ["RUNTIME_EVIDENCE_RESULT"] == "success",
               "base_evidence_job": os.environ["EVIDENCE_RESULT"] == "success",
               "evidence_manifest_eligible": manifest.get("release_eligible") is True,
               "release_security_complete": not manifest.get("security_evidence", {}).get("missing"),

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -456,11 +456,14 @@ jobs:
           fi
 
   heavy-cells:
-    name: Delegation marker / Heavy (not executed in source repository)
-    # MLX-70: protected infrastructure validation is scheduled and owned by
-    # modulix-validation.  This collection must never start it from a PR,
-    # push, or local manual dispatch.
-    if: ${{ github.event_name == 'workflow_call' }}
+    name: Heavy matrix / central protected validation
+    # The central workflow runs inside this producer workflow run, against the
+    # exact protected-main candidate. It is never callable from a PR, develop,
+    # or a local manual dispatch path.
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.quality-matrix.outputs.heavy_required == 'true'
     needs: [build-install, quality-matrix]
     uses: lightning-it/modulix-validation/.github/workflows/collection-quality-profile.yml@ec110a9545dc6b8efe4ed8820b50b27912175111
     with:
@@ -468,15 +471,14 @@ jobs:
       matrix-json: ${{ needs.quality-matrix.outputs.heavy }}
       candidate-artifact: collection-candidate-${{ github.event.pull_request.head.sha || github.sha }}
       source-sha: ${{ github.event.pull_request.head.sha || github.sha }}
-      environment-name: >-
-        ${{ github.event_name == 'pull_request' &&
-            'ansible-collection-runtime-tests' ||
-            'ansible-collection-runtime-protected' }}
-    secrets: inherit
+      environment-name: ansible-collection-runtime-protected
 
   heavy:
-    name: Deprecated alias / Heavy (not executed)
-    if: ${{ github.event_name == 'workflow_call' }}
+    name: Collection / Heavy
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
     needs: [quality-matrix, heavy-cells]
     runs-on: ubuntu-latest
     steps:
@@ -495,9 +497,13 @@ jobs:
           fi
 
   acceptance-cells:
-    name: Delegation marker / Application Acceptance (not executed in source repository)
-    # See heavy-cells: Application Acceptance has the same central ownership.
-    if: ${{ github.event_name == 'workflow_call' }}
+    name: Application Acceptance matrix / central protected validation
+    # See heavy-cells: Application Acceptance has the same central ownership
+    # and the same exact protected-main boundary.
+    if: >-
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.quality-matrix.outputs.acceptance_required == 'true'
     # The reusable validation workflow has a repository-wide Incus concurrency
     # group. Run acceptance only after the Heavy aggregate completes so the two
     # delegated profiles from this workflow cannot cancel each other.
@@ -508,15 +514,14 @@ jobs:
       matrix-json: ${{ needs.quality-matrix.outputs.acceptance }}
       candidate-artifact: collection-candidate-${{ github.event.pull_request.head.sha || github.sha }}
       source-sha: ${{ github.event.pull_request.head.sha || github.sha }}
-      environment-name: >-
-        ${{ github.event_name == 'pull_request' &&
-            'ansible-collection-runtime-tests' ||
-            'ansible-collection-runtime-protected' }}
-    secrets: inherit
+      environment-name: ansible-collection-runtime-protected
 
   acceptance:
-    name: Deprecated alias / Application Acceptance (not executed)
-    if: ${{ github.event_name == 'workflow_call' }}
+    name: Collection / Application Acceptance
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
     needs: [quality-matrix, acceptance-cells]
     runs-on: ubuntu-latest
     steps:
@@ -535,7 +540,7 @@ jobs:
           fi
 
   runtime-evidence:
-    name: Deprecated adapter / Runtime evidence (not executed)
+    name: Runtime evidence / exact tested SHA
     env:
       # Do not expose this override to repository unit tests: they exercise
       # _tested_commit() with isolated process environments.
@@ -543,8 +548,13 @@ jobs:
       TINY_REQUIRED: ${{ needs.quality-matrix.outputs.tiny_required }}
       HEAVY_REQUIRED: ${{ needs.quality-matrix.outputs.heavy_required }}
       ACCEPTANCE_REQUIRED: ${{ needs.quality-matrix.outputs.acceptance_required }}
-    # The central controller publishes the trusted runtime evidence.
-    if: ${{ github.event_name == 'workflow_call' }}
+    # Aggregate only the same-run protected-main evidence. Central reusable
+    # jobs publish their artifacts into this caller workflow run.
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main' &&
+      needs.quality-matrix.outputs.runtime_evidence_required == 'true'
     needs: [lint-sanity, build-install, role-coverage, quality-matrix, tiny, heavy, acceptance]
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -1026,11 +1036,13 @@ jobs:
           fi
 
   release-security:
-    name: Deprecated adapter / Release Security (not executed)
-    # Publication remains blocked until the central evidence adapter replaces
-    # this source-repository release job.
-    if: ${{ github.event_name == 'workflow_call' }}
-    needs: [lint-sanity, build-install, role-coverage, tiny, heavy, acceptance, evidence]
+    name: Collection / Release Security
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
+    needs:
+      [lint-sanity, build-install, role-coverage, tiny, heavy, acceptance, runtime-evidence, evidence]
     runs-on: ubuntu-latest
     timeout-minutes: 60
     environment: ansible-collection-release-evidence
@@ -1220,6 +1232,7 @@ jobs:
           TINY_RESULT: ${{ needs.tiny.result }}
           HEAVY_RESULT: ${{ needs.heavy.result }}
           ACCEPTANCE_RESULT: ${{ needs.acceptance.result }}
+          RUNTIME_EVIDENCE_RESULT: ${{ needs.runtime-evidence.result }}
           EVIDENCE_RESULT: ${{ needs.evidence.result }}
           ARCHIVE_REQUIRED: ${{ steps.archive-policy.outputs.required }}
           ARCHIVE_CONFIGURED: ${{ steps.archive-policy.outputs.configured }}
@@ -1634,13 +1647,26 @@ jobs:
           test "$TINY_RESULT" = success
           test "$HEAVY_RESULT" = success
           test "$ACCEPTANCE_RESULT" = success
+          test "$RUNTIME_EVIDENCE_RESULT" = success
           test "$EVIDENCE_RESULT" = success
           test "$UPLOAD_OUTCOME" = success
   release-validation:
-    name: Deprecated adapter / Release Validation (not executed)
-    if: ${{ github.event_name == 'workflow_call' }}
+    name: Collection / Release Validation
+    if: >-
+      always() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
     needs:
-      [lint-sanity, build-install, role-coverage, quality-matrix, tiny, heavy, acceptance, evidence, release-security]
+      - lint-sanity
+      - build-install
+      - role-coverage
+      - quality-matrix
+      - tiny
+      - heavy
+      - acceptance
+      - runtime-evidence
+      - evidence
+      - release-security
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -1814,6 +1840,7 @@ jobs:
           TINY_RESULT: ${{ needs.tiny.result }}
           HEAVY_RESULT: ${{ needs.heavy.result }}
           ACCEPTANCE_RESULT: ${{ needs.acceptance.result }}
+          RUNTIME_EVIDENCE_RESULT: ${{ needs.runtime-evidence.result }}
           EVIDENCE_RESULT: ${{ needs.evidence.result }}
           RELEASE_SECURITY_RESULT: ${{ needs.release-security.result }}
           IS_PROTECTED_MAIN_PUSH: >-
@@ -1826,6 +1853,7 @@ jobs:
           test "$TINY_RESULT" = success
           test "$HEAVY_RESULT" = success
           test "$ACCEPTANCE_RESULT" = success
+          test "$RUNTIME_EVIDENCE_RESULT" = success
           test "$EVIDENCE_RESULT" = success
           if [ "$IS_PROTECTED_MAIN_PUSH" = true ]; then
             test "$RELEASE_SECURITY_RESULT" = success

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -904,10 +904,8 @@ jobs:
               --dir "$existing_pair"
             cmp --silent "$existing_pair/security-release-evidence.json" "$evidence"
             cp "$existing_pair/security-release-evidence.json.sigstore.json" "$bundle"
-            echo "attest_needed=false" >> "$GITHUB_OUTPUT"
           else
             cosign sign-blob --yes --bundle "$bundle" "$evidence"
-            echo "attest_needed=true" >> "$GITHUB_OUTPUT"
           fi
           publish_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/collection-publish.yml@refs/heads/main"
           cosign verify-blob \
@@ -919,9 +917,7 @@ jobs:
 
       - name: Attest Security release evidence
         id: attest-security-evidence
-        if: >-
-          env.SECURITY_RELEASE == 'true' &&
-          steps.security-evidence.outputs.attest_needed == 'true'
+        if: env.SECURITY_RELEASE == 'true'
         uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d  # v4
         with:
           subject-path: dist/release/security-release-evidence.json
@@ -931,14 +927,11 @@ jobs:
         env:
           ATTESTATION_BUNDLE: ${{ steps.attest-security-evidence.outputs.bundle-path }}
           ATTESTATION_ID: ${{ steps.attest-security-evidence.outputs.attestation-id }}
-          ATTEST_NEEDED: ${{ steps.security-evidence.outputs.attest_needed }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if [ "$ATTEST_NEEDED" = true ]; then
-            test -n "$ATTESTATION_ID"
-            test -s "$ATTESTATION_BUNDLE"
-          fi
+          test -n "$ATTESTATION_ID"
+          test -s "$ATTESTATION_BUNDLE"
           publish_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/collection-publish.yml@refs/heads/main"
           gh attestation verify dist/release/security-release-evidence.json \
             --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -1644,6 +1644,11 @@ jobs:
           set -euo pipefail
           test "$APP_SLUG" = lightning-it-release-automation
           test "$APP_INSTALLATION_ID" = 148019054
+          actual_repositories="$(gh api --paginate --slurp \
+            'installation/repositories?per_page=100' \
+            --jq '[.[].repositories[].full_name] | sort | unique')"
+          test "$actual_repositories" = \
+            '["lightning-it/container-ee-wunder-ansible-ubi9"]'
           evidence=dist/release/security-release-evidence.json
           python scripts/generate-security-release-evidence.py verify \
             --metadata "$SECURITY_METADATA" \

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -1644,9 +1644,10 @@ jobs:
           set -euo pipefail
           test "$APP_SLUG" = lightning-it-release-automation
           test "$APP_INSTALLATION_ID" = 148019054
-          actual_repositories="$(gh api --paginate --slurp \
-            'installation/repositories?per_page=100' \
-            --jq '[.[].repositories[].full_name] | sort | unique')"
+          actual_repositories="$(
+            gh api --paginate 'installation/repositories?per_page=100' \
+              | jq -sc '[.[].repositories[].full_name] | sort | unique'
+          )"
           test "$actual_repositories" = \
             '["lightning-it/container-ee-wunder-ansible-ubi9"]'
           evidence=dist/release/security-release-evidence.json

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -156,7 +156,7 @@ jobs:
       cancel-in-progress: false
     permissions:
       actions: write
-      attestations: read
+      attestations: write
       contents: write
       id-token: write
       pull-requests: read
@@ -659,6 +659,28 @@ jobs:
             sha256sum --check "collection-release-evidence-${RELEASE_SHA}.tar.gz.sha256"
           )
 
+      - name: Classify exact-SHA Security release metadata
+        run: |
+          set -euo pipefail
+          profiles=.lit/security-release-profiles.json
+          metadata=".lit/security-releases/${RELEASE_VERSION}.json"
+          test -s "$profiles"
+          test ! -L "$profiles"
+          if [ -L "$metadata" ]; then
+            echo "Security release metadata must not be a symlink: $metadata" >&2
+            exit 1
+          fi
+          if [ -e "$metadata" ]; then
+            test -f "$metadata"
+            test -s "$metadata"
+            echo "SECURITY_RELEASE=true" >> "$GITHUB_ENV"
+            echo "SECURITY_METADATA=$metadata" >> "$GITHUB_ENV"
+          else
+            echo "SECURITY_RELEASE=false" >> "$GITHUB_ENV"
+            echo "SECURITY_METADATA=" >> "$GITHUB_ENV"
+            echo "No exact-version Security metadata; retaining transition-only release semantics."
+          fi
+
       - name: Install exact candidate in a clean collection path
         run: |
           set -euo pipefail
@@ -680,6 +702,77 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+
+          CANDIDATE="incoming/candidate/${CANDIDATE_NAME}" python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          candidate = Path(os.environ["CANDIDATE"])
+          candidate_sha = hashlib.sha256(candidate.read_bytes()).hexdigest()
+          sbom = json.loads(
+              Path("incoming/evidence/release-assets/sbom.cdx.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          component = ((sbom.get("metadata") or {}).get("component") or {})
+          expected_component = {
+              "group": "lit",
+              "name": "supplementary",
+              "version": os.environ["RELEASE_VERSION"],
+          }
+          if any(component.get(key) != value for key, value in expected_component.items()):
+              raise SystemExit("SBOM component does not match the collection release")
+          if component.get("purl") != (
+              f"pkg:ansible/lit/supplementary@{os.environ['RELEASE_VERSION']}"
+          ):
+              raise SystemExit("SBOM purl does not match the collection release")
+          hashes = component.get("hashes")
+          if not isinstance(hashes, list) or not any(
+              isinstance(item, dict)
+              and item.get("alg") == "SHA-256"
+              and item.get("content") == candidate_sha
+              for item in hashes
+          ):
+              raise SystemExit("SBOM does not bind the exact collection digest")
+          properties = component.get("properties")
+          if not isinstance(properties, list):
+              raise SystemExit("SBOM candidate properties are missing")
+          actual_properties = {
+              (item.get("name"), item.get("value"))
+              for item in properties
+              if isinstance(item, dict)
+          }
+          expected_properties = {
+              ("lit:candidate:filename", candidate.name),
+              ("lit:candidate:commit", os.environ["RELEASE_SHA"]),
+          }
+          if not expected_properties <= actual_properties:
+              raise SystemExit("SBOM does not bind the candidate filename and source SHA")
+
+          provenance = json.loads(
+              Path("incoming/evidence/release-assets/provenance.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          expected_provenance = {
+              "schema_version": 1,
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "commit_sha": os.environ["RELEASE_SHA"],
+              "candidate": candidate.name,
+              "candidate_sha256": candidate_sha,
+              "ref": "refs/heads/main",
+              "source_ref": "refs/heads/main",
+              "workflow": "Collection CI",
+              "workflow_event_sha": os.environ["RELEASE_SHA"],
+          }
+          if any(
+              provenance.get(key) != value
+              for key, value in expected_provenance.items()
+          ):
+              raise SystemExit("provenance does not bind the exact collection release")
+          PY
 
           identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/collection-ci.yml@refs/heads/main"
           subjects=(
@@ -718,9 +811,7 @@ jobs:
               "dist/attestation-bundles/$(basename "$subject").attestation.jsonl"
           done
 
-      - name: Assemble immutable release attachments and notes
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Assemble verified release attachments
         run: |
           set -euo pipefail
 
@@ -749,6 +840,119 @@ jobs:
             cd dist/release
             sha256sum --check ci-candidate-SHA256SUMS
             sha256sum --check ci-release-assets-SHA256SUMS
+          )
+
+      - name: Prepare deterministic signed Security release evidence
+        id: security-evidence
+        if: env.SECURITY_RELEASE == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          evidence=dist/release/security-release-evidence.json
+          bundle="${evidence}.sigstore.json"
+          python scripts/generate-security-release-evidence.py generate \
+            --metadata "$SECURITY_METADATA" \
+            --profiles .lit/security-release-profiles.json \
+            --source-sha "$RELEASE_SHA" \
+            --artifact "dist/release/${CANDIDATE_NAME}" \
+            --signature "dist/release/${CANDIDATE_NAME}.sigstore.json" \
+            --sbom dist/release/sbom.cdx.json \
+            --provenance dist/release/provenance.json \
+            --output "$evidence"
+
+          release_response="$RUNNER_TEMP/existing-release-for-security-evidence.json"
+          release_status="$(
+            curl --silent --show-error --location \
+              --output "$release_response" \
+              --write-out '%{http_code}' \
+              --header 'Accept: application/vnd.github+json' \
+              --header "Authorization: Bearer ${GH_TOKEN}" \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}"
+          )"
+          case "$release_status" in
+            404)
+              evidence_asset_count=0
+              evidence_bundle_count=0
+              ;;
+            200)
+              evidence_asset_count="$(
+                jq '[.assets[] | select(.name == "security-release-evidence.json")] | length' \
+                  "$release_response"
+              )"
+              evidence_bundle_count="$(
+                jq '[.assets[] | select(.name == "security-release-evidence.json.sigstore.json")] | length' \
+                  "$release_response"
+              )"
+              ;;
+            *)
+              echo "Unexpected GitHub Release lookup status: $release_status" >&2
+              exit 1
+              ;;
+          esac
+          test "$evidence_asset_count" -le 1
+          test "$evidence_bundle_count" -le 1
+          test "$evidence_asset_count" -eq "$evidence_bundle_count"
+          if [ "$evidence_asset_count" -eq 1 ]; then
+            existing_pair="$RUNNER_TEMP/existing-security-evidence-pair"
+            mkdir -p "$existing_pair"
+            gh release download "$RELEASE_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern security-release-evidence.json \
+              --pattern security-release-evidence.json.sigstore.json \
+              --dir "$existing_pair"
+            cmp --silent "$existing_pair/security-release-evidence.json" "$evidence"
+            cp "$existing_pair/security-release-evidence.json.sigstore.json" "$bundle"
+            echo "attest_needed=false" >> "$GITHUB_OUTPUT"
+          else
+            cosign sign-blob --yes --bundle "$bundle" "$evidence"
+            echo "attest_needed=true" >> "$GITHUB_OUTPUT"
+          fi
+          publish_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/collection-publish.yml@refs/heads/main"
+          cosign verify-blob \
+            --bundle "$bundle" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            --certificate-identity "$publish_identity" \
+            --certificate-github-workflow-sha "$RELEASE_SHA" \
+            "$evidence"
+
+      - name: Attest Security release evidence
+        id: attest-security-evidence
+        if: >-
+          env.SECURITY_RELEASE == 'true' &&
+          steps.security-evidence.outputs.attest_needed == 'true'
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d  # v4
+        with:
+          subject-path: dist/release/security-release-evidence.json
+
+      - name: Verify Security release evidence attestation
+        if: env.SECURITY_RELEASE == 'true'
+        env:
+          ATTESTATION_BUNDLE: ${{ steps.attest-security-evidence.outputs.bundle-path }}
+          ATTESTATION_ID: ${{ steps.attest-security-evidence.outputs.attestation-id }}
+          ATTEST_NEEDED: ${{ steps.security-evidence.outputs.attest_needed }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "$ATTEST_NEEDED" = true ]; then
+            test -n "$ATTESTATION_ID"
+            test -s "$ATTESTATION_BUNDLE"
+          fi
+          publish_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/collection-publish.yml@refs/heads/main"
+          gh attestation verify dist/release/security-release-evidence.json \
+            --repo "$GITHUB_REPOSITORY" \
+            --cert-identity "$publish_identity" \
+            --source-ref refs/heads/main \
+            --source-digest "$RELEASE_SHA"
+
+      - name: Finalize immutable release attachments and notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          (
+            cd dist/release
             checksum_file="$RUNNER_TEMP/publish-release-assets-SHA256SUMS"
             find . -maxdepth 1 -type f ! -name SHA256SUMS -printf '%f\n' \
               | sort \
@@ -832,6 +1036,30 @@ jobs:
           notes = "\n".join(lines[start:end]).strip() + "\n"
           if len(notes.splitlines()) < 3:
               raise SystemExit(f"CHANGELOG.rst v{version} section is empty")
+          if os.environ["SECURITY_RELEASE"] == "true":
+              import json
+
+              evidence = json.loads(
+                  Path("dist/release/security-release-evidence.json").read_text(
+                      encoding="utf-8"
+                  )
+              )
+              evidence_id = evidence["metadata"]["id"]
+              identifiers = ", ".join(
+                  f"``{identifier}``"
+                  for identifier in evidence["security"]["identifiers"]
+              )
+              evidence_url = (
+                  f"https://github.com/{os.environ['GITHUB_REPOSITORY']}/releases/"
+                  f"download/{os.environ['RELEASE_TAG']}/security-release-evidence.json"
+              )
+              notes += (
+                  "\nSecurity release evidence\n"
+                  "-------------------------\n\n"
+                  f"* Evidence ID: ``{evidence_id}``\n"
+                  f"* Security identifiers: {identifiers}\n"
+                  f"* Evidence: `{evidence_id} <{evidence_url}>`_\n"
+              )
           Path("dist/release-notes.rst").write_text(notes, encoding="utf-8")
           PY
 
@@ -1210,6 +1438,35 @@ jobs:
             "$verify_root/SHA256SUMS"
           test "$(sha256sum "$verify_root/$CANDIDATE_NAME" | awk '{print $1}')" = \
             "$(sha256sum "incoming/candidate/$CANDIDATE_NAME" | awk '{print $1}')"
+          if [ "$SECURITY_RELEASE" = true ]; then
+            python scripts/generate-security-release-evidence.py verify \
+              --metadata "$SECURITY_METADATA" \
+              --profiles .lit/security-release-profiles.json \
+              --source-sha "$RELEASE_SHA" \
+              --artifact "$verify_root/$CANDIDATE_NAME" \
+              --signature "$verify_root/$CANDIDATE_NAME.sigstore.json" \
+              --sbom "$verify_root/sbom.cdx.json" \
+              --provenance "$verify_root/provenance.json" \
+              --evidence "$verify_root/security-release-evidence.json"
+            cosign verify-blob \
+              --bundle "$verify_root/security-release-evidence.json.sigstore.json" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              --certificate-identity "$publish_identity" \
+              --certificate-github-workflow-sha "$RELEASE_SHA" \
+              "$verify_root/security-release-evidence.json"
+            gh attestation verify "$verify_root/security-release-evidence.json" \
+              --repo "$GITHUB_REPOSITORY" \
+              --cert-identity "$publish_identity" \
+              --source-ref refs/heads/main \
+              --source-digest "$RELEASE_SHA"
+            candidate_identity="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/collection-ci.yml@refs/heads/main"
+            cosign verify-blob \
+              --bundle "$verify_root/$CANDIDATE_NAME.sigstore.json" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              --certificate-identity "$candidate_identity" \
+              --certificate-github-workflow-sha "$RELEASE_SHA" \
+              "$verify_root/$CANDIDATE_NAME"
+          fi
           ansible-galaxy collection install \
             "$verify_root/$CANDIDATE_NAME" \
             -p "$install_root" \
@@ -1364,6 +1621,60 @@ jobs:
             --certificate-identity "$identity" \
             --certificate-github-workflow-sha "$RELEASE_SHA" \
             "$verify_root/$(basename "$receipt")"
+
+      - name: Mint exact consumer-scoped Security release token
+        id: security-app
+        if: env.SECURITY_RELEASE == 'true'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: container-ee-wunder-ansible-ubi9
+          permission-actions: write
+
+      - name: Dispatch immutable Security evidence after Producer acceptance
+        if: env.SECURITY_RELEASE == 'true'
+        env:
+          APP_INSTALLATION_ID: ${{ steps.security-app.outputs.installation-id }}
+          APP_SLUG: ${{ steps.security-app.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.security-app.outputs.token }}
+          PRODUCER_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$APP_SLUG" = lightning-it-release-automation
+          test "$APP_INSTALLATION_ID" = 148019054
+          evidence=dist/release/security-release-evidence.json
+          python scripts/generate-security-release-evidence.py verify \
+            --metadata "$SECURITY_METADATA" \
+            --profiles .lit/security-release-profiles.json \
+            --source-sha "$RELEASE_SHA" \
+            --artifact "dist/release/${CANDIDATE_NAME}" \
+            --signature "dist/release/${CANDIDATE_NAME}.sigstore.json" \
+            --sbom dist/release/sbom.cdx.json \
+            --provenance dist/release/provenance.json \
+            --evidence "$evidence"
+          evidence_id="$(jq -er '.metadata.id' "$evidence")"
+          release_state="$RUNNER_TEMP/security-release-before-dispatch.json"
+          curl --fail --silent --show-error --location \
+            --output "$release_state" \
+            --header 'Accept: application/vnd.github+json' \
+            --header "Authorization: Bearer ${PRODUCER_TOKEN}" \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}"
+          revocation_count="$(
+            jq --arg id "$evidence_id" '[.assets[].name | select(
+              . == "security-release-revocation.json"
+              or . == ("security-release-revocation-" + $id + ".json")
+            )] | length' "$release_state"
+          )"
+          test "$revocation_count" -eq 0
+          evidence_url="https://github.com/${GITHUB_REPOSITORY}/"
+          evidence_url+="releases/download/${RELEASE_TAG}/$(basename "$evidence")"
+          evidence_sha256="sha256:$(sha256sum "$evidence" | awk '{print $1}')"
+          python scripts/dispatch-security-release.py \
+            --evidence-url "$evidence_url" \
+            --evidence-sha256 "$evidence_sha256"
 
       - name: Upload exact release attachment set
         if: always()

--- a/.lit/security-release-profiles.json
+++ b/.lit/security-release-profiles.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "lit.supplementary/mlx90-fixture": {
+      "description": "Historical v3.1.2/#488 dry-run fixture; never release eligible.",
+      "releaseEligible": false
+    }
+  },
+  "schemaVersion": 1
+}

--- a/changelogs/fragments/mlx90-producer-evidence-adapter.yml
+++ b/changelogs/fragments/mlx90-producer-evidence-adapter.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Restore the protected-main producer evidence adapter so release publication
+    consumes exact-SHA Heavy, Application Acceptance, runtime, and signed release
+    evidence from one workflow run.

--- a/changelogs/fragments/mlx90-security-release-producer.yml
+++ b/changelogs/fragments/mlx90-security-release-producer.yml
@@ -1,0 +1,9 @@
+---
+security_fixes:
+  - >-
+    Bind MLX-90 producer evidence to reviewed, versioned Security metadata and the exact protected-main collection
+    release, then sign, attest, persist, and re-verify the immutable evidence before dispatching the allowlisted
+    consumer with only its release-asset URL and SHA-256 digest.
+  - >-
+    Keep ordinary collection releases on the asynchronous transition-only path and reject missing profiles,
+    non-allowlisted consumers, invalid or expired metadata, revocations, and every release-material digest mismatch.

--- a/docs/security-release-producer.md
+++ b/docs/security-release-producer.md
@@ -1,0 +1,51 @@
+# MLX-90 producer security release contract
+
+The collection publish workflow treats a release as an MLX-90 security release only when the exact protected-main
+release SHA contains `.lit/security-releases/<fixed-version>.json`. A missing file selects the normal asynchronous
+transition path and cannot dispatch the zero-touch consumer workflow.
+
+The reviewed metadata file has this exact shape:
+
+```json
+{
+  "schemaVersion": 1,
+  "evidenceId": "LIT-SEC-EXAMPLE",
+  "createdAt": "2026-08-02T00:00:00Z",
+  "securityIdentifiers": ["LIT-SEC-EXAMPLE"],
+  "affectedVersion": "3.1.2",
+  "fixedVersion": "3.1.3",
+  "consumers": ["lightning-it/container-ee-wunder-ansible-ubi9"],
+  "acceptanceProfile": "lit.supplementary/example",
+  "validity": {
+    "notBefore": "2026-08-02T00:00:00Z",
+    "expiresAt": "2026-08-09T00:00:00Z",
+    "revoked": false
+  }
+}
+```
+
+Security classification, identifiers, versions, consumer, profile, and validity cannot be supplied as workflow or
+dispatch inputs. The generator validates the metadata against `.lit/security-release-profiles.json`, binds it to the
+exact source SHA and verified release materials, then creates `security-release-evidence.json` without replacement.
+The workflow signs and attests that evidence, stores it as an immutable GitHub Release asset, downloads and verifies
+the published copy, and only then dispatches the allowlisted consumer with the evidence URL and its `sha256:` digest.
+The consumer derives all trusted claims and the signature-bundle URL from that verified evidence.
+
+## Current fail-closed dependency
+
+The only currently defined profile is `lit.supplementary/mlx90-fixture`; it is deliberately marked
+`releaseEligible: false` because v3.1.2/#488 is historical dry-run data, not retrospective release attestation. A real
+Security release therefore remains blocked until a separately reviewed, fix-specific acceptance profile is added to
+both the producer registry and the central final-acceptance allowlist. The consumer
+`.github/workflows/security-release-update.yml` must also be promoted and registered on its protected `main` branch
+before the first producer Security release. There is no fallback to labels, mutable claims, or a weaker dispatch.
+
+The current producer `main` additionally leaves the former source-repository `Release Security` and
+`Release Validation` jobs as non-executed adapters while `collection-publish.yml` still requires their exact-SHA
+`Collection / Release Validation` result and `collection-release-evidence-<sha>` artifact. Publication therefore
+continues to stop before this new Security path until the reviewed central evidence adapter restores that prerequisite.
+This PR does not remove, synthesize, or weaken the existing gate.
+
+Revocation is fail-closed: metadata with `revoked: true` cannot generate approved evidence, and consumers/finalizers
+must additionally reject a release carrying a matching revocation asset. Published evidence and release assets are
+never overwritten; a replacement requires a new reviewed release.

--- a/docs/security-release-producer.md
+++ b/docs/security-release-producer.md
@@ -40,11 +40,19 @@ both the producer registry and the central final-acceptance allowlist. The consu
 `.github/workflows/security-release-update.yml` must also be promoted and registered on its protected `main` branch
 before the first producer Security release. There is no fallback to labels, mutable claims, or a weaker dispatch.
 
-The current producer `main` additionally leaves the former source-repository `Release Security` and
-`Release Validation` jobs as non-executed adapters while `collection-publish.yml` still requires their exact-SHA
-`Collection / Release Validation` result and `collection-release-evidence-<sha>` artifact. Publication therefore
-continues to stop before this new Security path until the reviewed central evidence adapter restores that prerequisite.
-This PR does not remove, synthesize, or weaken the existing gate.
+The producer evidence adapter is restricted to an exact `push` on `refs/heads/main`. It delegates Heavy and
+Application Acceptance to the SHA-pinned reusable workflow in `lightning-it/modulix-validation`, using the producer's
+protected runtime environment. The reusable jobs execute as part of the producer workflow run and publish their
+exact-SHA evidence into that same run. No pull request, `develop` push, or manual dispatch can enter this path, and the
+delegation neither inherits repository secrets nor mints an App token.
+
+The producer aggregates those same-run artifacts as `collection-evidence-<sha>`. `Collection / Release Security`
+directly depends on that aggregation before it may create `collection-release-evidence-<sha>` in the protected release
+environment. The final `Collection / Release Validation` check verifies the exact protected-main SHA, workflow-run
+identity, signatures, attestations, eligible gate receipts, and long-term archive digest. `collection-publish.yml`
+continues to stop unless that exact named check succeeds and that exact artifact exists; it does not synthesize or
+weaken the prerequisite. The release App's later transition and consumer dispatch remain separate, post-publication
+operations.
 
 Revocation is fail-closed: metadata with `revoked: true` cannot generate approved evidence, and consumers/finalizers
 must additionally reject a release carrying a matching revocation asset. Published evidence and release assets are

--- a/docs/testing/source-dependencies.md
+++ b/docs/testing/source-dependencies.md
@@ -70,14 +70,19 @@ a privileged PR validation.
 
 ### Central execution boundary
 
-Supplementary runs only the Fast Lane. `modulix-validation` resolves the exact
-protected `develop` SHA nightly, builds that candidate, and runs Heavy before
-Application Acceptance in its protected environment. It publishes a compact
-evidence artifact bound to that SHA.
+Supplementary PRs and `develop` pushes run only the Fast Lane.
+`modulix-validation` retains ownership of the protected Heavy and Application
+Acceptance orchestration. For an exact push to protected `main`, the producer
+release gate calls the SHA-pinned reusable ModuLix workflow inside the same
+producer run, without inheriting repository secrets. Heavy completes before
+Application Acceptance, both use the producer's protected runtime environment,
+and their evidence artifacts are bound to the exact candidate SHA and run
+attempt.
 
-`Collection / Fast` is the only required context on `develop`. A PR to `main`
-also requires `Collection / Release Evidence`: the collection workflow obtains
-the central artifact and accepts it only when its repository, SHA, schema, and
-`release_eligible` value match exactly. Missing, expired, malformed, or
-mismatched evidence fails closed. This keeps infrastructure validation out of
-PR/release execution while preventing promotion without a completed central run.
+`Collection / Fast` is the only required context on `develop`. The protected
+`main` push aggregates only same-run Heavy and Application Acceptance artifacts,
+then creates `Collection / Release Evidence`, `Collection / Release Security`,
+and the exact named `Collection / Release Validation` publisher prerequisite.
+Missing, skipped, malformed, cross-attempt, or SHA-mismatched evidence fails
+closed. This keeps protected infrastructure execution out of PRs while ensuring
+that publication cannot use evidence from another workflow run.

--- a/scripts/dispatch-security-release.py
+++ b/scripts/dispatch-security-release.py
@@ -1,0 +1,54 @@
+"""Dispatch the fixed MLX-90 consumer with an immutable evidence pointer."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+
+EVIDENCE_URL = re.compile(
+    r"^https://github\.com/lightning-it/ansible-collection-supplementary/"
+    r"releases/download/v(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\."
+    r"(?:0|[1-9][0-9]*)/security-release-evidence\.json$"
+)
+DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+WORKFLOW_ENDPOINT = (
+    "repos/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/security-release-update.yml/dispatches"
+)
+CONTROLLER_REF = "main"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence-url", required=True)
+    parser.add_argument("--evidence-sha256", required=True)
+    args = parser.parse_args()
+
+    if EVIDENCE_URL.fullmatch(args.evidence_url) is None:
+        parser.error("evidence URL must be the fixed producer release asset URL")
+    if DIGEST.fullmatch(args.evidence_sha256) is None:
+        parser.error("evidence SHA-256 must include the canonical sha256: prefix")
+    if not os.environ.get("GH_TOKEN"):
+        parser.error("a release automation App token is required as GH_TOKEN")
+
+    command = [
+        "gh",
+        "api",
+        "--method",
+        "POST",
+        WORKFLOW_ENDPOINT,
+        "-f",
+        f"ref={CONTROLLER_REF}",
+        "-f",
+        f"inputs[evidence_url]={args.evidence_url}",
+        "-f",
+        f"inputs[evidence_sha256]={args.evidence_sha256}",
+    ]
+    subprocess.run(command, check=True)  # noqa: S603 -- fixed executable and validated arguments.
+    print("Dispatched immutable MLX-90 producer evidence to the allowlisted consumer.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dispatch-security-release.py
+++ b/scripts/dispatch-security-release.py
@@ -17,6 +17,7 @@ WORKFLOW_ENDPOINT = (
     "repos/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/security-release-update.yml/dispatches"
 )
 CONTROLLER_REF = "main"
+DISPATCH_TIMEOUT_SECONDS = 60
 
 
 def main() -> int:
@@ -45,7 +46,11 @@ def main() -> int:
         "-f",
         f"inputs[evidence_sha256]={args.evidence_sha256}",
     ]
-    subprocess.run(command, check=True)  # noqa: S603 -- fixed executable and validated arguments.
+    subprocess.run(  # noqa: S603 -- fixed executable and validated arguments.
+        command,
+        check=True,
+        timeout=DISPATCH_TIMEOUT_SECONDS,
+    )
     print("Dispatched immutable MLX-90 producer evidence to the allowlisted consumer.")
     return 0
 

--- a/scripts/generate-security-release-evidence.py
+++ b/scripts/generate-security-release-evidence.py
@@ -1,20 +1,113 @@
-"""Generate deterministic producer evidence for the MLX-90 contract.
+"""Generate or verify deterministic MLX-90 producer evidence.
 
-Signing/attestation and consumer dispatch happen only after this payload and all
-referenced release assets have been verified by the release workflow.
+Security classification fields are read only from reviewed metadata committed at
+the exact release SHA. Runtime arguments identify the already verified release
+materials; they cannot supply Security IDs, consumers, validity, or profiles.
 """
+
+from __future__ import annotations
 
 import argparse
 import hashlib
 import json
+import os
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
+
+PRODUCER = "lightning-it/ansible-collection-supplementary"
+CONSUMER = "lightning-it/container-ee-wunder-ansible-ubi9"
+COLLECTION = "lit.supplementary"
 
 SHA = re.compile(r"^[0-9a-f]{40}$")
+SEMVER = re.compile(r"^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$")
+EVIDENCE_ID = re.compile(r"^[A-Z0-9][A-Z0-9._-]{2,127}$")
+SECURITY_ID = re.compile(
+    r"^(?:CVE-[0-9]{4}-[0-9]{4,}|"
+    r"GHSA-[23456789cfghjmpqrvwx]{4}(?:-[23456789cfghjmpqrvwx]{4}){2}|"
+    r"LIT-SEC-[A-Z0-9._-]+)$"
+)
+PROFILE_ID = re.compile(r"^[a-z0-9][a-z0-9._/-]+$")
+CANONICAL_TIME = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+
+METADATA_KEYS = {
+    "schemaVersion",
+    "evidenceId",
+    "createdAt",
+    "securityIdentifiers",
+    "affectedVersion",
+    "fixedVersion",
+    "consumers",
+    "acceptanceProfile",
+    "validity",
+}
+VALIDITY_KEYS = {"notBefore", "expiresAt", "revoked"}
 
 
-def sha256(path: Path):
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            fail(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def has_symlink_component(path: Path) -> bool:
+    # The checkout/runner roots are trusted by the workflow and may themselves
+    # be platform aliases (for example macOS /var -> /private/var). Reject the
+    # caller-controlled leaf and its immediate container without treating such
+    # platform roots as an unsafe release input.
+    return path.is_symlink() or path.parent.is_symlink()
+
+
+def require_regular_file(path: Path, label: str) -> None:
+    if has_symlink_component(path) or not path.is_file():
+        fail(f"{label} must be a regular non-symlink file: {path}")
+
+
+def load_json(path: Path, label: str) -> dict[str, Any]:
+    require_regular_file(path, label)
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicate_keys)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label} is not valid JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        fail(f"{label} must be a JSON object")
+    return value
+
+
+def require_exact(value: dict[str, Any], keys: set[str], label: str) -> None:
+    missing = keys - value.keys()
+    unknown = value.keys() - keys
+    if missing:
+        fail(f"{label} is missing fields: {', '.join(sorted(missing))}")
+    if unknown:
+        fail(f"{label} has unknown fields: {', '.join(sorted(unknown))}")
+
+
+def require_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or value != value.strip() or not value:
+        fail(f"{label} must be a non-empty trimmed string")
+    return value
+
+
+def timestamp(value: object, label: str) -> datetime:
+    text = require_string(value, label)
+    if CANONICAL_TIME.fullmatch(text) is None:
+        fail(f"{label} must be a canonical UTC RFC3339 timestamp")
+    try:
+        return datetime.strptime(text, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise ValueError(f"{label} must be a valid timestamp") from exc
+
+
+def sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as stream:
         for chunk in iter(lambda: stream.read(1024 * 1024), b""):
@@ -22,108 +115,208 @@ def sha256(path: Path):
     return "sha256:" + digest.hexdigest()
 
 
-def file_ref(path: Path, url: str):
-    return {"url": url, "digest": sha256(path)}
+def load_profiles(path: Path, profile_id: str) -> None:
+    registry = load_json(path, "security release profile registry")
+    require_exact(registry, {"schemaVersion", "profiles"}, "security release profile registry")
+    if registry["schemaVersion"] != 1 or not isinstance(registry["profiles"], dict):
+        fail("security release profile registry is unsupported")
+    profile = registry["profiles"].get(profile_id)
+    if not isinstance(profile, dict):
+        fail("acceptance profile is not in the fixed producer allowlist")
+    require_exact(profile, {"releaseEligible", "description"}, f"acceptance profile {profile_id}")
+    if profile["releaseEligible"] is not True:
+        fail("acceptance profile is explicitly non-releaseable")
+    require_string(profile["description"], f"acceptance profile {profile_id}.description")
 
 
-def has_symlink_component(path: Path):
-    current = path
-    while True:
-        if current.is_symlink():
-            return True
-        if current == current.parent:
-            return False
-        current = current.parent
+def load_metadata(path: Path, profiles: Path, checked_at: datetime) -> dict[str, Any]:
+    metadata = load_json(path, "security release metadata")
+    require_exact(metadata, METADATA_KEYS, "security release metadata")
+    if metadata["schemaVersion"] != 1:
+        fail("security release metadata schemaVersion must be 1")
+
+    evidence_id = require_string(metadata["evidenceId"], "evidenceId")
+    if EVIDENCE_ID.fullmatch(evidence_id) is None:
+        fail("evidenceId is invalid")
+    identifiers = metadata["securityIdentifiers"]
+    if (
+        not isinstance(identifiers, list)
+        or not identifiers
+        or any(not isinstance(item, str) or SECURITY_ID.fullmatch(item) is None for item in identifiers)
+        or len(identifiers) != len(set(identifiers))
+    ):
+        fail("securityIdentifiers must be a non-empty unique list of canonical Security IDs")
+    affected = require_string(metadata["affectedVersion"], "affectedVersion")
+    fixed = require_string(metadata["fixedVersion"], "fixedVersion")
+    if SEMVER.fullmatch(affected) is None:
+        fail("affectedVersion must be a stable semantic version")
+    if SEMVER.fullmatch(fixed) is None:
+        fail("fixedVersion must be a stable semantic version")
+    if affected == fixed:
+        fail("affectedVersion must differ from fixedVersion")
+    if path.name != f"{fixed}.json" or path.parent.name != "security-releases" or path.parent.parent.name != ".lit":
+        fail("security metadata path must be .lit/security-releases/<fixedVersion>.json")
+
+    consumers = metadata["consumers"]
+    if consumers != [CONSUMER]:
+        fail(f"consumers must contain exactly the approved repository {CONSUMER}")
+    profile_id = require_string(metadata["acceptanceProfile"], "acceptanceProfile")
+    if PROFILE_ID.fullmatch(profile_id) is None:
+        fail("acceptanceProfile is invalid")
+    load_profiles(profiles, profile_id)
+
+    validity = metadata["validity"]
+    if not isinstance(validity, dict):
+        fail("validity must be an object")
+    require_exact(validity, VALIDITY_KEYS, "validity")
+    created = timestamp(metadata["createdAt"], "createdAt")
+    not_before = timestamp(validity["notBefore"], "validity.notBefore")
+    expires_at = timestamp(validity["expiresAt"], "validity.expiresAt")
+    if validity["revoked"] is not False:
+        fail("security release metadata is revoked")
+    if expires_at <= not_before:
+        fail("security release validity interval is empty")
+    if created < not_before or created >= expires_at:
+        fail("createdAt is outside the security release validity interval")
+    if checked_at < not_before or checked_at >= expires_at:
+        fail("security release metadata is not currently valid")
+    return metadata
 
 
-def timestamp(value: str, field: str):
-    try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        raise ValueError(f"{field} must be RFC3339") from None
-    if parsed.tzinfo is None:
-        raise ValueError(f"{field} must include a timezone")
-    return parsed
+def release_asset_url(version: str, name: str) -> str:
+    return f"https://github.com/{PRODUCER}/releases/download/v{version}/{name}"
 
 
-def main():
-    p = argparse.ArgumentParser()
-    p.add_argument("--id", required=True)
-    p.add_argument("--security-id", required=True)
-    p.add_argument("--affected-version", required=True)
-    p.add_argument("--version", required=True)
-    p.add_argument("--source-sha", required=True)
-    p.add_argument("--workflow-ref", required=True)
-    p.add_argument("--artifact", type=Path, required=True)
-    p.add_argument("--artifact-url", required=True)
-    p.add_argument("--signature", type=Path, required=True)
-    p.add_argument("--signature-url", required=True)
-    p.add_argument("--sbom", type=Path, required=True)
-    p.add_argument("--sbom-url", required=True)
-    p.add_argument("--provenance", type=Path, required=True)
-    p.add_argument("--provenance-url", required=True)
-    p.add_argument("--consumer", action="append", required=True)
-    p.add_argument("--acceptance-profile", required=True)
-    p.add_argument("--created-at", required=True)
-    p.add_argument("--not-before", required=True)
-    p.add_argument("--expires-at", required=True)
-    p.add_argument("--output", type=Path, required=True)
-    a = p.parse_args()
-    for path in (a.artifact, a.signature, a.sbom, a.provenance):
-        if path.is_symlink() or not path.is_file():
-            p.error(f"release asset must be a regular non-symlink file: {path}")
-    if has_symlink_component(a.output):
-        p.error(f"evidence output must not contain symlink components: {a.output}")
-    if not SHA.fullmatch(a.source_sha) or not SHA.fullmatch(a.workflow_ref):
-        p.error("source/workflow refs must be full SHAs")
-    for field in (a.artifact_url, a.signature_url, a.sbom_url, a.provenance_url):
-        if not field.startswith("https://"):
-            p.error("all artifact references must use HTTPS")
-    try:
-        created = timestamp(a.created_at, "--created-at")
-        not_before = timestamp(a.not_before, "--not-before")
-        expires = timestamp(a.expires_at, "--expires-at")
-    except ValueError as exc:
-        p.error(str(exc))
-    if expires <= not_before:
-        p.error("--expires-at must be after --not-before")
-    if created < not_before or created >= expires:
-        p.error("--created-at must be within the evidence validity interval")
-    evidence = {
+def file_ref(path: Path, version: str) -> dict[str, str]:
+    return {"url": release_asset_url(version, path.name), "digest": sha256(path)}
+
+
+def build_evidence(args: argparse.Namespace) -> dict[str, Any]:
+    if SHA.fullmatch(args.source_sha) is None:
+        fail("source SHA must be a full lowercase 40-character SHA")
+    checked_at = timestamp(args.checked_at, "--checked-at") if args.checked_at else datetime.now(UTC)
+    metadata = load_metadata(args.metadata, args.profiles, checked_at)
+    version = metadata["fixedVersion"]
+
+    expected_names = {
+        "artifact": f"lit-supplementary-{version}.tar.gz",
+        "signature": f"lit-supplementary-{version}.tar.gz.sigstore.json",
+        "sbom": "sbom.cdx.json",
+        "provenance": "provenance.json",
+    }
+    for label, expected_name in expected_names.items():
+        path = getattr(args, label)
+        require_regular_file(path, label)
+        if path.name != expected_name:
+            fail(f"{label} must be named {expected_name}")
+
+    return {
         "apiVersion": "lit.security-release/v1",
         "kind": "SecurityReleaseEvidence",
-        "metadata": {"id": a.id, "createdAt": a.created_at},
-        "security": {"identifiers": [a.security_id], "affectedVersion": a.affected_version, "fixedVersion": a.version},
+        "metadata": {
+            "id": metadata["evidenceId"],
+            "createdAt": metadata["createdAt"],
+        },
+        "security": {
+            "identifiers": sorted(metadata["securityIdentifiers"]),
+            "affectedVersion": metadata["affectedVersion"],
+            "fixedVersion": version,
+        },
         "producer": {
-            "repository": "lightning-it/ansible-collection-supplementary",
-            "sourceSha": a.source_sha,
-            "workflowRepository": "lightning-it/ansible-collection-supplementary",
-            "workflowRef": a.workflow_ref,
+            "repository": PRODUCER,
+            "sourceSha": args.source_sha,
+            "workflowRepository": PRODUCER,
+            "workflowRef": args.source_sha,
         },
         "artifact": {
-            "collection": "lit.supplementary",
-            "version": a.version,
-            "digest": sha256(a.artifact),
-            "releaseUrl": a.artifact_url,
-            "signature": file_ref(a.signature, a.signature_url),
-            "sbom": file_ref(a.sbom, a.sbom_url),
-            "provenance": file_ref(a.provenance, a.provenance_url),
+            "collection": COLLECTION,
+            "version": version,
+            "digest": sha256(args.artifact),
+            "releaseUrl": f"https://github.com/{PRODUCER}/releases/tag/v{version}",
+            "signature": file_ref(args.signature, version),
+            "sbom": file_ref(args.sbom, version),
+            "provenance": file_ref(args.provenance, version),
         },
-        "consumers": sorted(set(a.consumer)),
+        "consumers": [CONSUMER],
         "acceptance": {
-            "profile": a.acceptance_profile,
-            "expectedCollection": "lit.supplementary",
-            "expectedVersion": a.version,
+            "profile": metadata["acceptanceProfile"],
+            "expectedCollection": COLLECTION,
+            "expectedVersion": version,
         },
-        "validity": {"notBefore": a.not_before, "expiresAt": a.expires_at, "revoked": False},
+        "validity": {
+            "notBefore": metadata["validity"]["notBefore"],
+            "expiresAt": metadata["validity"]["expiresAt"],
+            "revoked": False,
+        },
         "status": "approved",
     }
+
+
+def serialize(evidence: dict[str, Any]) -> str:
+    return json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+
+
+def write_exclusive(path: Path, value: str) -> None:
+    if has_symlink_component(path):
+        fail(f"evidence output must not contain symlink components: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if has_symlink_component(path):
+        fail(f"evidence output must not contain symlink components: {path}")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
     try:
-        a.output.parent.mkdir(parents=True, exist_ok=True)
-        a.output.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    except OSError as exc:
-        p.error(f"unable to write evidence output {a.output}: {exc}")
+        descriptor = os.open(path, flags, 0o644)
+    except FileExistsError as exc:
+        raise ValueError(f"refusing to replace existing evidence output: {path}") from exc
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(value)
+    except BaseException:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise
+
+
+def add_material_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--metadata", type=Path, required=True)
+    parser.add_argument("--profiles", type=Path, required=True)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--artifact", type=Path, required=True)
+    parser.add_argument("--signature", type=Path, required=True)
+    parser.add_argument("--sbom", type=Path, required=True)
+    parser.add_argument("--provenance", type=Path, required=True)
+    parser.add_argument("--checked-at", help="canonical UTC test override; defaults to current UTC")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    generate = commands.add_parser("generate", help="create a new evidence file without replacement")
+    add_material_arguments(generate)
+    generate.add_argument("--output", type=Path, required=True)
+    verify = commands.add_parser("verify", help="recompute and verify an existing canonical evidence file")
+    add_material_arguments(verify)
+    verify.add_argument("--evidence", type=Path, required=True)
+    args = parser.parse_args()
+
+    try:
+        evidence = build_evidence(args)
+        canonical = serialize(evidence)
+        if args.command == "generate":
+            write_exclusive(args.output, canonical)
+            print(f"Generated approved security release evidence {evidence['metadata']['id']}.")
+        else:
+            require_regular_file(args.evidence, "security release evidence")
+            if args.evidence.read_text(encoding="utf-8") != canonical:
+                fail("security release evidence differs from authoritative metadata or verified release materials")
+            print(f"Verified approved security release evidence {evidence['metadata']['id']}.")
+    except (OSError, UnicodeError, ValueError) as exc:
+        parser.error(str(exc))
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/generate-security-release-evidence.py
+++ b/scripts/generate-security-release-evidence.py
@@ -60,10 +60,9 @@ def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
 
 def has_symlink_component(path: Path) -> bool:
     # Inspect the lexical path rather than resolving it so a symlink cannot
-    # disappear from the path being checked. The first component below the
-    # filesystem root is trusted runner/platform state and may be an alias (for
-    # example macOS /var -> /private/var); every deeper component is part of the
-    # checkout or release-material path and must not be a symlink.
+    # disappear from the path being checked. The only accepted platform alias
+    # is macOS /var -> /private/var; every other component must not be a
+    # symlink.
     absolute = path if path.is_absolute() else Path.cwd() / path
     if ".." in absolute.parts:
         return True
@@ -71,8 +70,14 @@ def has_symlink_component(path: Path) -> bool:
     current = anchor
     for component in absolute.parts[1:]:
         current /= component
-        if current.parent != anchor and current.is_symlink():
-            return True
+        if current.is_symlink():
+            if current != Path("/var"):
+                return True
+            try:
+                if current.resolve(strict=True) != Path("/private/var"):
+                    return True
+            except OSError:
+                return True
     return False
 
 

--- a/scripts/generate-security-release-evidence.py
+++ b/scripts/generate-security-release-evidence.py
@@ -59,11 +59,21 @@ def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
 
 
 def has_symlink_component(path: Path) -> bool:
-    # The checkout/runner roots are trusted by the workflow and may themselves
-    # be platform aliases (for example macOS /var -> /private/var). Reject the
-    # caller-controlled leaf and its immediate container without treating such
-    # platform roots as an unsafe release input.
-    return path.is_symlink() or path.parent.is_symlink()
+    # Inspect the lexical path rather than resolving it so a symlink cannot
+    # disappear from the path being checked. The first component below the
+    # filesystem root is trusted runner/platform state and may be an alias (for
+    # example macOS /var -> /private/var); every deeper component is part of the
+    # checkout or release-material path and must not be a symlink.
+    absolute = path if path.is_absolute() else Path.cwd() / path
+    if ".." in absolute.parts:
+        return True
+    anchor = Path(absolute.anchor)
+    current = anchor
+    for component in absolute.parts[1:]:
+        current /= component
+        if current.parent != anchor and current.is_symlink():
+            return True
+    return False
 
 
 def require_regular_file(path: Path, label: str) -> None:

--- a/tests/unit/test_security_release_dispatch.py
+++ b/tests/unit/test_security_release_dispatch.py
@@ -1,0 +1,108 @@
+"""Tests for the immutable MLX-90 consumer dispatch contract."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/dispatch-security-release.py"
+EVIDENCE_URL = (
+    "https://github.com/lightning-it/ansible-collection-supplementary/"
+    "releases/download/v3.1.2/security-release-evidence.json"
+)
+DIGEST = "sha256:" + "a" * 64
+
+
+class SecurityReleaseDispatchTests(unittest.TestCase):
+    def run_dispatch(
+        self,
+        root: Path,
+        *,
+        evidence_url: str = EVIDENCE_URL,
+        digest: str = DIGEST,
+        include_token: bool = True,
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
+        fake_bin = root / "bin"
+        fake_bin.mkdir()
+        capture = root / "arguments"
+        fake_gh = fake_bin / "gh"
+        fake_gh.write_text(
+            '#!/usr/bin/env bash\nset -euo pipefail\nprintf "%s\\n" "$@" >"${MLX90_CAPTURE:?}"\n',
+            encoding="utf-8",
+        )
+        fake_gh.chmod(0o700)
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "MLX90_CAPTURE": str(capture),
+                "PATH": f"{fake_bin}:{environment['PATH']}",
+            }
+        )
+        if include_token:
+            environment["GH_TOKEN"] = "test-app-token"  # noqa: S105 -- fake process-local test value.
+        else:
+            environment.pop("GH_TOKEN", None)
+        command = [
+            sys.executable,
+            str(SCRIPT),
+            "--evidence-url",
+            evidence_url,
+            "--evidence-sha256",
+            digest,
+        ]
+        result = subprocess.run(  # noqa: S603 -- fixed interpreter/script and test-owned fake PATH.
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=environment,
+            timeout=30,
+        )
+        return result, capture
+
+    def test_dispatch_contains_only_fixed_ref_and_immutable_evidence_pointer(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            result, capture = self.run_dispatch(Path(temporary))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            arguments = capture.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(
+                arguments,
+                [
+                    "api",
+                    "--method",
+                    "POST",
+                    "repos/lightning-it/container-ee-wunder-ansible-ubi9/actions/workflows/"
+                    "security-release-update.yml/dispatches",
+                    "-f",
+                    "ref=main",
+                    "-f",
+                    f"inputs[evidence_url]={EVIDENCE_URL}",
+                    "-f",
+                    f"inputs[evidence_sha256]={DIGEST}",
+                ],
+            )
+            serialized = "\n".join(arguments)
+            self.assertNotIn("evidence_id", serialized)
+            self.assertNotIn("version", serialized)
+            self.assertNotIn("consumer", serialized)
+
+    def test_invalid_url_digest_and_missing_app_token_never_dispatch(self) -> None:
+        cases = (
+            {"evidence_url": "https://example.invalid/security-release-evidence.json"},
+            {"digest": "a" * 64},
+            {"include_token": False},
+        )
+        for case in cases:
+            with self.subTest(case=case), tempfile.TemporaryDirectory() as temporary:
+                result, capture = self.run_dispatch(Path(temporary), **case)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertFalse(capture.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_security_release_dispatch.py
+++ b/tests/unit/test_security_release_dispatch.py
@@ -91,6 +91,11 @@ class SecurityReleaseDispatchTests(unittest.TestCase):
             self.assertNotIn("version", serialized)
             self.assertNotIn("consumer", serialized)
 
+    def test_dispatch_has_a_fixed_network_timeout(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn("DISPATCH_TIMEOUT_SECONDS = 60", source)
+        self.assertIn("timeout=DISPATCH_TIMEOUT_SECONDS", source)
+
     def test_invalid_url_digest_and_missing_app_token_never_dispatch(self) -> None:
         cases = (
             {"evidence_url": "https://example.invalid/security-release-evidence.json"},

--- a/tests/unit/test_security_release_evidence.py
+++ b/tests/unit/test_security_release_evidence.py
@@ -219,6 +219,48 @@ class ProducerEvidenceTests(unittest.TestCase):
             self.assertIn("must not contain symlink components", result.stderr)
             self.assertFalse(target.exists())
 
+    def test_symlinked_metadata_grandparent_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            metadata, profiles, assets = self.make_inputs(root)
+            real_metadata_root = root / "review-bypass"
+            (root / ".lit").rename(real_metadata_root)
+            (root / ".lit").symlink_to(real_metadata_root, target_is_directory=True)
+
+            output = root / "security-release-evidence.json"
+            result = self.run_command(self.command("generate", metadata, profiles, assets, output))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must be a regular non-symlink file", result.stderr)
+            self.assertFalse(output.exists())
+
+    def test_symlinked_output_grandparent_is_rejected_without_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            metadata, profiles, assets = self.make_inputs(root)
+            real_output_root = root / "real-output"
+            real_output_root.mkdir()
+            linked_output_root = root / "linked-output"
+            linked_output_root.symlink_to(real_output_root, target_is_directory=True)
+            output = linked_output_root / "nested" / "security-release-evidence.json"
+
+            result = self.run_command(self.command("generate", metadata, profiles, assets, output))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must not contain symlink components", result.stderr)
+            self.assertFalse((real_output_root / "nested").exists())
+
+    def test_parent_traversal_cannot_hide_a_symlink_component(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            metadata, profiles, assets = self.make_inputs(root)
+            linked_output_root = root / "linked-output"
+            linked_output_root.symlink_to(root, target_is_directory=True)
+            output = linked_output_root / ".." / "escaped-evidence.json"
+
+            result = self.run_command(self.command("generate", metadata, profiles, assets, output))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must not contain symlink components", result.stderr)
+            self.assertFalse((root.parent / "escaped-evidence.json").exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_security_release_evidence.py
+++ b/tests/unit/test_security_release_evidence.py
@@ -1,4 +1,4 @@
-"""Tests for deterministic MLX-90 producer evidence."""
+"""Tests for deterministic, fail-closed MLX-90 producer evidence."""
 
 from __future__ import annotations
 
@@ -8,81 +8,216 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts/generate-security-release-evidence.py"
+CHECKED_AT = "2026-08-02T12:00:00Z"
+SOURCE_SHA = "1" * 40
+CONSUMER = "lightning-it/container-ee-wunder-ansible-ubi9"
+PROFILE = "lit.supplementary/approved-test"
 
 
 class ProducerEvidenceTests(unittest.TestCase):
-    def test_evidence_binds_every_release_asset(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            files = {}
-            for name in ("artifact", "signature", "sbom", "provenance"):
-                files[name] = root / name
-                files[name].write_text(name, encoding="utf-8")
-            output = root / "missing" / "evidence.json"
-            cmd = [
-                sys.executable,
-                str(SCRIPT),
-                "--id",
-                "LIT-SEC-TEST",
-                "--security-id",
-                "LIT-SEC-TEST",
-                "--affected-version",
-                "3.1.0",
-                "--version",
-                "3.1.2",
-                "--source-sha",
-                "1" * 40,
-                "--workflow-ref",
-                "2" * 40,
-                "--consumer",
-                "lightning-it/container-ee-wunder-ansible-ubi9",
-                "--acceptance-profile",
-                "lit.supplementary/test",
-                "--created-at",
-                "2026-07-31T00:00:00Z",
-                "--not-before",
-                "2026-07-31T00:00:00Z",
-                "--expires-at",
-                "2026-08-07T00:00:00Z",
-                "--output",
-                str(output),
-            ]
-            for name, path in files.items():
-                cmd += [f"--{name}", str(path), f"--{name}-url", f"https://example.invalid/{name}"]
-            # The command contains only a fixed interpreter/script and test-owned arguments.
-            subprocess.run(cmd, check=True, timeout=30)  # noqa: S603
+    def make_inputs(
+        self,
+        root: Path,
+        *,
+        mutate: Callable[[dict[str, Any]], None] | None = None,
+        release_eligible: bool = True,
+    ) -> tuple[Path, Path, dict[str, Path]]:
+        metadata_root = root / ".lit" / "security-releases"
+        metadata_root.mkdir(parents=True)
+        metadata: dict[str, Any] = {
+            "schemaVersion": 1,
+            "evidenceId": "LIT-SEC-TEST",
+            "createdAt": "2026-08-02T00:00:00Z",
+            "securityIdentifiers": ["LIT-SEC-TEST", "CVE-2026-12345"],
+            "affectedVersion": "3.1.0",
+            "fixedVersion": "3.1.2",
+            "consumers": [CONSUMER],
+            "acceptanceProfile": PROFILE,
+            "validity": {
+                "notBefore": "2026-08-02T00:00:00Z",
+                "expiresAt": "2026-08-09T00:00:00Z",
+                "revoked": False,
+            },
+        }
+        if mutate is not None:
+            mutate(metadata)
+        metadata_path = metadata_root / f"{metadata['fixedVersion']}.json"
+        metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+        profiles = root / ".lit" / "security-release-profiles.json"
+        profiles.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "profiles": {
+                        PROFILE: {
+                            "description": "Unit-test-only release-eligible profile.",
+                            "releaseEligible": release_eligible,
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        assets = {
+            "artifact": root / "lit-supplementary-3.1.2.tar.gz",
+            "signature": root / "lit-supplementary-3.1.2.tar.gz.sigstore.json",
+            "sbom": root / "sbom.cdx.json",
+            "provenance": root / "provenance.json",
+        }
+        for name, path in assets.items():
+            path.write_text(name, encoding="utf-8")
+        return metadata_path, profiles, assets
+
+    def command(
+        self,
+        action: str,
+        metadata: Path,
+        profiles: Path,
+        assets: dict[str, Path],
+        target: Path,
+    ) -> list[str]:
+        command = [
+            sys.executable,
+            str(SCRIPT),
+            action,
+            "--metadata",
+            str(metadata),
+            "--profiles",
+            str(profiles),
+            "--source-sha",
+            SOURCE_SHA,
+            "--checked-at",
+            CHECKED_AT,
+        ]
+        for name, path in assets.items():
+            command.extend((f"--{name}", str(path)))
+        command.extend(("--output" if action == "generate" else "--evidence", str(target)))
+        return command
+
+    def run_command(self, command: list[str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(  # noqa: S603 -- fixed interpreter/script and test-owned arguments.
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_evidence_is_deterministic_and_binds_every_release_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            metadata, profiles, assets = self.make_inputs(root)
+            output = root / "output" / "security-release-evidence.json"
+            command = self.command("generate", metadata, profiles, assets, output)
+            result = self.run_command(command)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
             value = json.loads(output.read_text(encoding="utf-8"))
-            self.assertEqual(value["artifact"]["digest"], "sha256:" + hashlib.sha256(b"artifact").hexdigest())
-            for name in ("signature", "sbom", "provenance"):
-                expected_digest = "sha256:" + hashlib.sha256(name.encode()).hexdigest()
-                self.assertEqual(value["artifact"][name]["digest"], expected_digest)
-            self.assertEqual(value["consumers"], ["lightning-it/container-ee-wunder-ansible-ubi9"])
+            artifact_digest = "sha256:" + hashlib.sha256(b"artifact").hexdigest()
+            self.assertEqual(value["artifact"]["digest"], artifact_digest)
+            self.assertEqual(value["producer"]["sourceSha"], SOURCE_SHA)
+            self.assertEqual(value["producer"]["workflowRef"], SOURCE_SHA)
+            self.assertEqual(value["consumers"], [CONSUMER])
             self.assertEqual(value["status"], "approved")
             self.assertNotIn("delivery", value)
+            for name in ("signature", "sbom", "provenance"):
+                expected = "sha256:" + hashlib.sha256(name.encode()).hexdigest()
+                self.assertEqual(value["artifact"][name]["digest"], expected)
+                self.assertRegex(
+                    value["artifact"][name]["url"],
+                    rf"/releases/download/v3\.1\.2/{assets[name].name}$",
+                )
 
-            output_arg = cmd.index("--output") + 1
+            verification = self.run_command(self.command("verify", metadata, profiles, assets, output))
+            self.assertEqual(verification.returncode, 0, verification.stderr)
+            replacement = self.run_command(command)
+            self.assertNotEqual(replacement.returncode, 0)
+            self.assertIn("refusing to replace existing evidence output", replacement.stderr)
+
+    def test_digest_mismatch_is_rejected_after_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            metadata, profiles, assets = self.make_inputs(root)
+            output = root / "security-release-evidence.json"
+            result = self.run_command(self.command("generate", metadata, profiles, assets, output))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            assets["artifact"].write_text("changed artifact", encoding="utf-8")
+            verification = self.run_command(self.command("verify", metadata, profiles, assets, output))
+            self.assertNotEqual(verification.returncode, 0)
+            self.assertIn("differs from authoritative metadata", verification.stderr)
+
+    def test_invalid_expired_revoked_and_non_allowlisted_metadata_fail_closed(self) -> None:
+        cases: tuple[tuple[str, Callable[[dict[str, Any]], None], str], ...] = (
+            (
+                "invalid identifier",
+                lambda value: value.__setitem__("securityIdentifiers", ["security-label"]),
+                "canonical Security IDs",
+            ),
+            (
+                "invalid affected version",
+                lambda value: value.__setitem__("affectedVersion", "old"),
+                "affectedVersion must be a stable semantic version",
+            ),
+            (
+                "expired",
+                lambda value: value["validity"].__setitem__("expiresAt", "2026-08-02T12:00:00Z"),
+                "not currently valid",
+            ),
+            (
+                "revoked",
+                lambda value: value["validity"].__setitem__("revoked", True),
+                "metadata is revoked",
+            ),
+            (
+                "consumer",
+                lambda value: value.__setitem__("consumers", [CONSUMER, "lightning-it/extra"]),
+                "must contain exactly the approved repository",
+            ),
+        )
+        for label, mutation, message in cases:
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                metadata, profiles, assets = self.make_inputs(root, mutate=mutation)
+                output = root / "security-release-evidence.json"
+                result = self.run_command(self.command("generate", metadata, profiles, assets, output))
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(message, result.stderr)
+                self.assertFalse(output.exists())
+
+    def test_missing_or_non_releaseable_profile_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            metadata, profiles, assets = self.make_inputs(root, release_eligible=False)
+            output = root / "security-release-evidence.json"
+            result = self.run_command(self.command("generate", metadata, profiles, assets, output))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("explicitly non-releaseable", result.stderr)
+
+            registry = json.loads(profiles.read_text(encoding="utf-8"))
+            registry["profiles"].clear()
+            profiles.write_text(json.dumps(registry), encoding="utf-8")
+            result = self.run_command(self.command("generate", metadata, profiles, assets, output))
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("not in the fixed producer allowlist", result.stderr)
+
+    def test_symlinked_output_is_rejected_without_touching_target(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            metadata, profiles, assets = self.make_inputs(root)
             target = root / "target.json"
-            linked_output = root / "linked-output.json"
-            linked_output.symlink_to(target)
-            cmd[output_arg] = str(linked_output)
-            result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=30)  # noqa: S603
+            output = root / "security-release-evidence.json"
+            output.symlink_to(target)
+            result = self.run_command(self.command("generate", metadata, profiles, assets, output))
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("must not contain symlink components", result.stderr)
             self.assertFalse(target.exists())
-
-            real_directory = root / "real-directory"
-            real_directory.mkdir()
-            linked_directory = root / "linked-directory"
-            linked_directory.symlink_to(real_directory, target_is_directory=True)
-            cmd[output_arg] = str(linked_directory / "evidence.json")
-            result = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=30)  # noqa: S603
-            self.assertNotEqual(result.returncode, 0)
-            self.assertIn("must not contain symlink components", result.stderr)
-            self.assertFalse((real_directory / "evidence.json").exists())
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_security_release_evidence.py
+++ b/tests/unit/test_security_release_evidence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import runpy
 import subprocess
 import sys
 import tempfile
@@ -11,6 +12,7 @@ import unittest
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts/generate-security-release-evidence.py"
@@ -218,6 +220,54 @@ class ProducerEvidenceTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("must not contain symlink components", result.stderr)
             self.assertFalse(target.exists())
+
+    def test_unrecognized_root_level_symlink_is_rejected(self) -> None:
+        module = runpy.run_path(str(SCRIPT), run_name="mlx90_evidence_module")
+        has_symlink_component = module["has_symlink_component"]
+        with patch.object(
+            Path,
+            "is_symlink",
+            autospec=True,
+            side_effect=lambda candidate: candidate == Path("/untrusted-root"),
+        ):
+            self.assertTrue(has_symlink_component(Path("/untrusted-root/repository/evidence.json")))
+
+    def test_only_the_canonical_macos_var_alias_is_accepted(self) -> None:
+        module = runpy.run_path(str(SCRIPT), run_name="mlx90_evidence_module")
+        has_symlink_component = module["has_symlink_component"]
+        with (
+            patch.object(
+                Path,
+                "is_symlink",
+                autospec=True,
+                side_effect=lambda candidate: candidate == Path("/var"),
+            ),
+            patch.object(
+                Path,
+                "resolve",
+                autospec=True,
+                side_effect=lambda candidate, *, strict: (
+                    Path("/private/var") if candidate == Path("/var") and strict else candidate
+                ),
+            ),
+        ):
+            self.assertFalse(has_symlink_component(Path("/var/folders/repository/evidence.json")))
+
+        with (
+            patch.object(
+                Path,
+                "is_symlink",
+                autospec=True,
+                side_effect=lambda candidate: candidate == Path("/var"),
+            ),
+            patch.object(
+                Path,
+                "resolve",
+                autospec=True,
+                return_value=Path("/attacker-controlled"),
+            ),
+        ):
+            self.assertTrue(has_symlink_component(Path("/var/folders/repository/evidence.json")))
 
     def test_symlinked_metadata_grandparent_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -839,6 +839,13 @@ class WorkflowSecurityTests(unittest.TestCase):
         )
         self.assertEqual(
             "env.SECURITY_RELEASE == 'true'",
+            steps["Attest Security release evidence"]["if"],
+        )
+        self.assertNotIn("attest_needed", workflow_text)
+        self.assertIn('test -n "$ATTESTATION_ID"', workflow_text)
+        self.assertIn('test -s "$ATTESTATION_BUNDLE"', workflow_text)
+        self.assertEqual(
+            "env.SECURITY_RELEASE == 'true'",
             steps["Dispatch immutable Security evidence after Producer acceptance"]["if"],
         )
         transition_condition = steps["Dispatch transitional central validation"]["if"]

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -749,6 +749,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn('--metadata "$SECURITY_METADATA"', workflow_text)
         self.assertIn("actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d", workflow_text)
         self.assertIn('test "$APP_INSTALLATION_ID" = 148019054', workflow_text)
+        self.assertIn("installation/repositories?per_page=100", workflow_text)
         self.assertIn('test "$revocation_count" -eq 0', workflow_text)
         self.assertGreaterEqual(workflow_text.count("generate-security-release-evidence.py verify"), 2)
         self.assertIn("permission-actions: write", workflow_text)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -750,6 +750,11 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d", workflow_text)
         self.assertIn('test "$APP_INSTALLATION_ID" = 148019054', workflow_text)
         self.assertIn("installation/repositories?per_page=100", workflow_text)
+        self.assertIn(
+            "jq -sc '[.[].repositories[].full_name] | sort | unique'",
+            workflow_text,
+        )
+        self.assertNotIn("gh api --paginate --slurp", workflow_text)
         self.assertIn('test "$revocation_count" -eq 0', workflow_text)
         self.assertGreaterEqual(workflow_text.count("generate-security-release-evidence.py verify"), 2)
         self.assertIn("permission-actions: write", workflow_text)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -121,9 +121,16 @@ class WorkflowSecurityTests(unittest.TestCase):
             if step.get("uses") == "./.github/actions/run-quality-profile"
         )
         self.assertEqual("12GiB", tiny_action["with"]["memory-limit"])
-        disabled_adapter = "${{ github.event_name == 'workflow_call' }}"
-        self.assertEqual(disabled_adapter, collection["jobs"]["heavy-cells"]["if"])
-        self.assertEqual(disabled_adapter, collection["jobs"]["acceptance-cells"]["if"])
+        for job_name, required_output in (
+            ("heavy-cells", "heavy_required"),
+            ("acceptance-cells", "acceptance_required"),
+        ):
+            guard = collection["jobs"][job_name]["if"]
+            self.assertIn("github.event_name == 'push'", guard)
+            self.assertIn("github.ref == 'refs/heads/main'", guard)
+            self.assertIn(f"quality-matrix.outputs.{required_output} == 'true'", guard)
+            self.assertNotIn("pull_request", guard)
+            self.assertNotIn("workflow_dispatch", guard)
         self.assertFalse((WORKFLOWS / "candidate-platform-validation.yml").exists())
 
     def test_copilot_and_renovate_gates_preserve_safe_update_boundaries(self) -> None:
@@ -253,7 +260,13 @@ class WorkflowSecurityTests(unittest.TestCase):
     def test_release_credentials_are_outside_pull_request_jobs(self) -> None:
         jobs = load_yaml(WORKFLOWS / "collection-ci.yml")["jobs"]
         release_security = jobs["release-security"]
-        self.assertEqual("${{ github.event_name == 'workflow_call' }}", release_security["if"])
+        release_guard = release_security["if"]
+        self.assertIn("github.event_name == 'push'", release_guard)
+        self.assertIn("github.ref == 'refs/heads/main'", release_guard)
+        self.assertNotIn("pull_request", release_guard)
+        self.assertNotIn("workflow_dispatch", release_guard)
+        self.assertEqual("ansible-collection-release-evidence", release_security["environment"])
+        self.assertIn("runtime-evidence", release_security["needs"])
         self.assertEqual("Collection / Release Evidence", jobs["evidence"]["name"])
         self.assertNotIn("environment", jobs["evidence"])
         self.assertEqual({"contents": "read"}, jobs["evidence"]["permissions"])
@@ -272,14 +285,68 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("needs.quality-matrix.outputs.tiny_required == 'true'", guard)
         self.assertIn("github.event.pull_request.head.repo.full_name == github.repository", guard)
         self.assertNotIn("github.event_name == 'schedule'", guard)
-        disabled_adapter = "${{ github.event_name == 'workflow_call' }}"
-        self.assertEqual(disabled_adapter, jobs["heavy-cells"]["if"])
-        self.assertEqual(disabled_adapter, jobs["acceptance-cells"]["if"])
-        self.assertEqual(disabled_adapter, jobs["runtime-evidence"]["if"])
+        for job_name in ("heavy-cells", "acceptance-cells", "runtime-evidence"):
+            protected_main_guard = jobs[job_name]["if"]
+            self.assertIn("github.event_name == 'push'", protected_main_guard)
+            self.assertIn("github.ref == 'refs/heads/main'", protected_main_guard)
+            self.assertNotIn("pull_request", protected_main_guard)
+            self.assertNotIn("workflow_dispatch", protected_main_guard)
+        for job_name in ("heavy-cells", "acceptance-cells"):
+            delegated = jobs[job_name]
+            self.assertEqual(
+                "ansible-collection-runtime-protected",
+                delegated["with"]["environment-name"],
+            )
+            self.assertNotIn("secrets", delegated)
         self.assertEqual("Collection / Release Evidence", jobs["evidence"]["name"])
         self.assertEqual(
             ["lint-sanity", "build-install", "role-coverage", "quality-matrix", "tiny"],
             jobs["fast"]["needs"],
+        )
+
+    def test_protected_main_evidence_adapter_is_exact_and_fail_closed(self) -> None:
+        jobs = load_yaml(WORKFLOWS / "collection-ci.yml")["jobs"]
+
+        self.assertEqual("Collection / Heavy", jobs["heavy"]["name"])
+        self.assertEqual("Collection / Application Acceptance", jobs["acceptance"]["name"])
+        self.assertEqual("Runtime evidence / exact tested SHA", jobs["runtime-evidence"]["name"])
+        self.assertEqual("Collection / Release Security", jobs["release-security"]["name"])
+        self.assertEqual("Collection / Release Validation", jobs["release-validation"]["name"])
+
+        for job_name in (
+            "heavy",
+            "acceptance",
+            "runtime-evidence",
+            "release-security",
+            "release-validation",
+        ):
+            guard = jobs[job_name]["if"]
+            self.assertIn("github.event_name == 'push'", guard)
+            self.assertIn("github.ref == 'refs/heads/main'", guard)
+            self.assertNotIn("pull_request", guard)
+            self.assertNotIn("workflow_dispatch", guard)
+
+        self.assertIn("runtime-evidence", jobs["release-security"]["needs"])
+        self.assertIn("runtime-evidence", jobs["release-validation"]["needs"])
+        release_security = json.dumps(jobs["release-security"])
+        release_validation = json.dumps(jobs["release-validation"])
+        self.assertIn("needs.runtime-evidence.result", release_security)
+        self.assertIn("needs.runtime-evidence.result", release_validation)
+        self.assertIn("collection-evidence-${{ env.SOURCE_SHA }}", release_security)
+        self.assertIn("collection-release-evidence-${{ env.SOURCE_SHA }}", release_security)
+        self.assertIn("collection-release-evidence-${{ env.SOURCE_SHA }}", release_validation)
+        final_aggregate = next(
+            step
+            for step in jobs["release-validation"]["steps"]
+            if step.get("name") == "Enforce every mandatory aggregate"
+        )
+        self.assertEqual(
+            "${{ needs.runtime-evidence.result }}",
+            final_aggregate["env"]["RUNTIME_EVIDENCE_RESULT"],
+        )
+        self.assertIn(
+            'test "$RUNTIME_EVIDENCE_RESULT" = success',
+            final_aggregate["run"],
         )
 
     def test_candidate_platforms_run_only_as_non_release_promotion_input(self) -> None:

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -346,6 +346,19 @@ class WorkflowSecurityTests(unittest.TestCase):
             'test "$RUNTIME_EVIDENCE_RESULT" = success',
             release_security_aggregate["run"],
         )
+        release_security_finalize = next(
+            step
+            for step in jobs["release-security"]["steps"]
+            if step.get("name") == "Finalize protected-main publication eligibility"
+        )
+        self.assertEqual(
+            "${{ needs.runtime-evidence.result }}",
+            release_security_finalize["env"]["RUNTIME_EVIDENCE_RESULT"],
+        )
+        self.assertIn(
+            '"runtime_evidence": os.environ["RUNTIME_EVIDENCE_RESULT"] == "success"',
+            release_security_finalize["run"],
+        )
         self.assertIn("collection-evidence-${{ env.SOURCE_SHA }}", release_security)
         self.assertIn("collection-release-evidence-${{ env.SOURCE_SHA }}", release_security)
         self.assertIn("collection-release-evidence-${{ env.SOURCE_SHA }}", release_validation)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -711,6 +711,78 @@ class WorkflowSecurityTests(unittest.TestCase):
         )
         self.assertNotIn(r"(?:[-.][0-9A-Za-z.-]+)?\Z", dispatcher)
 
+    def test_publish_security_release_is_metadata_bound_and_dispatches_after_acceptance(self) -> None:
+        workflow_path = WORKFLOWS / "collection-publish.yml"
+        workflow_text = workflow_path.read_text(encoding="utf-8")
+        publish = load_yaml(workflow_path)["jobs"]["publish"]
+        self.assertEqual("write", publish["permissions"]["attestations"])
+        step_names = [step.get("name") for step in publish["steps"]]
+        classify_index = step_names.index("Classify exact-SHA Security release metadata")
+        prepare_index = step_names.index("Prepare deterministic signed Security release evidence")
+        attest_index = step_names.index("Attest Security release evidence")
+        finalize_index = step_names.index("Finalize immutable release attachments and notes")
+        release_index = step_names.index("Create or verify GitHub Release and immutable assets")
+        verify_index = step_names.index("Verify GitHub Release download, install, and smoke")
+        receipt_index = step_names.index("Attach signed post-publication verification receipt")
+        dispatch_index = step_names.index("Dispatch immutable Security evidence after Producer acceptance")
+        self.assertLess(classify_index, prepare_index)
+        self.assertLess(prepare_index, attest_index)
+        self.assertLess(attest_index, finalize_index)
+        self.assertLess(finalize_index, release_index)
+        self.assertLess(release_index, verify_index)
+        self.assertLess(verify_index, receipt_index)
+        self.assertLess(receipt_index, dispatch_index)
+
+        steps = {step.get("name"): step for step in publish["steps"]}
+        self.assertEqual(
+            "env.SECURITY_RELEASE == 'true'",
+            steps["Prepare deterministic signed Security release evidence"]["if"],
+        )
+        self.assertEqual(
+            "env.SECURITY_RELEASE == 'true'",
+            steps["Dispatch immutable Security evidence after Producer acceptance"]["if"],
+        )
+        transition_condition = steps["Dispatch transitional central validation"]["if"]
+        self.assertEqual("env.GALAXY_REQUIRED == 'true'", transition_condition)
+        self.assertIn("No exact-version Security metadata", workflow_text)
+        self.assertIn(".lit/security-releases/${RELEASE_VERSION}.json", workflow_text)
+        self.assertIn('--metadata "$SECURITY_METADATA"', workflow_text)
+        self.assertIn("actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d", workflow_text)
+        self.assertIn('test "$APP_INSTALLATION_ID" = 148019054', workflow_text)
+        self.assertIn('test "$revocation_count" -eq 0', workflow_text)
+        self.assertGreaterEqual(workflow_text.count("generate-security-release-evidence.py verify"), 2)
+        self.assertIn("permission-actions: write", workflow_text)
+        self.assertNotIn("--clobber", workflow_text)
+
+        generator = (ROOT / "scripts/generate-security-release-evidence.py").read_text(encoding="utf-8")
+        for free_claim in (
+            'add_argument("--id"',
+            'add_argument("--security-id"',
+            'add_argument("--consumer"',
+            'add_argument("--acceptance-profile"',
+            'add_argument("--created-at"',
+            'add_argument("--not-before"',
+            'add_argument("--expires-at"',
+        ):
+            self.assertNotIn(free_claim, generator)
+        dispatcher = (ROOT / "scripts/dispatch-security-release.py").read_text(encoding="utf-8")
+        self.assertIn("security-release-update.yml/dispatches", dispatcher)
+        self.assertIn("inputs[evidence_url]", dispatcher)
+        self.assertIn("inputs[evidence_sha256]", dispatcher)
+        self.assertNotIn("inputs[evidence_id]", dispatcher)
+        self.assertNotIn('add_argument("--ref"', dispatcher)
+
+        profiles = json.loads((ROOT / ".lit" / "security-release-profiles.json").read_text(encoding="utf-8"))
+        self.assertEqual(
+            {
+                "lit.supplementary/mlx90-fixture": {
+                    "description": "Historical v3.1.2/#488 dry-run fixture; never release eligible.",
+                    "releaseEligible": False,
+                }
+            },
+            profiles["profiles"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -294,6 +294,12 @@ class WorkflowSecurityTests(unittest.TestCase):
         for job_name in ("heavy-cells", "acceptance-cells"):
             delegated = jobs[job_name]
             self.assertEqual(
+                "lightning-it/modulix-validation/.github/workflows/"
+                "collection-quality-profile.yml@"
+                "154c99eb0d907b01edc10e9b39c94ef4912fd9dd",
+                delegated["uses"],
+            )
+            self.assertEqual(
                 "ansible-collection-runtime-protected",
                 delegated["with"]["environment-name"],
             )

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -335,8 +335,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         release_security_aggregate = next(
             step
             for step in jobs["release-security"]["steps"]
-            if step.get("name")
-            == "Enforce trusted release-security result after upload"
+            if step.get("name") == "Enforce trusted release-security result after upload"
         )
         self.assertEqual(
             "${{ needs.runtime-evidence.result }}",

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -332,6 +332,20 @@ class WorkflowSecurityTests(unittest.TestCase):
         release_validation = json.dumps(jobs["release-validation"])
         self.assertIn("needs.runtime-evidence.result", release_security)
         self.assertIn("needs.runtime-evidence.result", release_validation)
+        release_security_aggregate = next(
+            step
+            for step in jobs["release-security"]["steps"]
+            if step.get("name")
+            == "Enforce trusted release-security result after upload"
+        )
+        self.assertEqual(
+            "${{ needs.runtime-evidence.result }}",
+            release_security_aggregate["env"]["RUNTIME_EVIDENCE_RESULT"],
+        )
+        self.assertIn(
+            'test "$RUNTIME_EVIDENCE_RESULT" = success',
+            release_security_aggregate["run"],
+        )
         self.assertIn("collection-evidence-${{ env.SOURCE_SHA }}", release_security)
         self.assertIn("collection-release-evidence-${{ env.SOURCE_SHA }}", release_security)
         self.assertIn("collection-release-evidence-${{ env.SOURCE_SHA }}", release_validation)


### PR DESCRIPTION
## Summary

- classify an MLX-90 Security release only from reviewed `.lit/security-releases/<fixed-version>.json` metadata at the exact protected-main release SHA
- derive canonical `lit.security-release/v1` Evidence from that metadata and the verified collection, signature bundle, CycloneDX SBOM, and provenance
- create the Evidence without replacement, sign and attest it, persist it as an immutable GitHub Release asset, and re-verify the published copy before any Security dispatch
- dispatch only the immutable Evidence asset URL and `sha256:` digest to the fixed allowlisted consumer workflow with the existing Actions-write GitHub App installation
- restore the protected-main-only evidence adapter: Heavy and Application Acceptance run through the exact SHA-pinned ModuLix reusable workflow, publish same-run/attempt evidence, and feed the direct `Collection / Release Security` and `Collection / Release Validation` prerequisites

## Fail-closed boundaries

- PRs, `develop` pushes, and manual dispatches cannot enter the protected runtime/release adapter
- the reusable jobs use `ansible-collection-runtime-protected`, inherit no secrets, and pin ModuLix commit `154c99eb0d907b01edc10e9b39c94ef4912fd9dd`
- runtime evidence is both a direct job dependency and a field in the signed `release_eligible` gate map
- the historical `lit.supplementary/mlx90-fixture` profile remains `releaseEligible: false`; no real profile or Security fix is invented
- the consumer workflow must be promoted and registered on protected `main` before the first real Security release
- invalid, expired, revoked, non-allowlisted, digest-mismatched, cross-run, cross-attempt, or non-canonical Evidence stops; there is no label, mutable-input, or weaker-path fallback
- no App permissions or secrets are added; the dispatch token requests only the already approved `Actions: write` permission and verifies App slug plus installation ID `148019054`

## Verification

- Actionlint, Yamllint, Ruff lint/format, Markdownlint, ShellCheck, Mypy, Renovate validation, changelog policy, collection smoke, role coverage/source-dependency checks, and Galaxy-style role verification pass
- 226/227 local Python tests pass; the sole unchanged macOS-only failure is the repository test that invokes unavailable `/usr/bin/bash`
- the containerized Molecule suite reaches the unchanged `artifacts-basic` scenario and fails because the macOS UID `501` has no container passwd entry (`id -un`); this is unrelated to the workflow/evidence diff
- focused protected-main adapter regressions and the independent security audit pass

No release, merge, or workflow dispatch was executed by this change.

Refs #568

- ADR: https://wiki.cloud.l-it.io/wiki/spaces/LIT/pages/2894659587
- REL-20: https://wiki.cloud.l-it.io/wiki/spaces/LIT/pages/2894790704
