### PR TITLE
feat: automate evidence-bound security releases

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -16,6 +16,14 @@ on:
         type: choice
         options:
           - manual-main
+      security_version:
+        description: Exact Security release version; release automation only.
+        required: false
+        default: ""
+      security_evidence_id:
+        description: Exact MLX-90 Evidence ID; release automation only.
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -48,6 +56,68 @@ env:
       github.event.pull_request.head.sha || github.sha }}
 
 jobs:
+  security-classification:
+    name: Classify evidence-bound Security release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      security-release: ${{ steps.classify.outputs.security_release }}
+      security-evidence-id: ${{ steps.classify.outputs.security_evidence_id }}
+      security-version: ${{ steps.classify.outputs.security_version }}
+    steps:
+      - name: Checkout exact source for classification
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ env.SOURCE_SHA }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Classify exact event without granting an environment
+        id: classify
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || '' }}
+          BASE_SHA: ${{ env.COMPARE_BASE_SHA }}
+          EVIDENCE_ID: ${{ inputs.security_evidence_id || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          HEAD_REF: ${{ env.COMPARE_HEAD_REF }}
+          HEAD_SHA: ${{ env.SOURCE_SHA }}
+          SECURITY_VERSION: ${{ inputs.security_version || '' }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request)
+              python scripts/classify-security-release.py \
+                --event-kind pull_request \
+                --base-sha "$BASE_SHA" \
+                --head-sha "$HEAD_SHA" \
+                --base-ref "$BASE_REF" \
+                --head-ref "$HEAD_REF" \
+                --evidence-id "$EVIDENCE_ID"
+              ;;
+            push)
+              commit_message="$(git show -s --format=%B "$HEAD_SHA")"
+              python scripts/classify-security-release.py \
+                --event-kind push \
+                --base-sha "$BASE_SHA" \
+                --head-sha "$HEAD_SHA" \
+                --ref "$EVENT_REF" \
+                --commit-message "$commit_message" \
+                --evidence-id "$EVIDENCE_ID"
+              ;;
+            workflow_dispatch)
+              python scripts/classify-security-release.py \
+                --event-kind version \
+                --version "$SECURITY_VERSION" \
+                --evidence-id "$EVIDENCE_ID"
+              ;;
+            *)
+              echo "Unsupported classification event: $EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac
+
   lint-sanity:
     name: Collection / Lint and Sanity
     runs-on: ubuntu-latest
@@ -344,13 +414,21 @@ jobs:
        (github.event.pull_request.base.ref == 'develop' ||
         (github.event.pull_request.base.ref == 'main' &&
          (github.event.pull_request.head.ref == 'develop' ||
-          startsWith(github.event.pull_request.head.ref, 'release/v'))))) ||
+          startsWith(github.event.pull_request.head.ref, 'release/v') ||
+          startsWith(github.event.pull_request.head.ref, 'security-release/'))))) ||
       (github.event_name == 'push' &&
        (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main')) ||
       (github.event_name == 'workflow_dispatch' &&
        ((inputs.execution_mode == 'manual-main' && github.ref == 'refs/heads/main') ||
-        (inputs.execution_mode == 'nightly-develop' && github.ref == 'refs/heads/develop'))))
-    needs: [build-install, quality-matrix]
+        (inputs.execution_mode == 'nightly-develop' && github.ref == 'refs/heads/develop')))) &&
+      (needs.security-classification.outputs.security-release != 'true' ||
+       (github.event_name == 'pull_request' &&
+        github.event.pull_request.user.login ==
+          'lightning-it-release-automation[bot]' &&
+        github.event.pull_request.head.repo.full_name == github.repository) ||
+       (github.event_name != 'pull_request' &&
+        github.actor == 'lightning-it-release-automation[bot]'))
+    needs: [build-install, quality-matrix, security-classification]
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -358,7 +436,17 @@ jobs:
     runs-on: ${{ matrix.runner }}
     environment:
       name: >-
-        ${{ github.event_name == 'pull_request' &&
+        ${{ needs.security-classification.outputs.security-release == 'true' &&
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.user.login ==
+              'lightning-it-release-automation[bot]' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            'mlx90-security-runtime-tests' ||
+            needs.security-classification.outputs.security-release == 'true' &&
+            github.event_name != 'pull_request' &&
+            github.actor == 'lightning-it-release-automation[bot]' &&
+            'mlx90-security-runtime-protected' ||
+            github.event_name == 'pull_request' &&
             'ansible-collection-runtime-tests' ||
             'ansible-collection-runtime-protected' }}
     timeout-minutes: 90
@@ -1040,12 +1128,27 @@ jobs:
     if: >-
       always() &&
       github.event_name == 'push' &&
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/main' &&
+      (needs.security-classification.outputs.security-release != 'true' ||
+       github.actor == 'lightning-it-release-automation[bot]')
     needs:
-      [lint-sanity, build-install, role-coverage, tiny, heavy, acceptance, runtime-evidence, evidence]
+      - security-classification
+      - lint-sanity
+      - build-install
+      - role-coverage
+      - tiny
+      - heavy
+      - acceptance
+      - runtime-evidence
+      - evidence
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    environment: ansible-collection-release-evidence
+    environment:
+      name: >-
+        ${{ needs.security-classification.outputs.security-release == 'true' &&
+            github.actor == 'lightning-it-release-automation[bot]' &&
+            'mlx90-security-release-evidence' ||
+            'ansible-collection-release-evidence' }}
     permissions:
       actions: read
       artifact-metadata: write

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -33,6 +33,10 @@ on:
       reviewed_base_sha:
         description: Reviewed PR base parent for automated merge-integrity validation.
         required: true
+      security_evidence_id:
+        description: Exact MLX-90 Evidence ID; release automation only.
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -116,6 +120,7 @@ jobs:
           fi
 
           {
+            echo "release_version=$release_version"
             echo "release_sha=$MERGE_SHA"
             echo "reviewed_head_sha=$REVIEWED_HEAD_SHA"
             echo "reviewed_base_sha=${parents[0]}"
@@ -123,14 +128,41 @@ jobs:
             echo "publish_galaxy=$publish_galaxy"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Checkout exact merge for Security classification
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ steps.release.outputs.release_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Classify evidence-bound release version
+        id: security
+        env:
+          RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
+        run: >-
+          python scripts/classify-security-release.py
+          --event-kind version
+          --version "$RELEASE_VERSION"
+
+      - name: Mint exact publish-dispatch App token
+        id: publish-dispatch-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-actions: write
+
       - name: Dispatch exact-SHA publish workflow on main
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.publish-dispatch-app.outputs.token }}
           CREATE_GITHUB_RELEASE: ${{ steps.release.outputs.create_github_release }}
           PUBLISH_GALAXY: ${{ steps.release.outputs.publish_galaxy }}
           RELEASE_SHA: ${{ steps.release.outputs.release_sha }}
           REVIEWED_HEAD_SHA: ${{ steps.release.outputs.reviewed_head_sha }}
           REVIEWED_BASE_SHA: ${{ steps.release.outputs.reviewed_base_sha }}
+          SECURITY_EVIDENCE_ID: ${{ steps.security.outputs.security_evidence_id }}
         run: |
           set -euo pipefail
 
@@ -141,16 +173,72 @@ jobs:
             -f publish_galaxy="$PUBLISH_GALAXY" \
             -f release_sha="$RELEASE_SHA" \
             -f reviewed_head_sha="$REVIEWED_HEAD_SHA" \
-            -f reviewed_base_sha="$REVIEWED_BASE_SHA"
+            -f reviewed_base_sha="$REVIEWED_BASE_SHA" \
+            -f security_evidence_id="$SECURITY_EVIDENCE_ID"
+
+  security-classification:
+    name: Classify exact publish request
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      security-release: ${{ steps.classify.outputs.security_release }}
+      security-evidence-id: ${{ steps.classify.outputs.security_evidence_id }}
+      security-version: ${{ steps.classify.outputs.security_version }}
+    steps:
+      - name: Checkout requested protected-main SHA
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ inputs.release_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify main identity and classify before environment selection
+        id: classify
+        env:
+          EVIDENCE_ID: ${{ inputs.security_evidence_id || '' }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$RELEASE_SHA"
+          test "$(git ls-remote origin refs/heads/main | awk '{print $1}')" = "$RELEASE_SHA"
+          release_version="$(python - <<'PY'
+          import re
+          from pathlib import Path
+          match = re.search(
+              r"(?m)^version:\s*[\"']?([^\s\"']+)",
+              Path("galaxy.yml").read_text(encoding="utf-8"),
+          )
+          if match is None:
+              raise SystemExit("galaxy.yml has no version")
+          print(match.group(1))
+          PY
+          )"
+          python scripts/classify-security-release.py \
+            --event-kind version \
+            --version "$release_version" \
+            --evidence-id "$EVIDENCE_ID"
 
   publish:
     if: >-
       github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/main' &&
+      (needs.security-classification.outputs.security-release != 'true' ||
+       github.actor == 'lightning-it-release-automation[bot]')
     name: Publish collection release
+    needs: security-classification
     runs-on: ubuntu-latest
     timeout-minutes: 180
-    environment: ansible-collections
+    environment:
+      name: >-
+        ${{ needs.security-classification.outputs.security-release == 'true' &&
+            github.actor == 'lightning-it-release-automation[bot]' &&
+            'mlx90-security-publish' ||
+            'ansible-collections' }}
     concurrency:
       group: collection-release-${{ github.repository }}
       cancel-in-progress: false
@@ -1488,12 +1576,23 @@ jobs:
           ANSIBLE_COLLECTIONS_PATH="$install_root" \
             ansible-playbook --syntax-check "$installed_playbook"
 
+      - name: Mint exact back-sync dispatch App token
+        id: back-sync-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-actions: write
+
       - name: Trigger release back-sync after verified publication
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.back-sync-app.outputs.token }}
           RELEASE_TAG_APP_SLUG: ${{ steps.release-tag-token.outputs.app-slug }}
           RELEASE_TAG_APP_ID: ${{ vars.RELEASE_TAG_APP_ID }}
           RELEASE_TAG_APP_CLIENT_ID: ${{ vars.RELEASE_TAG_APP_CLIENT_ID }}
+          SECURITY_EVIDENCE_ID: ${{ needs.security-classification.outputs.security-evidence-id }}
         run: |
           set -euo pipefail
           gh workflow run release-back-sync.yml \
@@ -1502,7 +1601,8 @@ jobs:
             -f tag="$RELEASE_TAG" \
             -f release_tag_app_slug="$RELEASE_TAG_APP_SLUG" \
             -f release_tag_app_id="$RELEASE_TAG_APP_ID" \
-            -f release_tag_app_client_id="$RELEASE_TAG_APP_CLIENT_ID"
+            -f release_tag_app_client_id="$RELEASE_TAG_APP_CLIENT_ID" \
+            -f security_evidence_id="$SECURITY_EVIDENCE_ID"
 
       - name: Attach signed post-publication verification receipt
         env:

--- a/.github/workflows/release-back-sync.yml
+++ b/.github/workflows/release-back-sync.yml
@@ -17,6 +17,10 @@ on:
       release_tag_app_client_id:
         description: Exact GitHub App client ID validated by the protected publish job.
         required: true
+      security_evidence_id:
+        description: Exact MLX-90 Evidence ID; release automation only.
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -27,11 +31,53 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  back-sync:
-    name: Open release back-sync PR
+  security-classification:
+    name: Classify exact back-sync request
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    environment: ansible-collection-release-prepare
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      security-release: ${{ steps.classify.outputs.security_release }}
+      security-evidence-id: ${{ steps.classify.outputs.security_evidence_id }}
+      security-version: ${{ steps.classify.outputs.security_version }}
+    steps:
+      - name: Checkout exact protected-main source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify tag-shaped input and classify before environment selection
+        id: classify
+        env:
+          EVIDENCE_ID: ${{ inputs.security_evidence_id || '' }}
+          TAG_INPUT: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$TAG_INPUT" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::A stable semantic v-prefixed release tag is required."
+            exit 1
+          fi
+          python scripts/classify-security-release.py \
+            --event-kind version \
+            --version "${TAG_INPUT#v}" \
+            --evidence-id "$EVIDENCE_ID"
+
+  back-sync:
+    name: Open release back-sync PR
+    needs: security-classification
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (needs.security-classification.outputs.security-release != 'true' ||
+       github.actor == 'lightning-it-release-automation[bot]')
+    runs-on: ubuntu-latest
+    environment:
+      name: >-
+        ${{ needs.security-classification.outputs.security-release == 'true' &&
+            'mlx90-security-release-prepare' ||
+            'ansible-collection-release-prepare' }}
 
     steps:
       - name: Mint release automation App token

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -32,6 +32,10 @@ on:
         default: "true"
         type: choice
         options: ["true", "false"]
+      security_evidence_id:
+        description: Exact MLX-90 Evidence ID; release automation only.
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -42,20 +46,72 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  security-classification:
+    name: Classify evidence-bound Security release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      security-release: ${{ steps.classify.outputs.security_release }}
+      security-evidence-id: ${{ steps.classify.outputs.security_evidence_id }}
+      security-version: ${{ steps.classify.outputs.security_version }}
+    steps:
+      - name: Checkout exact protected-main source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Classify before selecting a protected environment
+        id: classify
+        env:
+          BEFORE_SHA: ${{ github.event.before || '' }}
+          EVIDENCE_ID: ${{ inputs.security_evidence_id || '' }}
+          EVENT_NAME: ${{ github.event_name }}
+          VERSION: ${{ inputs.version || '' }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = push ]; then
+            commit_message="$(git show -s --format=%B "$GITHUB_SHA")"
+            python scripts/classify-security-release.py \
+              --event-kind push \
+              --base-sha "$BEFORE_SHA" \
+              --head-sha "$GITHUB_SHA" \
+              --ref "$GITHUB_REF" \
+              --commit-message "$commit_message" \
+              --evidence-id "$EVIDENCE_ID"
+          else
+            python scripts/classify-security-release.py \
+              --event-kind version \
+              --version "$VERSION" \
+              --evidence-id "$EVIDENCE_ID"
+          fi
+
   prepare:
     name: Prepare release PR
     runs-on: ubuntu-latest
+    needs: security-classification
     if: >-
       (
-        github.event_name == 'workflow_dispatch' &&
-        github.ref == 'refs/heads/main'
-      ) ||
-      (
-        github.event_name == 'push' &&
-        github.ref == 'refs/heads/main' &&
-        !startsWith(github.event.head_commit.message, 'chore(release): prepare v')
-      )
-    environment: ansible-collection-release-prepare
+        (
+          github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/main'
+        ) ||
+        (
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' &&
+          !startsWith(github.event.head_commit.message, 'chore(release): prepare v')
+        )
+      ) &&
+      (needs.security-classification.outputs.security-release != 'true' ||
+       github.actor == 'lightning-it-release-automation[bot]')
+    environment:
+      name: >-
+        ${{ needs.security-classification.outputs.security-release == 'true' &&
+            github.actor == 'lightning-it-release-automation[bot]' &&
+            'mlx90-security-release-prepare' ||
+            'ansible-collection-release-prepare' }}
 
     steps:
       - name: Mint release automation App token

--- a/changelogs/fragments/mlx90-zero-touch-release-chain.yml
+++ b/changelogs/fragments/mlx90-zero-touch-release-chain.yml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - >-
+    Route MLX-90 release-App and GitHub-Actions execution through dedicated
+    reviewer-free protected environments so evidence, preparation,
+    publication, promotion, and back-sync can complete without a human
+    deployment approval while retaining the existing manual environments for
+    non-automation callers.

--- a/scripts/classify-security-release.py
+++ b/scripts/classify-security-release.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Classify only evidence-bound MLX-90 Security release events."""
 
 from __future__ import annotations

--- a/scripts/classify-security-release.py
+++ b/scripts/classify-security-release.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Classify only evidence-bound MLX-90 Security release events."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SEMVER = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+SHA = re.compile(r"^[0-9a-f]{40}$")
+EVIDENCE_ID = re.compile(r"^MLX90-[A-Z0-9][A-Z0-9._-]{2,127}$")
+SECURITY_ID = re.compile(r"^(?:CVE-[0-9]{4}-[0-9]{4,}|GHSA-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4})$")
+PROFILE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{2,127}$")
+METADATA_PATH = re.compile(r"^\.lit/security-releases/([0-9]+\.[0-9]+\.[0-9]+)\.json$")
+RELEASE_BRANCH = re.compile(r"^release/v([0-9]+\.[0-9]+\.[0-9]+)$")
+SECURITY_BRANCH = re.compile(r"^security-release/(MLX90-[A-Z0-9][A-Z0-9._-]{2,127})$")
+PREPARE_TITLE = re.compile(r"(?:^|\n)chore\(release\): prepare v([0-9]+\.[0-9]+\.[0-9]+)(?:$|\n)")
+PRODUCER = "lightning-it/ansible-collection-supplementary"
+CONSUMER = "lightning-it/container-ee-wunder-ansible-ubi9"
+METADATA_KEYS = {
+    "schemaVersion",
+    "evidenceId",
+    "createdAt",
+    "securityIdentifiers",
+    "affectedVersion",
+    "fixedVersion",
+    "consumers",
+    "acceptanceProfile",
+    "validity",
+}
+VALIDITY_KEYS = {"notBefore", "expiresAt", "revoked"}
+
+
+class ClassificationError(ValueError):
+    """Raised when an event claims Security semantics without valid evidence."""
+
+
+@dataclass(frozen=True)
+class Classification:
+    security_release: bool
+    evidence_id: str = ""
+    version: str = ""
+
+
+def fail(message: str) -> None:
+    raise ClassificationError(message)
+
+
+def timestamp(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not value:
+        fail(f"{field} must be a non-empty RFC3339 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ClassificationError(f"{field} must be RFC3339") from exc
+    if parsed.tzinfo is None:
+        fail(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def load_json(path: Path, label: str) -> dict[str, Any]:
+    if not path.is_file() or path.is_symlink():
+        fail(f"{label} must be a regular file")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ClassificationError(f"{label} is not valid UTF-8 JSON") from exc
+    if not isinstance(payload, dict):
+        fail(f"{label} must be a JSON object")
+    return payload
+
+
+def exact_keys(payload: dict[str, Any], expected: set[str], label: str) -> None:
+    if set(payload) != expected:
+        fail(f"{label} has unexpected or missing fields")
+
+
+def classify_version(
+    root: Path,
+    version: str,
+    expected_evidence_id: str,
+    checked_at: datetime,
+) -> Classification:
+    if SEMVER.fullmatch(version) is None:
+        fail("Security release version is not stable SemVer")
+    metadata_path = root / ".lit" / "security-releases" / f"{version}.json"
+    if not metadata_path.exists():
+        if expected_evidence_id:
+            fail("claimed Security release metadata is missing")
+        return Classification(False)
+
+    metadata = load_json(metadata_path, "Security release metadata")
+    exact_keys(metadata, METADATA_KEYS, "Security release metadata")
+    if metadata["schemaVersion"] != 1:
+        fail("Security release metadata schemaVersion must be 1")
+    evidence_id = metadata["evidenceId"]
+    if not isinstance(evidence_id, str) or EVIDENCE_ID.fullmatch(evidence_id) is None:
+        fail("Security release evidenceId is invalid")
+    if expected_evidence_id and evidence_id != expected_evidence_id:
+        fail("Security release evidenceId does not match the event binding")
+    if metadata["fixedVersion"] != version:
+        fail("Security release fixedVersion does not match its path")
+    affected = metadata["affectedVersion"]
+    if not isinstance(affected, str) or SEMVER.fullmatch(affected) is None or affected == version:
+        fail("Security release affectedVersion is invalid")
+    identifiers = metadata["securityIdentifiers"]
+    if (
+        not isinstance(identifiers, list)
+        or not identifiers
+        or len(identifiers) != len(set(identifiers))
+        or any(not isinstance(item, str) or SECURITY_ID.fullmatch(item) is None for item in identifiers)
+    ):
+        fail("Security release identifiers are invalid")
+    if metadata["consumers"] != [CONSUMER]:
+        fail("Security release consumer allowlist is invalid")
+    profile_id = metadata["acceptanceProfile"]
+    if not isinstance(profile_id, str) or PROFILE_ID.fullmatch(profile_id) is None:
+        fail("Security release acceptanceProfile is invalid")
+
+    profiles = load_json(
+        root / ".lit" / "security-release-profiles.json",
+        "Security release profile registry",
+    )
+    exact_keys(profiles, {"schemaVersion", "profiles"}, "Security release profile registry")
+    if profiles["schemaVersion"] != 1 or not isinstance(profiles["profiles"], dict):
+        fail("Security release profile registry is unsupported")
+    profile = profiles["profiles"].get(profile_id)
+    if not isinstance(profile, dict) or profile.get("releaseEligible") is not True:
+        fail("Security release acceptanceProfile is not release eligible")
+
+    validity = metadata["validity"]
+    if not isinstance(validity, dict):
+        fail("Security release validity must be an object")
+    exact_keys(validity, VALIDITY_KEYS, "Security release validity")
+    if validity["revoked"] is not False:
+        fail("Security release metadata is revoked")
+    created_at = timestamp(metadata["createdAt"], "createdAt")
+    not_before = timestamp(validity["notBefore"], "validity.notBefore")
+    expires_at = timestamp(validity["expiresAt"], "validity.expiresAt")
+    if not_before > created_at or created_at >= expires_at:
+        fail("Security release createdAt is outside its validity interval")
+    if checked_at < not_before or checked_at >= expires_at:
+        fail("Security release metadata is not currently valid")
+    return Classification(True, evidence_id, version)
+
+
+def changed_security_versions(root: Path, base_sha: str, head_sha: str) -> list[str]:
+    for label, value in (("base SHA", base_sha), ("head SHA", head_sha)):
+        if SHA.fullmatch(value) is None:
+            fail(f"{label} is invalid")
+    result = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--name-only",
+            "--diff-filter=AM",
+            base_sha,
+            head_sha,
+            "--",
+            ".lit/security-releases",
+        ],
+        cwd=root,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    versions: list[str] = []
+    for raw in result.stdout.splitlines():
+        match = METADATA_PATH.fullmatch(raw)
+        if match is None:
+            fail("Security release metadata change has an invalid path")
+        versions.append(match.group(1))
+    if len(versions) > 1 or len(versions) != len(set(versions)):
+        fail("an event may bind at most one Security release metadata file")
+    return versions
+
+
+def classify(args: argparse.Namespace, root: Path, checked_at: datetime) -> Classification:
+    if args.event_kind == "version":
+        if not args.version:
+            if args.evidence_id:
+                fail("Security evidenceId requires an exact version")
+            return Classification(False)
+        return classify_version(root, args.version, args.evidence_id, checked_at)
+
+    if args.event_kind == "pull_request":
+        if args.base_ref != "main":
+            return Classification(False)
+        release = RELEASE_BRANCH.fullmatch(args.head_ref)
+        if release is not None:
+            return classify_version(root, release.group(1), args.evidence_id, checked_at)
+        security = SECURITY_BRANCH.fullmatch(args.head_ref)
+        if security is None:
+            return Classification(False)
+        versions = changed_security_versions(root, args.base_sha, args.head_sha)
+        if len(versions) != 1:
+            fail("Security release branch must change exactly one metadata file")
+        return classify_version(root, versions[0], security.group(1), checked_at)
+
+    if args.event_kind == "push":
+        if args.ref != "refs/heads/main":
+            return Classification(False)
+        versions = changed_security_versions(root, args.base_sha, args.head_sha)
+        if versions:
+            return classify_version(root, versions[0], args.evidence_id, checked_at)
+        prepared = PREPARE_TITLE.search(args.commit_message)
+        if prepared is not None:
+            return classify_version(root, prepared.group(1), args.evidence_id, checked_at)
+        return Classification(False)
+
+    fail("unsupported event kind")
+
+
+def write_output(classification: Classification, path: str) -> None:
+    fields = {
+        "security_release": str(classification.security_release).lower(),
+        "security_evidence_id": classification.evidence_id,
+        "security_version": classification.version,
+    }
+    if path:
+        output = Path(path)
+        with output.open("a", encoding="utf-8") as stream:
+            for key, value in fields.items():
+                stream.write(f"{key}={value}\n")
+    print(json.dumps(fields, sort_keys=True, separators=(",", ":")))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event-kind", choices=("pull_request", "push", "version"), required=True)
+    parser.add_argument("--base-sha", default="")
+    parser.add_argument("--head-sha", default="")
+    parser.add_argument("--base-ref", default="")
+    parser.add_argument("--head-ref", default="")
+    parser.add_argument("--ref", default="")
+    parser.add_argument("--commit-message", default="")
+    parser.add_argument("--version", default="")
+    parser.add_argument("--evidence-id", default="")
+    parser.add_argument("--checked-at", default="")
+    parser.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT", ""))
+    args = parser.parse_args()
+    checked_at = (
+        timestamp(args.checked_at, "--checked-at")
+        if args.checked_at
+        else datetime.now(timezone.utc)
+    )
+    try:
+        result = classify(args, Path.cwd(), checked_at)
+    except (ClassificationError, subprocess.CalledProcessError) as exc:
+        parser.error(str(exc))
+    write_output(result, args.github_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_security_release_classification.py
+++ b/tests/unit/test_security_release_classification.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import importlib.util
-from argparse import Namespace
-from datetime import datetime, timezone
 import json
-from pathlib import Path
 import sys
 import tempfile
 import unittest
+from argparse import Namespace
+from datetime import UTC, datetime
+from pathlib import Path
 from unittest import mock
-
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "classify-security-release.py"
@@ -19,7 +18,7 @@ if SPEC is None or SPEC.loader is None:
 MODULE = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = MODULE
 SPEC.loader.exec_module(MODULE)
-CHECKED_AT = datetime(2026, 8, 8, tzinfo=timezone.utc)
+CHECKED_AT = datetime(2026, 8, 8, tzinfo=UTC)
 EVIDENCE_ID = "MLX90-GHSA-VJJF-WC74-GP86-3.2.2"
 
 
@@ -74,9 +73,7 @@ class SecurityReleaseClassificationTests(unittest.TestCase):
                 "revoked": False,
             },
         }
-        (metadata_root / "3.2.2.json").write_text(
-            json.dumps(self.metadata), encoding="utf-8"
-        )
+        (metadata_root / "3.2.2.json").write_text(json.dumps(self.metadata), encoding="utf-8")
 
     def tearDown(self):
         self.temporary.cleanup()
@@ -108,7 +105,7 @@ class SecurityReleaseClassificationTests(unittest.TestCase):
             MODULE.classify(
                 args(event_kind="version", version="3.2.2"),
                 self.root,
-                datetime(2026, 10, 1, tzinfo=timezone.utc),
+                datetime(2026, 10, 1, tzinfo=UTC),
             )
 
     def test_normal_develop_and_unrelated_main_events_stay_manual(self):

--- a/tests/unit/test_security_release_classification.py
+++ b/tests/unit/test_security_release_classification.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import importlib.util
+from argparse import Namespace
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "classify-security-release.py"
+SPEC = importlib.util.spec_from_file_location("security_release_classifier", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+CHECKED_AT = datetime(2026, 8, 8, tzinfo=timezone.utc)
+EVIDENCE_ID = "MLX90-GHSA-VJJF-WC74-GP86-3.2.2"
+
+
+def args(**overrides):
+    values = {
+        "event_kind": "version",
+        "base_sha": "1" * 40,
+        "head_sha": "2" * 40,
+        "base_ref": "",
+        "head_ref": "",
+        "ref": "",
+        "commit_message": "",
+        "version": "",
+        "evidence_id": "",
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+class SecurityReleaseClassificationTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        metadata_root = self.root / ".lit" / "security-releases"
+        metadata_root.mkdir(parents=True)
+        (self.root / ".lit" / "security-release-profiles.json").write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "profiles": {
+                        "lit.supplementary/fix-v1": {
+                            "description": "fixture",
+                            "releaseEligible": True,
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.metadata = {
+            "schemaVersion": 1,
+            "evidenceId": EVIDENCE_ID,
+            "createdAt": "2026-08-04T11:31:48Z",
+            "securityIdentifiers": ["GHSA-vjjf-wc74-gp86"],
+            "affectedVersion": "3.1.0",
+            "fixedVersion": "3.2.2",
+            "consumers": ["lightning-it/container-ee-wunder-ansible-ubi9"],
+            "acceptanceProfile": "lit.supplementary/fix-v1",
+            "validity": {
+                "notBefore": "2026-08-04T11:31:48Z",
+                "expiresAt": "2026-09-03T11:31:48Z",
+                "revoked": False,
+            },
+        }
+        (metadata_root / "3.2.2.json").write_text(
+            json.dumps(self.metadata), encoding="utf-8"
+        )
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def test_exact_version_classifies_only_real_metadata(self):
+        result = MODULE.classify(
+            args(event_kind="version", version="3.2.2", evidence_id=EVIDENCE_ID),
+            self.root,
+            CHECKED_AT,
+        )
+        self.assertTrue(result.security_release)
+        self.assertEqual(EVIDENCE_ID, result.evidence_id)
+        self.assertFalse(
+            MODULE.classify(
+                args(event_kind="version", version="3.2.3"),
+                self.root,
+                CHECKED_AT,
+            ).security_release
+        )
+
+    def test_claimed_evidence_mismatch_and_expiry_fail_closed(self):
+        with self.assertRaisesRegex(MODULE.ClassificationError, "does not match"):
+            MODULE.classify(
+                args(event_kind="version", version="3.2.2", evidence_id="MLX90-OTHER"),
+                self.root,
+                CHECKED_AT,
+            )
+        with self.assertRaisesRegex(MODULE.ClassificationError, "not currently valid"):
+            MODULE.classify(
+                args(event_kind="version", version="3.2.2"),
+                self.root,
+                datetime(2026, 10, 1, tzinfo=timezone.utc),
+            )
+
+    def test_normal_develop_and_unrelated_main_events_stay_manual(self):
+        self.assertFalse(
+            MODULE.classify(
+                args(event_kind="pull_request", base_ref="develop", head_ref="release/v3.2.2"),
+                self.root,
+                CHECKED_AT,
+            ).security_release
+        )
+        with mock.patch.object(MODULE, "changed_security_versions", return_value=[]):
+            self.assertFalse(
+                MODULE.classify(
+                    args(event_kind="push", ref="refs/heads/main", commit_message="feat: normal"),
+                    self.root,
+                    CHECKED_AT,
+                ).security_release
+            )
+
+    def test_release_pr_and_security_branch_are_evidence_bound(self):
+        release = MODULE.classify(
+            args(event_kind="pull_request", base_ref="main", head_ref="release/v3.2.2"),
+            self.root,
+            CHECKED_AT,
+        )
+        self.assertTrue(release.security_release)
+        with mock.patch.object(MODULE, "changed_security_versions", return_value=["3.2.2"]):
+            security = MODULE.classify(
+                args(
+                    event_kind="pull_request",
+                    base_ref="main",
+                    head_ref=f"security-release/{EVIDENCE_ID}",
+                ),
+                self.root,
+                CHECKED_AT,
+            )
+        self.assertTrue(security.security_release)
+
+    def test_main_push_classifies_metadata_or_release_prepare_only(self):
+        with mock.patch.object(MODULE, "changed_security_versions", return_value=["3.2.2"]):
+            promoted = MODULE.classify(
+                args(event_kind="push", ref="refs/heads/main"),
+                self.root,
+                CHECKED_AT,
+            )
+        self.assertTrue(promoted.security_release)
+        with mock.patch.object(MODULE, "changed_security_versions", return_value=[]):
+            prepared = MODULE.classify(
+                args(
+                    event_kind="push",
+                    ref="refs/heads/main",
+                    commit_message="Merge pull request #1\n\nchore(release): prepare v3.2.2",
+                ),
+                self.root,
+                CHECKED_AT,
+            )
+        self.assertTrue(prepared.security_release)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_security_release_classification.py
+++ b/tests/unit/test_security_release_classification.py
@@ -14,7 +14,8 @@ from unittest import mock
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "classify-security-release.py"
 SPEC = importlib.util.spec_from_file_location("security_release_classifier", SCRIPT)
-assert SPEC and SPEC.loader
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError("unable to load security release classifier")
 MODULE = importlib.util.module_from_spec(SPEC)
 sys.modules[SPEC.name] = MODULE
 SPEC.loader.exec_module(MODULE)

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -265,7 +266,10 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("github.ref == 'refs/heads/main'", release_guard)
         self.assertNotIn("pull_request", release_guard)
         self.assertNotIn("workflow_dispatch", release_guard)
-        self.assertEqual("ansible-collection-release-evidence", release_security["environment"])
+        release_environment = release_security["environment"]["name"]
+        self.assertIn("mlx90-security-release-evidence", release_environment)
+        self.assertIn("ansible-collection-release-evidence", release_environment)
+        self.assertIn("lightning-it-release-automation[bot]", release_environment)
         self.assertIn("runtime-evidence", release_security["needs"])
         self.assertEqual("Collection / Release Evidence", jobs["evidence"]["name"])
         self.assertNotIn("environment", jobs["evidence"])
@@ -397,7 +401,10 @@ class WorkflowSecurityTests(unittest.TestCase):
 
     def test_publish_mutation_is_protected_and_scorecard_is_immutable(self) -> None:
         publish = load_yaml(WORKFLOWS / "collection-publish.yml")["jobs"]["publish"]
-        self.assertEqual("ansible-collections", publish["environment"])
+        publish_environment = publish["environment"]["name"]
+        self.assertIn("mlx90-security-publish", publish_environment)
+        self.assertIn("ansible-collections", publish_environment)
+        self.assertIn("lightning-it-release-automation[bot]", publish_environment)
         self.assertIn("github.ref == 'refs/heads/main'", publish["if"])
         self.assertEqual("write", publish["permissions"]["contents"])
         self.assertEqual("write", publish["permissions"]["id-token"])
@@ -492,8 +499,19 @@ class WorkflowSecurityTests(unittest.TestCase):
                 self.assertIn("RELEASE_AUTOMATION_APP_PRIVATE_KEY", text)
                 self.assertIn("repositories: ${{ github.event.repository.name }}", text)
                 self.assertIn("permission-pull-requests: write", text)
+                self.assertIn("ansible-collection-release-prepare", text)
                 self.assertNotIn("LITRELEASEBOT_TOKEN", text)
                 self.assertNotIn("litreleasebot", text)
+
+        promotion = (WORKFLOWS / "promote-develop-to-main.yml").read_text(encoding="utf-8")
+        self.assertNotIn("mlx90-security-", promotion)
+        self.assertIn("environment: ansible-collection-release-prepare", promotion)
+
+        for name in ("release-back-sync.yml", "release-prepare.yml"):
+            with self.subTest(security_workflow=name):
+                text = (WORKFLOWS / name).read_text(encoding="utf-8")
+                self.assertIn("mlx90-security-release-prepare", text)
+                self.assertIn("lightning-it-release-automation[bot]", text)
 
         for name in ("release-back-sync.yml", "release-prepare.yml"):
             with self.subTest(identity_workflow=name):
@@ -512,6 +530,42 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn(
             '"--force-with-lease=${release_ref}:${remote_release_sha}"',
             release_prepare,
+        )
+
+    def test_zero_touch_is_security_only_and_normal_promotion_stays_manual(self) -> None:
+        ci = load_yaml(WORKFLOWS / "collection-ci.yml")["jobs"]
+        prepare = load_yaml(WORKFLOWS / "release-prepare.yml")["jobs"]
+        publish = load_yaml(WORKFLOWS / "collection-publish.yml")["jobs"]
+        back_sync = load_yaml(WORKFLOWS / "release-back-sync.yml")["jobs"]
+        promotion = load_yaml(WORKFLOWS / "promote-develop-to-main.yml")["jobs"]
+
+        for jobs, mutation_name in (
+            (prepare, "prepare"),
+            (publish, "publish"),
+            (back_sync, "back-sync"),
+        ):
+            with self.subTest(mutation=mutation_name):
+                self.assertIn("security-classification", jobs)
+                mutation = jobs[mutation_name]
+                self.assertIn("security-classification", mutation["needs"])
+                self.assertIn(
+                    "needs.security-classification.outputs.security-release != 'true'",
+                    mutation["if"],
+                )
+                self.assertIn("lightning-it-release-automation[bot]", mutation["if"])
+
+        for name in ("tiny-cells", "release-security"):
+            with self.subTest(ci_job=name):
+                self.assertIn("security-classification", ci[name]["needs"])
+                self.assertIn(
+                    "needs.security-classification.outputs.security-release != 'true'",
+                    ci[name]["if"],
+                )
+                self.assertIn("lightning-it-release-automation[bot]", ci[name]["if"])
+
+        self.assertEqual(
+            "ansible-collection-release-prepare",
+            promotion["promote"]["environment"],
         )
 
     def test_release_prepare_bounds_exact_owned_pr_propagation_retries(self) -> None:
@@ -830,8 +884,10 @@ class WorkflowSecurityTests(unittest.TestCase):
                 }
             )
 
+            bash = shutil.which("bash")
+            self.assertIsNotNone(bash, "bash is required for the wrapper contract test")
             subprocess.run(  # noqa: S603 -- execute the repository-owned wrapper under test.
-                ["/usr/bin/bash", str(wrapper), "true"],
+                [bash, str(wrapper), "true"],
                 cwd=ROOT,
                 env=environment,
                 check=True,


### PR DESCRIPTION
## Summary

- classify releases fail-closed from exact MLX-90 security evidence
- allow zero-touch environments only for Security Releases and the release-automation App
- retain all existing human environments for normal releases and normal develop-to-main promotion
- propagate the evidence ID through publish and backsync dispatches

## Verification

- 27 focused classifier/workflow tests pass
- yamllint passes for all changed workflow/YAML files
- actionlint passes for all changed workflows
- branch includes current shared-assets sync develop@9238ba9

No normal release approval was removed. No branch, ruleset, environment, or admin bypass is used.