### PR TITLE
chore(release): sync main ancestry into develop

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,6 +30,10 @@ Do not direct-push release commits, bypass protection, use an administrator
 override, or publish from a feature/develop branch. A release-generated change
 must be back-synced before the next promotion.
 
+Every merge into `main`, including a develop-to-main promotion that does not
+yet publish a release, must become an ancestor of `develop` through a reviewed
+back-sync pull request before another promotion is opened.
+
 ## Validation lanes
 
 Collection source pull requests require the stable `Collection / Fast` aggregate

--- a/changelogs/fragments/mlx90-back-sync-contract.yml
+++ b/changelogs/fragments/mlx90-back-sync-contract.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - >-
+    Document that every protected main merge must be back-synced into develop before the next promotion, preserving
+    an exact and reviewable MLX-90 release ancestry without bypassing protected branch gates.


### PR DESCRIPTION
## Summary

- merge current protected `main` ancestry into `develop`
- preserve the exact `develop` file tree containing MLX-90 Producer PR #602
- document that every future protected `main` merge must be back-synced before the next promotion
- add the required antsibull changelog fragment for that repository contract
- unblock the guarded `develop` to `main` promotion workflow

## Exact ancestry and revision

- `develop` first parent: `e57680d6c2ada98e3b244bfcdd7e6c98861d4cd7`
- protected `main` second parent: `da46cd1645c78291ce6178ae21adaec65f487f00`
- tree-identical ancestry merge: `5c0d3424f84cb7284fac2de8a80c4f28ca9bda48`
- back-sync contract commit: `a86767aa0453d8a1c5e2314c2ea07df65eb16382`
- current exact head: `bf840c1eee73f8977cceffb5432804fc5e7264fc`
- exact review patch SHA-256: `c54427c59ce0fd7b4eac8537b70d130508a935c0437a786c5f09ba0fcb78e9b7`

## Validation and merge contract

- ancestry merge tree against its first parent: unchanged
- final diff: only `RELEASE.md` and `changelogs/fragments/mlx90-back-sync-contract.yml`
- required local collection gates passed; the one host-only macOS `/usr/bin/bash` path mismatch is not present on the required Ubuntu runner and is unrelated to this documentation/changelog-only commit
- history-free exact-diff pre-push review: GitHub Copilot PASS; Codex PASS with no findings
- all checks attached to earlier revisions are obsolete; only protected checks and Copilot review on current head `bf840c1…` count
- normal merge commit only after every protected Current-Head gate succeeds
- no branch, ruleset, environment, or admin bypass

References: [MLX-90 governance issue](https://github.com/lightning-it/github-management-lit/issues/267), [producer fix #595](https://github.com/lightning-it/ansible-collection-supplementary/pull/595).
