### PR TITLE
fix(ci): normalize Chrome Linux scanner CPE

### DIFF
--- a/changelogs/fragments/mlx90-chrome-linux-cpe-equivalence.yml
+++ b/changelogs/fragments/mlx90-chrome-linux-cpe-equivalence.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - >-
+    Bind the observed Chrome 151.0.7922.71 Linux runtime to its reviewed
+    platform-neutral CPE equivalent 151.0.7922.72 while preserving the exact
+    Linux version, executable digest, package URL, and upstream release source
+    in the SBOM, so cross-platform NVD version ordering no longer produces
+    false blocking findings.

--- a/changelogs/fragments/mlx90-chrome-linux-cpe-equivalence.yml
+++ b/changelogs/fragments/mlx90-chrome-linux-cpe-equivalence.yml
@@ -1,3 +1,4 @@
+---
 bugfixes:
   - >-
     Bind the observed Chrome 151.0.7922.71 Linux runtime to its reviewed

--- a/scripts/enrich-cyclonedx-sbom.py
+++ b/scripts/enrich-cyclonedx-sbom.py
@@ -39,10 +39,25 @@ MUTABLE_APPLICATION_VERSIONS = {
     "unversioned",
     "unspecified",
 }
+CHROME_LINUX_CPE_EQUIVALENCE = {
+    "151.0.7922.71": (
+        "151.0.7922.72",
+        "https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0887107924.html",
+    ),
+}
 
 
 class SbomError(ValueError):
     """Raised when SBOM identity or dependency evidence is unsafe."""
+
+
+def _chrome_linux_scanner_cpe(browser_version: str) -> tuple[str, str | None]:
+    """Return the reviewed platform-neutral CPE version for an observed Linux build."""
+
+    equivalent = CHROME_LINUX_CPE_EQUIVALENCE.get(browser_version)
+    if equivalent is None:
+        return browser_version, None
+    return equivalent
 
 
 def _os_package_purl(
@@ -640,6 +655,7 @@ def enrich_sbom(
                 raise SbomError(f"malformed Chromium runtime identity: {dependency}")
             cell_identity = "\0".join((*cell, source_sha))
             browser_reference = f"urn:lit:target-browser:sha256:{hashlib.sha256(cell_identity.encode()).hexdigest()}"
+            scanner_cpe_version, scanner_cpe_source = _chrome_linux_scanner_cpe(browser_version)
             common_properties = [
                 {"name": "lit:dependency:source", "value": "target-browser-runtime"},
                 {"name": "lit:dependency:profile", "value": profile},
@@ -655,7 +671,7 @@ def enrich_sbom(
                     "version": browser_version,
                     "bom-ref": browser_reference,
                     "purl": f"pkg:generic/google-chrome@{browser_version}",
-                    "cpe": f"cpe:2.3:a:google:chrome:{browser_version}:*:*:*:*:*:*:*",
+                    "cpe": f"cpe:2.3:a:google:chrome:{scanner_cpe_version}:*:*:*:*:*:*:*",
                     "hashes": [{"alg": "SHA-256", "content": executable_digest}],
                     "properties": common_properties
                     + [
@@ -664,9 +680,29 @@ def enrich_sbom(
                         {"name": "lit:dependency:executable", "value": executable.as_posix()},
                         {
                             "name": "lit:dependency:scanner-cpe-rationale",
-                            "value": "NVD maps Chromium security advisories to the Google Chrome CPE",
+                            "value": (
+                                "NVD maps Chromium advisories to a platform-neutral Google Chrome CPE; "
+                                "the reviewed Stable update binds the observed Linux patch level to the "
+                                "paired Windows/macOS CPE patch level"
+                                if scanner_cpe_source is not None
+                                else "NVD maps Chromium security advisories to the Google Chrome CPE"
+                            ),
                         },
-                    ],
+                    ]
+                    + (
+                        [
+                            {
+                                "name": "lit:dependency:scanner-cpe-version",
+                                "value": scanner_cpe_version,
+                            },
+                            {
+                                "name": "lit:dependency:scanner-cpe-source",
+                                "value": scanner_cpe_source,
+                            },
+                        ]
+                        if scanner_cpe_source is not None
+                        else []
+                    ),
                 },
                 "browser",
             )

--- a/tests/unit/test_enrich_cyclonedx_sbom.py
+++ b/tests/unit/test_enrich_cyclonedx_sbom.py
@@ -444,7 +444,7 @@ class EnrichCycloneDxSbomTests(unittest.TestCase):
                         "chromium": {
                             "name": "chromium",
                             "channel": "chrome",
-                            "version": "140.0.7339.16",
+                            "version": "151.0.7922.71",
                             "executable": "/opt/google/chrome/chrome",
                             "sha256": "e" * 64,
                         },
@@ -490,15 +490,21 @@ class EnrichCycloneDxSbomTests(unittest.TestCase):
             )
             self.assertEqual("e" * 64, chromium["hashes"][0]["content"])
             self.assertEqual(
-                "cpe:2.3:a:google:chrome:140.0.7339.16:*:*:*:*:*:*:*",
+                "cpe:2.3:a:google:chrome:151.0.7922.72:*:*:*:*:*:*:*",
                 chromium["cpe"],
             )
             self.assertEqual(
-                "pkg:generic/google-chrome@140.0.7339.16",
+                "pkg:generic/google-chrome@151.0.7922.71",
                 chromium["purl"],
             )
             properties = {item["name"]: item["value"] for item in chromium["properties"]}
             self.assertEqual("chrome", properties["lit:dependency:browser-channel"])
+            self.assertEqual("151.0.7922.72", properties["lit:dependency:scanner-cpe-version"])
+            self.assertIn(
+                "chromereleases.googleblog.com",
+                properties["lit:dependency:scanner-cpe-source"],
+            )
+            self.assertIn("platform-neutral", properties["lit:dependency:scanner-cpe-rationale"])
             self.assertTrue(
                 any(
                     component["name"] == "libc++6"
@@ -522,6 +528,12 @@ class EnrichCycloneDxSbomTests(unittest.TestCase):
                     dependencies_root=paths["dependencies"],
                     source_sha="c" * 40,
                 )
+
+    def test_unreviewed_chrome_linux_version_keeps_its_observed_cpe_version(self) -> None:
+        self.assertEqual(
+            ("152.0.8000.1", None),
+            SBOM._chrome_linux_scanner_cpe("152.0.8000.1"),
+        )
 
     def test_root_version_mismatch_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- preserve the observed Chrome Linux version, executable digest, and purl
- bind Linux 151.0.7922.71 to its reviewed platform-neutral CPE equivalent 151.0.7922.72
- keep Grype, the High threshold, and fail-closed release evidence unchanged

## Evidence
- failing release run: https://github.com/lightning-it/ansible-collection-supplementary/actions/runs/30893465400
- all 95 blocking findings were Chrome cross-platform version-order matches
- exact Grype 0.110.0 reproduction after the fix: 0 High/Critical findings
- 202 unit tests passed; one macOS-only environment error remains because /usr/bin/bash is unavailable
- focused tests, Ruff lint/format, YAML parsing, compile, and git diff checks passed

Tracks #568.