### PR TITLE
fix(release): bind MLX-90 security evidence to v3.2.2

### DIFF
--- a/.lit/security-releases/3.2.2.json
+++ b/.lit/security-releases/3.2.2.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "evidenceId": "MLX90-GHSA-VJJF-WC74-GP86-3.2.2",
+  "createdAt": "2026-08-04T11:31:48Z",
+  "securityIdentifiers": [
+    "GHSA-vjjf-wc74-gp86"
+  ],
+  "affectedVersion": "3.1.0",
+  "fixedVersion": "3.2.2",
+  "consumers": [
+    "lightning-it/container-ee-wunder-ansible-ubi9"
+  ],
+  "acceptanceProfile": "lit.supplementary/forgejo-manifest-secret-permissions-v1",
+  "validity": {
+    "notBefore": "2026-08-04T11:31:48Z",
+    "expiresAt": "2026-09-03T11:31:48Z",
+    "revoked": false
+  }
+}

--- a/changelogs/fragments/mlx90-v322-security-release-metadata.yml
+++ b/changelogs/fragments/mlx90-v322-security-release-metadata.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Bind the first live MLX-90 security publication to collection version
+    3.2.2, the GHSA-vjjf-wc74-gp86 identifier, the reviewed Forgejo manifest
+    acceptance profile, and the allowlisted container consumer.

--- a/docs/security-release-producer.md
+++ b/docs/security-release-producer.md
@@ -31,14 +31,15 @@ The workflow signs and attests that evidence, stores it as an immutable GitHub R
 the published copy, and only then dispatches the allowlisted consumer with the evidence URL and its `sha256:` digest.
 The consumer derives all trusted claims and the signature-bundle URL from that verified evidence.
 
-## Current fail-closed dependency
+## Current live Security release candidate
 
 The historical `lit.supplementary/mlx90-fixture` profile remains explicitly non-releaseable. The separately reviewed
 `lit.supplementary/forgejo-manifest-secret-permissions-v1` profile is release eligible only for the fix identified by
 `GHSA-vjjf-wc74-gp86`; its packaged offline verifier binds the Forgejo manifest writer to root:root mode 0600 and
-`no_log: true`. The first real Security release remains blocked until this producer change, the matching central
-final-acceptance allowlist, and the consumer workflow are all promoted to their protected `main` branches. There is no
-fallback to labels, mutable claims, the historical fixture, or a weaker dispatch.
+`no_log: true`. The reviewed first live Security release candidate is bound to version `3.2.2` and the allowlisted
+`lightning-it/container-ee-wunder-ansible-ubi9` consumer. The producer, matching central final-acceptance allowlist,
+and consumer workflow are promoted to their protected `main` branches. There is no fallback to labels, mutable
+claims, the historical fixture, or a weaker dispatch.
 
 The producer evidence adapter is restricted to an exact `push` on `refs/heads/main`. It delegates Heavy and
 Application Acceptance to the SHA-pinned reusable workflow in `lightning-it/modulix-validation`, using the producer's

--- a/tests/unit/test_forgejo_manifest_security.py
+++ b/tests/unit/test_forgejo_manifest_security.py
@@ -23,7 +23,7 @@ PROFILE = "lit.supplementary/forgejo-manifest-secret-permissions-v1"
 class ForgejoManifestSecurityTests(unittest.TestCase):
     def test_real_release_metadata_binds_the_ghsa_version_and_profile(self) -> None:
         registry_path = ROOT / ".lit" / "security-release-profiles.json"
-        metadata_path = ROOT / ".lit" / "security-releases" / "3.2.0.json"
+        metadata_path = ROOT / ".lit" / "security-releases" / "3.2.2.json"
         registry = json.loads(registry_path.read_text(encoding="utf-8"))
         metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
         self.assertEqual(
@@ -36,9 +36,9 @@ class ForgejoManifestSecurityTests(unittest.TestCase):
             registry["profiles"][PROFILE],
         )
         self.assertEqual(["GHSA-vjjf-wc74-gp86"], metadata["securityIdentifiers"])
-        self.assertEqual("MLX90-GHSA-VJJF-WC74-GP86-3.2.0", metadata["evidenceId"])
+        self.assertEqual("MLX90-GHSA-VJJF-WC74-GP86-3.2.2", metadata["evidenceId"])
         self.assertEqual("3.1.0", metadata["affectedVersion"])
-        self.assertEqual("3.2.0", metadata["fixedVersion"])
+        self.assertEqual("3.2.2", metadata["fixedVersion"])
         self.assertEqual(PROFILE, metadata["acceptanceProfile"])
         self.assertEqual(
             ["lightning-it/container-ee-wunder-ansible-ubi9"],
@@ -51,7 +51,7 @@ class ForgejoManifestSecurityTests(unittest.TestCase):
         validated = generator["load_metadata"](
             metadata_path,
             registry_path,
-            datetime(2026, 8, 3, 3, 32, 24, tzinfo=UTC),
+            datetime(2026, 8, 4, 11, 31, 48, tzinfo=UTC),
         )
         self.assertEqual(metadata, validated)
 


### PR DESCRIPTION
Completes the first live MLX-90 producer binding after the v3.2.1 publication candidate was stopped fail-closed because only 3.2.0 metadata existed. Exact head 093e9653b4fa2119e4f0acf702806932de47fe71 adds reviewed version 3.2.2 evidence ID MLX90-GHSA-VJJF-WC74-GP86-3.2.2, GHSA-vjjf-wc74-gp86, the release-eligible Forgejo manifest profile, and only lightning-it/container-ee-wunder-ansible-ubi9 as consumer. Focused evidence tests, Ruff, JSON/YAML validation, and diff checks pass. The sole broader local test cannot start only because macOS has no /usr/bin/bash; protected Linux gates are authoritative. Merge only as a normal merge commit after all current-head gates pass; no force or bypass, and no secrets or tokens are included.