### PR TITLE
chore(release): sync current main ancestry into develop

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,6 +33,9 @@ must be back-synced before the next promotion.
 Every merge into `main`, including a develop-to-main promotion that does not
 yet publish a release, must become an ancestor of `develop` through a reviewed
 back-sync pull request before another promotion is opened.
+The back-sync must preserve the current `develop` tree and record the current
+protected `main` SHA as its second parent; a stale parent or changed source tree
+must fail closed.
 
 ## Validation lanes
 

--- a/changelogs/fragments/mlx90-current-main-back-sync.yml
+++ b/changelogs/fragments/mlx90-current-main-back-sync.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - >-
+    Bind every reviewed MLX-90 promotion back-sync to the current protected main SHA while preserving the current
+    develop tree, so stale ancestry and unintended source changes fail closed before the next promotion.


### PR DESCRIPTION
MLX-90 protected release-chain back-sync after promotion #605. The merge commit records exact current `develop@9b50c2d28f4555347b4080fdfaf0d7a98bf0cd93` as first parent and exact protected `main@5fbfaacdbb6dae1c8647789ad52228ee7f1058da` as second parent while preserving the develop source tree. The reviewable documentation delta makes the current-head/stale-head fail-closed contract explicit. Local evidence: clean diff; YAML lint passed; ansible-lint production passed; 232/233 native unit tests passed, with the sole test blocked only by macOS lacking `/usr/bin/bash`; containerized gates are delegated to GitHub because no local Docker/Podman engine is reachable. Merge only by normal merge commit after all protected current-head gates pass; no force or bypass.