### PR TITLE
fix(forgejo): protect secret-bearing pod manifest

### DIFF
--- a/.lit/security-release-profiles.json
+++ b/.lit/security-release-profiles.json
@@ -1,5 +1,9 @@
 {
   "profiles": {
+    "lit.supplementary/forgejo-manifest-secret-permissions-v1": {
+      "description": "Verify the packaged Forgejo Pod manifest writer is root:root mode 0600 with no_log enabled.",
+      "releaseEligible": true
+    },
     "lit.supplementary/mlx90-fixture": {
       "description": "Historical v3.1.2/#488 dry-run fixture; never release eligible.",
       "releaseEligible": false

--- a/.lit/security-releases/3.2.0.json
+++ b/.lit/security-releases/3.2.0.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "evidenceId": "MLX90-GHSA-VJJF-WC74-GP86-3.2.0",
+  "createdAt": "2026-08-03T03:32:24Z",
+  "securityIdentifiers": [
+    "GHSA-vjjf-wc74-gp86"
+  ],
+  "affectedVersion": "3.1.0",
+  "fixedVersion": "3.2.0",
+  "consumers": [
+    "lightning-it/container-ee-wunder-ansible-ubi9"
+  ],
+  "acceptanceProfile": "lit.supplementary/forgejo-manifest-secret-permissions-v1",
+  "validity": {
+    "notBefore": "2026-08-03T03:32:24Z",
+    "expiresAt": "2026-09-02T03:32:24Z",
+    "revoked": false
+  }
+}

--- a/changelogs/fragments/mlx90-forgejo-manifest-secret-permissions.yml
+++ b/changelogs/fragments/mlx90-forgejo-manifest-secret-permissions.yml
@@ -1,0 +1,5 @@
+---
+security_fixes:
+  - >-
+    Restrict the secret-bearing Forgejo Pod manifest to root:root mode 0600 and suppress its Ansible render output,
+    preventing local users and diff logs from exposing the effective Forgejo database password.

--- a/docs/security-release-producer.md
+++ b/docs/security-release-producer.md
@@ -33,12 +33,12 @@ The consumer derives all trusted claims and the signature-bundle URL from that v
 
 ## Current fail-closed dependency
 
-The only currently defined profile is `lit.supplementary/mlx90-fixture`; it is deliberately marked
-`releaseEligible: false` because v3.1.2/#488 is historical dry-run data, not retrospective release attestation. A real
-Security release therefore remains blocked until a separately reviewed, fix-specific acceptance profile is added to
-both the producer registry and the central final-acceptance allowlist. The consumer
-`.github/workflows/security-release-update.yml` must also be promoted and registered on its protected `main` branch
-before the first producer Security release. There is no fallback to labels, mutable claims, or a weaker dispatch.
+The historical `lit.supplementary/mlx90-fixture` profile remains explicitly non-releaseable. The separately reviewed
+`lit.supplementary/forgejo-manifest-secret-permissions-v1` profile is release eligible only for the fix identified by
+`GHSA-vjjf-wc74-gp86`; its packaged offline verifier binds the Forgejo manifest writer to root:root mode 0600 and
+`no_log: true`. The first real Security release remains blocked until this producer change, the matching central
+final-acceptance allowlist, and the consumer workflow are all promoted to their protected `main` branches. There is no
+fallback to labels, mutable claims, the historical fixture, or a weaker dispatch.
 
 The producer evidence adapter is restricted to an exact `push` on `refs/heads/main`. It delegates Heavy and
 Application Acceptance to the SHA-pinned reusable workflow in `lightning-it/modulix-validation`, using the producer's

--- a/roles/forgejo_deploy/README.md
+++ b/roles/forgejo_deploy/README.md
@@ -12,6 +12,7 @@ None.
 See `roles/forgejo_deploy/defaults/main.yml`.
 
 Key variables:
+
 - `forgejo_deploy_image`
 - `forgejo_deploy_pod_manifest_path`
 - `forgejo_deploy_host_data_dir`
@@ -32,6 +33,11 @@ Key variables:
 - `forgejo_deploy_root_url_effective`
 - `forgejo_deploy_generate_secrets`
 - `forgejo_deploy_manage_systemd`
+
+The generated Forgejo Pod manifest contains the effective database credential.
+The role therefore writes it as `root:root` with mode `0600` and suppresses the
+render task output. The optional PostgreSQL role manages its own manifest and is
+outside this role's manifest-permission guarantee.
 
 ## Dependencies
 

--- a/roles/forgejo_deploy/tasks/deploy_pod.yml
+++ b/roles/forgejo_deploy/tasks/deploy_pod.yml
@@ -374,7 +374,10 @@
   ansible.builtin.template:
     src: forgejo-pod.yml.j2
     dest: "{{ forgejo_deploy_pod_manifest_path }}"
-    mode: '0644'
+    owner: root
+    group: root
+    mode: '0600'
+  no_log: true
   notify:
     - Recreate forgejo pod
     - Run forgejo pod

--- a/scripts/verify-forgejo-manifest-security.py
+++ b/scripts/verify-forgejo-manifest-security.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Verify the packaged Forgejo manifest secret-permission contract offline."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+TASK_NAME = "Render Forgejo Pod manifest"
+MANIFEST_DESTINATION = "{{ forgejo_deploy_pod_manifest_path }}"
+MAX_SOURCE_BYTES = 1024 * 1024
+SECRET_BINDING = (
+    "        - name: FORGEJO__database__PASSWD\n"
+    '          value: "{{ forgejo_deploy_db_password_effective }}"'
+)
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"Forgejo manifest security verification failed: {message}")
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    """Safe YAML loader that rejects duplicate mapping keys."""
+
+
+def construct_unique_mapping(
+    loader: UniqueKeyLoader,
+    node: yaml.MappingNode,
+    deep: bool = False,
+) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            fail(f"duplicate YAML key: {key!r}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+UniqueKeyLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    construct_unique_mapping,
+)
+
+
+def read_bounded_file(collection_root: Path, path: Path) -> str:
+    try:
+        relative = path.relative_to(collection_root)
+    except ValueError:
+        fail(f"path escapes the collection root: {path}")
+    current = collection_root
+    for component in relative.parts:
+        current /= component
+        if current.is_symlink():
+            fail(f"expected a non-symlink path: {path}")
+    if not path.is_file():
+        fail(f"expected a regular non-symlink file: {path}")
+    try:
+        if path.stat().st_size > MAX_SOURCE_BYTES:
+            fail(f"source exceeds the {MAX_SOURCE_BYTES}-byte limit: {path}")
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:
+        fail(f"cannot read {path}: {exc}")
+
+
+def load_yaml(collection_root: Path, path: Path) -> Any:
+    try:
+        return yaml.load(read_bounded_file(collection_root, path), Loader=UniqueKeyLoader)
+    except yaml.YAMLError as exc:
+        fail(f"cannot parse {path}: {exc}")
+
+
+def verify(collection_root: Path) -> None:
+    task_path = collection_root / "roles" / "forgejo_deploy" / "tasks" / "deploy_pod.yml"
+    template_path = (
+        collection_root
+        / "roles"
+        / "forgejo_deploy"
+        / "templates"
+        / "forgejo-pod.yml.j2"
+    )
+
+    tasks = load_yaml(collection_root, task_path)
+    if not isinstance(tasks, list):
+        fail("Forgejo deployment task file is not a list")
+    matches = [
+        task
+        for task in tasks
+        if isinstance(task, dict) and task.get("name") == TASK_NAME
+    ]
+    if len(matches) != 1:
+        fail(f"expected exactly one {TASK_NAME!r} task")
+
+    task = matches[0]
+    template = task.get("ansible.builtin.template")
+    if not isinstance(template, dict):
+        fail("Forgejo manifest task does not use ansible.builtin.template")
+    if template.get("src") != "forgejo-pod.yml.j2":
+        fail("Forgejo manifest task uses an unexpected template source")
+    if template.get("dest") != MANIFEST_DESTINATION:
+        fail("Forgejo manifest task uses an unexpected destination")
+    expected = {"owner": "root", "group": "root", "mode": "0600"}
+    observed = {key: template.get(key) for key in expected}
+    if observed != expected:
+        fail("Forgejo manifest must be written as root:root with mode 0600")
+    if task.get("no_log") is not True:
+        fail("Forgejo manifest render task must set no_log to true")
+
+    writers = []
+    for candidate in tasks:
+        if not isinstance(candidate, dict):
+            continue
+        for module_name, arguments in candidate.items():
+            if (
+                isinstance(module_name, str)
+                and module_name.startswith("ansible.builtin.")
+                and isinstance(arguments, dict)
+                and arguments.get("dest") == MANIFEST_DESTINATION
+            ):
+                writers.append((candidate.get("name"), module_name))
+    if writers != [(TASK_NAME, "ansible.builtin.template")]:
+        fail("Forgejo manifest destination must have exactly one protected writer")
+
+    template_text = read_bounded_file(collection_root, template_path)
+    if template_text.count(SECRET_BINDING) != 1:
+        fail("Forgejo manifest no longer has the exact fix-specific password binding")
+
+
+def main() -> None:
+    verify(Path(__file__).resolve().parent.parent)
+    print("Forgejo manifest security contract verified")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-forgejo-manifest-security.py
+++ b/scripts/verify-forgejo-manifest-security.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Verify the packaged Forgejo manifest secret-permission contract offline."""
 
 from __future__ import annotations

--- a/tests/unit/test_forgejo_manifest_security.py
+++ b/tests/unit/test_forgejo_manifest_security.py
@@ -1,0 +1,100 @@
+"""Regression tests for the Forgejo secret-bearing Pod manifest."""
+
+from __future__ import annotations
+
+import json
+import runpy
+import subprocess
+import sys
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+TASKS = ROOT / "roles" / "forgejo_deploy" / "tasks" / "deploy_pod.yml"
+VERIFIER = ROOT / "scripts" / "verify-forgejo-manifest-security.py"
+EVIDENCE_GENERATOR = ROOT / "scripts" / "generate-security-release-evidence.py"
+PROFILE = "lit.supplementary/forgejo-manifest-secret-permissions-v1"
+
+
+class ForgejoManifestSecurityTests(unittest.TestCase):
+    def test_real_release_metadata_binds_the_ghsa_version_and_profile(self) -> None:
+        registry_path = ROOT / ".lit" / "security-release-profiles.json"
+        metadata_path = ROOT / ".lit" / "security-releases" / "3.2.0.json"
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            {
+                "description": (
+                    "Verify the packaged Forgejo Pod manifest writer is root:root mode 0600 with no_log enabled."
+                ),
+                "releaseEligible": True,
+            },
+            registry["profiles"][PROFILE],
+        )
+        self.assertEqual(["GHSA-vjjf-wc74-gp86"], metadata["securityIdentifiers"])
+        self.assertEqual("MLX90-GHSA-VJJF-WC74-GP86-3.2.0", metadata["evidenceId"])
+        self.assertEqual("3.1.0", metadata["affectedVersion"])
+        self.assertEqual("3.2.0", metadata["fixedVersion"])
+        self.assertEqual(PROFILE, metadata["acceptanceProfile"])
+        self.assertEqual(
+            ["lightning-it/container-ee-wunder-ansible-ubi9"],
+            metadata["consumers"],
+        )
+        generator = runpy.run_path(
+            str(EVIDENCE_GENERATOR),
+            run_name="security_release_evidence_module",
+        )
+        validated = generator["load_metadata"](
+            metadata_path,
+            registry_path,
+            datetime(2026, 8, 3, 3, 32, 24, tzinfo=UTC),
+        )
+        self.assertEqual(metadata, validated)
+
+    def test_secret_bearing_manifest_is_root_only_and_redacted(self) -> None:
+        tasks = yaml.safe_load(TASKS.read_text(encoding="utf-8"))
+        matches = [task for task in tasks if task.get("name") == "Render Forgejo Pod manifest"]
+        self.assertEqual(1, len(matches))
+        task = matches[0]
+        template = task["ansible.builtin.template"]
+        self.assertEqual("root", template.get("owner"))
+        self.assertEqual("root", template.get("group"))
+        self.assertEqual("0600", template.get("mode"))
+        self.assertIs(task.get("no_log"), True)
+
+    def test_packaged_offline_verifier_accepts_the_reviewed_source(self) -> None:
+        result = subprocess.run(  # noqa: S603 -- fixed interpreter and repository-owned verifier.
+            [sys.executable, str(VERIFIER)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual("Forgejo manifest security contract verified", result.stdout.strip())
+
+    def test_packaged_verifier_rejects_a_relaxed_contract(self) -> None:
+        module = runpy.run_path(str(VERIFIER), run_name="forgejo_manifest_security_module")
+        original = yaml.load
+
+        def relaxed_loader(stream: str, *, Loader: type[yaml.SafeLoader]) -> object:  # noqa: N803
+            payload = original(stream, Loader=Loader)
+            if isinstance(payload, list):
+                for task in payload:
+                    if isinstance(task, dict) and task.get("name") == "Render Forgejo Pod manifest":
+                        task["ansible.builtin.template"]["mode"] = "0644"
+            return payload
+
+        with (
+            patch.object(module["yaml"], "load", side_effect=relaxed_loader),
+            self.assertRaisesRegex(SystemExit, "root:root with mode 0600"),
+        ):
+            module["verify"](ROOT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -887,10 +887,16 @@ class WorkflowSecurityTests(unittest.TestCase):
         profiles = json.loads((ROOT / ".lit" / "security-release-profiles.json").read_text(encoding="utf-8"))
         self.assertEqual(
             {
+                "lit.supplementary/forgejo-manifest-secret-permissions-v1": {
+                    "description": (
+                        "Verify the packaged Forgejo Pod manifest writer is root:root mode 0600 with no_log enabled."
+                    ),
+                    "releaseEligible": True,
+                },
                 "lit.supplementary/mlx90-fixture": {
                     "description": "Historical v3.1.2/#488 dry-run fixture; never release eligible.",
                     "releaseEligible": False,
-                }
+                },
             },
             profiles["profiles"],
         )


### PR DESCRIPTION
## Summary

- protect the secret-bearing Forgejo Pod manifest as `root:root` with mode `0600`
- suppress the manifest render task output with `no_log: true`
- register the real, fix-specific MLX-90 producer metadata and offline acceptance verifier
- add regression tests, security changelog, and the operational boundary to the role documentation

## Security release contract

- Security ID: `GHSA-vjjf-wc74-gp86`
- Evidence ID: `MLX90-GHSA-VJJF-WC74-GP86-3.2.0`
- affected version: `3.1.0`
- fixed version: `3.2.0`
- acceptance profile: `lit.supplementary/forgejo-manifest-secret-permissions-v1`
- consumer: `lightning-it/container-ee-wunder-ansible-ubi9`

The profile is release-eligible only for the exact Forgejo manifest-permission contract. The optional PostgreSQL role manages a separate manifest and is explicitly outside this guarantee.

## Validation

- focused Forgejo security and producer-workflow regression tests: 5 passed
- packaged offline verifier: passed
- release-version resolver: `3.1.2` + minor impact -> `3.2.0`
- yamllint, ansible-lint, changelog policy, actionlint, Renovate validation, collection smoke, Galaxy verification, role coverage, source-dependency validation, Ruff, Markdownlint, and ShellCheck: passed

The full local pre-commit sweep also reported host-only deviations unrelated to this diff: the Linux Molecule container cannot resolve the macOS host UID 501, one existing unit test expects `/usr/bin/bash`, and the isolated local mypy environment has an incompatible `pathspec` installation. GitHub Current-Head CI remains authoritative.

This PR defines the reviewed inputs for a future Security release. It does not claim that version `3.2.0` has been published, promoted, consumed, or immutably accepted.
