### PR TITLE
fix: retry release PR propagation checks

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -373,7 +373,7 @@ jobs:
           max_pr_lookup_attempts=6
           owned_pr_ready=false
           owned_pulls='[]'
-          for attempt in 1 2 3 4 5 6; do
+          for (( attempt=1; attempt<=max_pr_lookup_attempts; attempt++ )); do
             if ! owned_pulls="$(
               gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
                 -f state=open \
@@ -390,7 +390,7 @@ jobs:
                 jq -er 'if type == "array" then length else error("response is not an array") end' \
                   <<< "$owned_pulls"
               )"; then
-                echo "::error::Release PR lookup returned malformed JSON."
+                echo "::error::Release PR lookup returned invalid JSON or an unexpected response shape."
                 exit 1
               fi
               if [ "$owned_count" -gt 1 ]; then

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -370,24 +370,73 @@ jobs:
               --body-file "$body_file"
           fi
 
-          owned_pulls="$(
-            gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
-              -f state=open \
-              -f "base=${TARGET_BRANCH}" \
-              -f "head=${GITHUB_REPOSITORY_OWNER}:${RELEASE_BRANCH}" \
-              -f per_page=100
-          )"
-          test "$(jq 'length' <<< "$owned_pulls")" -eq 1
-          jq -e \
-            --arg repo "$GITHUB_REPOSITORY" \
-            --arg branch "$RELEASE_BRANCH" \
-            --arg base "$TARGET_BRANCH" \
-            --arg sha "$pushed_sha" '
-              .[0].head.repo.full_name == $repo
-              and .[0].head.ref == $branch
-              and .[0].head.sha == $sha
-              and .[0].base.ref == $base
-            ' <<< "$owned_pulls" >/dev/null
+          max_pr_lookup_attempts=6
+          owned_pr_ready=false
+          owned_pulls='[]'
+          for attempt in 1 2 3 4 5 6; do
+            if ! owned_pulls="$(
+              gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
+                -f state=open \
+                -f "base=${TARGET_BRANCH}" \
+                -f "head=${GITHUB_REPOSITORY_OWNER}:${RELEASE_BRANCH}" \
+                -f per_page=100
+            )"; then
+              if [ "$attempt" -eq "$max_pr_lookup_attempts" ]; then
+                echo "::error::Release PR lookup failed on all ${max_pr_lookup_attempts} API attempts."
+                exit 1
+              fi
+            else
+              if ! owned_count="$(
+                jq -er 'if type == "array" then length else error("response is not an array") end' \
+                  <<< "$owned_pulls"
+              )"; then
+                echo "::error::Release PR lookup returned malformed JSON."
+                exit 1
+              fi
+              if [ "$owned_count" -gt 1 ]; then
+                echo "::error::Multiple same-repository release PRs exist."
+                exit 1
+              fi
+              if [ "$owned_count" -eq 1 ] && jq -e \
+                --arg repo "$GITHUB_REPOSITORY" \
+                --arg branch "$RELEASE_BRANCH" \
+                --arg base "$TARGET_BRANCH" \
+                --arg sha "$pushed_sha" '
+                  .[0].head.repo.full_name == $repo
+                  and .[0].head.ref == $branch
+                  and .[0].head.sha == $sha
+                  and .[0].base.ref == $base
+                ' <<< "$owned_pulls" >/dev/null
+              then
+                owned_pr_ready=true
+                break
+              fi
+            fi
+
+            if [ "$attempt" -lt "$max_pr_lookup_attempts" ]; then
+              retry_delay=$((1 << (attempt - 1)))
+              echo "::notice::Exact release PR head is not visible yet; retrying in ${retry_delay}s."
+              sleep "$retry_delay"
+            fi
+          done
+          if [ "$owned_pr_ready" != true ]; then
+            observed_release_pr="$(
+              jq -c '
+                map({
+                  number,
+                  head_repository: .head.repo.full_name,
+                  head_ref: .head.ref,
+                  head_sha: .head.sha,
+                  base_ref: .base.ref
+                })
+              ' <<< "$owned_pulls"
+            )"
+            echo "::error::Release PR did not converge to the exact same-repository ref/base/head" \
+              "after ${max_pr_lookup_attempts} API attempts. Expected" \
+              "${GITHUB_REPOSITORY}:${RELEASE_BRANCH}@${pushed_sha} -> ${TARGET_BRANCH};" \
+              "observed ${observed_release_pr}."
+            exit 1
+          fi
           existing="$(jq -r '.[0].number' <<< "$owned_pulls")"
           gh pr edit "$existing" \
             --title "Release v${VERSION}" \

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -415,7 +415,7 @@ jobs:
 
             if [ "$attempt" -lt "$max_pr_lookup_attempts" ]; then
               retry_delay=$((1 << (attempt - 1)))
-              echo "::notice::Exact release PR head is not visible yet; retrying in ${retry_delay}s."
+              echo "::notice::Release PR lookup has not converged to the exact expected state; retrying in ${retry_delay}s."
               sleep "$retry_delay"
             fi
           done

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -404,7 +404,8 @@ jobs:
                 exit 1
               fi
               if [ "$owned_count" -gt 1 ]; then
-                echo "::error::Multiple same-repository release PRs exist."
+                owned_numbers="$(jq -c 'map(.number)' <<< "$owned_pulls")"
+                echo "::error::Multiple same-repository release PRs exist: ${owned_numbers}."
                 exit 1
               fi
               if [ "$owned_count" -eq 1 ] && jq -e \

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -371,6 +371,7 @@ jobs:
           fi
 
           max_pr_lookup_attempts=6
+          successful_pr_lookup_count=0
           owned_pr_ready=false
           owned_pulls='[]'
           for (( attempt=1; attempt<=max_pr_lookup_attempts; attempt++ )); do
@@ -381,11 +382,17 @@ jobs:
                 -f "head=${GITHUB_REPOSITORY_OWNER}:${RELEASE_BRANCH}" \
                 -f per_page=100
             )"; then
+              owned_pulls='[]'
               if [ "$attempt" -eq "$max_pr_lookup_attempts" ]; then
-                echo "::error::Release PR lookup failed on all ${max_pr_lookup_attempts} API attempts."
+                if [ "$successful_pr_lookup_count" -eq 0 ]; then
+                  echo "::error::Release PR lookup failed on all ${max_pr_lookup_attempts} API attempts."
+                else
+                  echo "::error::Release PR lookup failed on the final API attempt after ${successful_pr_lookup_count} successful but non-converged response(s)."
+                fi
                 exit 1
               fi
             else
+              successful_pr_lookup_count=$((successful_pr_lookup_count + 1))
               if ! owned_count="$(
                 jq -er 'if type == "array" then length else error("response is not an array") end' \
                   <<< "$owned_pulls"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -375,6 +375,7 @@ jobs:
           owned_pr_ready=false
           owned_pulls='[]'
           for (( attempt=1; attempt<=max_pr_lookup_attempts; attempt++ )); do
+            lookup_outcome=api-failure
             if ! owned_pulls="$(
               gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
                 -f state=open \
@@ -392,6 +393,7 @@ jobs:
                 exit 1
               fi
             else
+              lookup_outcome=non-converged
               successful_pr_lookup_count=$((successful_pr_lookup_count + 1))
               if ! owned_count="$(
                 jq -er 'if type == "array" then length else error("response is not an array") end' \
@@ -422,7 +424,18 @@ jobs:
 
             if [ "$attempt" -lt "$max_pr_lookup_attempts" ]; then
               retry_delay=$((1 << (attempt - 1)))
-              echo "::notice::Release PR lookup has not converged to the exact expected state; retrying in ${retry_delay}s."
+              case "$lookup_outcome" in
+                api-failure)
+                  echo "::notice::Release PR API request failed; retrying in ${retry_delay}s."
+                  ;;
+                non-converged)
+                  echo "::notice::Release PR lookup has not converged to the exact expected state; retrying in ${retry_delay}s."
+                  ;;
+                *)
+                  echo "::error::Unexpected Release PR lookup outcome: ${lookup_outcome}."
+                  exit 1
+                  ;;
+              esac
               sleep "$retry_delay"
             fi
           done

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -388,7 +388,8 @@ jobs:
                 if [ "$successful_pr_lookup_count" -eq 0 ]; then
                   echo "::error::Release PR lookup failed on all ${max_pr_lookup_attempts} API attempts."
                 else
-                  echo "::error::Release PR lookup failed on the final API attempt after ${successful_pr_lookup_count} successful but non-converged response(s)."
+                  echo "::error::Release PR lookup failed on the final API attempt after" \
+                    "${successful_pr_lookup_count} successful but non-converged response(s)."
                 fi
                 exit 1
               fi
@@ -429,7 +430,8 @@ jobs:
                   echo "::notice::Release PR API request failed; retrying in ${retry_delay}s."
                   ;;
                 non-converged)
-                  echo "::notice::Release PR lookup has not converged to the exact expected state; retrying in ${retry_delay}s."
+                  echo "::notice::Release PR lookup has not converged to the exact expected state;" \
+                    "retrying in ${retry_delay}s."
                   ;;
                 *)
                   echo "::error::Unexpected Release PR lookup outcome: ${lookup_outcome}."

--- a/changelogs/fragments/release-pr-api-propagation-retry.yml
+++ b/changelogs/fragments/release-pr-api-propagation-retry.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    Retry the exact same-repository release pull-request lookup with bounded backoff after updating its branch, while
+    retaining fail-closed repository, ref, base, and pushed-head verification before editing the pull request body.

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -514,6 +514,35 @@ class WorkflowSecurityTests(unittest.TestCase):
             release_prepare,
         )
 
+    def test_release_prepare_bounds_exact_owned_pr_propagation_retries(self) -> None:
+        workflow = load_yaml(WORKFLOWS / "release-prepare.yml")
+        prepare_step = next(
+            step for step in workflow["jobs"]["prepare"]["steps"] if step.get("name") == "Prepare release branch"
+        )
+        run = prepare_step["run"]
+        retry_block = run.split('pushed_sha="$(git rev-parse HEAD)"', maxsplit=1)[1]
+        retry_block = retry_block.split("existing=\"$(jq -r '.[0].number'", maxsplit=1)[0]
+
+        self.assertIn("max_pr_lookup_attempts=6", retry_block)
+        self.assertIn("for attempt in 1 2 3 4 5 6; do", retry_block)
+        self.assertIn("retry_delay=$((1 << (attempt - 1)))", retry_block)
+        self.assertIn('sleep "$retry_delay"', retry_block)
+        self.assertIn('if [ "$owned_count" -gt 1 ]; then', retry_block)
+        self.assertIn("Multiple same-repository release PRs exist", retry_block)
+        for exact_binding in (
+            ".[0].head.repo.full_name == $repo",
+            ".[0].head.ref == $branch",
+            ".[0].head.sha == $sha",
+            ".[0].base.ref == $base",
+        ):
+            self.assertIn(exact_binding, retry_block)
+        self.assertIn(
+            "Release PR did not converge to the exact same-repository ref/base/head",
+            retry_block,
+        )
+        self.assertIn("after ${max_pr_lookup_attempts} API attempts. Expected", retry_block)
+        self.assertIn("${GITHUB_REPOSITORY}:${RELEASE_BRANCH}@${pushed_sha}", retry_block)
+
     def test_release_evidence_and_publication_are_attempt_and_identity_bound(self) -> None:
         ci = (WORKFLOWS / "collection-ci.yml").read_text(encoding="utf-8")
         self.assertIn("/${GITHUB_RUN_ID}/attempt-${GITHUB_RUN_ATTEMPT}", ci)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -545,7 +545,10 @@ class WorkflowSecurityTests(unittest.TestCase):
             retry_block,
         )
         self.assertIn(
-            "failed on the final API attempt after "
+            "failed on the final API attempt after",
+            retry_block,
+        )
+        self.assertIn(
             "${successful_pr_lookup_count} successful but non-converged response(s)",
             retry_block,
         )
@@ -559,6 +562,7 @@ class WorkflowSecurityTests(unittest.TestCase):
             "Release PR lookup has not converged to the exact expected state",
             retry_block,
         )
+        self.assertIn("retrying in ${retry_delay}s", retry_block)
         self.assertIn("Unexpected Release PR lookup outcome", retry_block)
         self.assertIn('if [ "$owned_count" -gt 1 ]; then', retry_block)
         self.assertIn("Multiple same-repository release PRs exist", retry_block)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -533,6 +533,8 @@ class WorkflowSecurityTests(unittest.TestCase):
             "for (( attempt=1; attempt<=max_pr_lookup_attempts; attempt++ )); do",
             retry_block,
         )
+        self.assertIn("lookup_outcome=api-failure", retry_block)
+        self.assertIn("lookup_outcome=non-converged", retry_block)
         self.assertGreaterEqual(retry_block.count("owned_pulls='[]'"), 2)
         self.assertIn(
             "successful_pr_lookup_count=$((successful_pr_lookup_count + 1))",
@@ -550,9 +552,14 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("retry_delay=$((1 << (attempt - 1)))", retry_block)
         self.assertIn('sleep "$retry_delay"', retry_block)
         self.assertIn(
+            "Release PR API request failed; retrying in ${retry_delay}s",
+            retry_block,
+        )
+        self.assertIn(
             "Release PR lookup has not converged to the exact expected state",
             retry_block,
         )
+        self.assertIn("Unexpected Release PR lookup outcome", retry_block)
         self.assertIn('if [ "$owned_count" -gt 1 ]; then', retry_block)
         self.assertIn("Multiple same-repository release PRs exist", retry_block)
         for exact_binding in (

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -520,11 +520,18 @@ class WorkflowSecurityTests(unittest.TestCase):
             step for step in workflow["jobs"]["prepare"]["steps"] if step.get("name") == "Prepare release branch"
         )
         run = prepare_step["run"]
-        retry_block = run.split('pushed_sha="$(git rev-parse HEAD)"', maxsplit=1)[1]
-        retry_block = retry_block.split("existing=\"$(jq -r '.[0].number'", maxsplit=1)[0]
+        retry_start = 'pushed_sha="$(git rev-parse HEAD)"'
+        retry_end = "existing=\"$(jq -r '.[0].number'"
+        self.assertIn(retry_start, run)
+        after_retry_start = run.partition(retry_start)[2]
+        self.assertIn(retry_end, after_retry_start)
+        retry_block = after_retry_start.partition(retry_end)[0]
 
         self.assertIn("max_pr_lookup_attempts=6", retry_block)
-        self.assertIn("for attempt in 1 2 3 4 5 6; do", retry_block)
+        self.assertIn(
+            "for (( attempt=1; attempt<=max_pr_lookup_attempts; attempt++ )); do",
+            retry_block,
+        )
         self.assertIn("retry_delay=$((1 << (attempt - 1)))", retry_block)
         self.assertIn('sleep "$retry_delay"', retry_block)
         self.assertIn('if [ "$owned_count" -gt 1 ]; then', retry_block)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -534,6 +534,10 @@ class WorkflowSecurityTests(unittest.TestCase):
         )
         self.assertIn("retry_delay=$((1 << (attempt - 1)))", retry_block)
         self.assertIn('sleep "$retry_delay"', retry_block)
+        self.assertIn(
+            "Release PR lookup has not converged to the exact expected state",
+            retry_block,
+        )
         self.assertIn('if [ "$owned_count" -gt 1 ]; then', retry_block)
         self.assertIn("Multiple same-repository release PRs exist", retry_block)
         for exact_binding in (

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -566,7 +566,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("Unexpected Release PR lookup outcome", retry_block)
         self.assertIn('if [ "$owned_count" -gt 1 ]; then', retry_block)
         self.assertIn(
-            "owned_numbers=\"$(jq -c 'map(.number)' <<< \"$owned_pulls\")\"",
+            'owned_numbers="$(jq -c \'map(.number)\' <<< "$owned_pulls")"',
             retry_block,
         )
         self.assertIn(

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -528,8 +528,23 @@ class WorkflowSecurityTests(unittest.TestCase):
         retry_block = after_retry_start.partition(retry_end)[0]
 
         self.assertIn("max_pr_lookup_attempts=6", retry_block)
+        self.assertIn("successful_pr_lookup_count=0", retry_block)
         self.assertIn(
             "for (( attempt=1; attempt<=max_pr_lookup_attempts; attempt++ )); do",
+            retry_block,
+        )
+        self.assertGreaterEqual(retry_block.count("owned_pulls='[]'"), 2)
+        self.assertIn(
+            "successful_pr_lookup_count=$((successful_pr_lookup_count + 1))",
+            retry_block,
+        )
+        self.assertIn(
+            'if [ "$successful_pr_lookup_count" -eq 0 ]; then',
+            retry_block,
+        )
+        self.assertIn(
+            "failed on the final API attempt after "
+            "${successful_pr_lookup_count} successful but non-converged response(s)",
             retry_block,
         )
         self.assertIn("retry_delay=$((1 << (attempt - 1)))", retry_block)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -565,7 +565,14 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("retrying in ${retry_delay}s", retry_block)
         self.assertIn("Unexpected Release PR lookup outcome", retry_block)
         self.assertIn('if [ "$owned_count" -gt 1 ]; then', retry_block)
-        self.assertIn("Multiple same-repository release PRs exist", retry_block)
+        self.assertIn(
+            "owned_numbers=\"$(jq -c 'map(.number)' <<< \"$owned_pulls\")\"",
+            retry_block,
+        )
+        self.assertIn(
+            "Multiple same-repository release PRs exist: ${owned_numbers}",
+            retry_block,
+        )
         for exact_binding in (
             ".[0].head.repo.full_name == $repo",
             ".[0].head.ref == $branch",


### PR DESCRIPTION
## Summary

- retry the exact same-repository release-PR lookup after a release-branch push with bounded exponential backoff
- retain fail-closed repository, branch, base, and exact pushed-head binding before any PR edit
- reject malformed responses and duplicate owned release PRs
- add a regression test and changelog fragment

## Why

Release prepare run 30831750873 pushed the correct v3.2.0 head, but the immediately following API read briefly returned the previous PR head. The old one-shot assertion stopped before updating PR #599. This change handles only that observed propagation window and does not weaken the ownership or SHA checks.

## Validation

- exact workflow-security regression: PASS
- changelog policy: PASS
- production Ansible lint: PASS on 1211 files
- git diff integrity: PASS

PR #599 remains unmerged until this corrected prepare path is protected and rerun. Merge this PR only after all protected current-head checks and the authoritative GitHub Copilot review pass; normal merge commit only, no bypass.