### PR TITLE
fix(release): fail closed on invalid Security classification

### DIFF
--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -421,13 +421,14 @@ jobs:
       (github.event_name == 'workflow_dispatch' &&
        ((inputs.execution_mode == 'manual-main' && github.ref == 'refs/heads/main') ||
         (inputs.execution_mode == 'nightly-develop' && github.ref == 'refs/heads/develop')))) &&
-      (needs.security-classification.outputs.security-release != 'true' ||
-       (github.event_name == 'pull_request' &&
-        github.event.pull_request.user.login ==
-          'lightning-it-release-automation[bot]' &&
-        github.event.pull_request.head.repo.full_name == github.repository) ||
-       (github.event_name != 'pull_request' &&
-        github.actor == 'lightning-it-release-automation[bot]'))
+      (needs.security-classification.outputs.security-release == 'false' ||
+       (needs.security-classification.outputs.security-release == 'true' &&
+        ((github.event_name == 'pull_request' &&
+          github.event.pull_request.user.login ==
+            'lightning-it-release-automation[bot]' &&
+          github.event.pull_request.head.repo.full_name == github.repository) ||
+         (github.event_name != 'pull_request' &&
+          github.actor == 'lightning-it-release-automation[bot]'))))
     needs: [build-install, quality-matrix, security-classification]
     strategy:
       fail-fast: false
@@ -1129,8 +1130,9 @@ jobs:
       always() &&
       github.event_name == 'push' &&
       github.ref == 'refs/heads/main' &&
-      (needs.security-classification.outputs.security-release != 'true' ||
-       github.actor == 'lightning-it-release-automation[bot]')
+      (needs.security-classification.outputs.security-release == 'false' ||
+       (needs.security-classification.outputs.security-release == 'true' &&
+        github.actor == 'lightning-it-release-automation[bot]'))
     needs:
       - security-classification
       - lint-sanity

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -227,8 +227,9 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
-      (needs.security-classification.outputs.security-release != 'true' ||
-       github.actor == 'lightning-it-release-automation[bot]')
+      (needs.security-classification.outputs.security-release == 'false' ||
+       (needs.security-classification.outputs.security-release == 'true' &&
+        github.actor == 'lightning-it-release-automation[bot]'))
     name: Publish collection release
     needs: security-classification
     runs-on: ubuntu-latest

--- a/.github/workflows/release-back-sync.yml
+++ b/.github/workflows/release-back-sync.yml
@@ -70,8 +70,9 @@ jobs:
     needs: security-classification
     if: >-
       github.ref == 'refs/heads/main' &&
-      (needs.security-classification.outputs.security-release != 'true' ||
-       github.actor == 'lightning-it-release-automation[bot]')
+      (needs.security-classification.outputs.security-release == 'false' ||
+       (needs.security-classification.outputs.security-release == 'true' &&
+        github.actor == 'lightning-it-release-automation[bot]'))
     runs-on: ubuntu-latest
     environment:
       name: >-

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -104,8 +104,9 @@ jobs:
           !startsWith(github.event.head_commit.message, 'chore(release): prepare v')
         )
       ) &&
-      (needs.security-classification.outputs.security-release != 'true' ||
-       github.actor == 'lightning-it-release-automation[bot]')
+      (needs.security-classification.outputs.security-release == 'false' ||
+       (needs.security-classification.outputs.security-release == 'true' &&
+        github.actor == 'lightning-it-release-automation[bot]'))
     environment:
       name: >-
         ${{ needs.security-classification.outputs.security-release == 'true' &&

--- a/changelogs/fragments/mlx90-security-classification-fail-closed.yml
+++ b/changelogs/fragments/mlx90-security-classification-fail-closed.yml
@@ -1,0 +1,8 @@
+---
+security_fixes:
+  - >-
+    Require an explicit false Security classification for normal release
+    execution and an explicit true classification plus the release App
+    identity for MLX-90 Zero-Touch execution. Empty or malformed classifier
+    output now stops before protected environments or release credentials are
+    selected.

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -548,20 +548,42 @@ class WorkflowSecurityTests(unittest.TestCase):
                 self.assertIn("security-classification", jobs)
                 mutation = jobs[mutation_name]
                 self.assertIn("security-classification", mutation["needs"])
+                normalized_condition = " ".join(mutation["if"].split())
                 self.assertIn(
-                    "needs.security-classification.outputs.security-release != 'true'",
-                    mutation["if"],
+                    "needs.security-classification.outputs.security-release == 'false'",
+                    normalized_condition,
                 )
-                self.assertIn("lightning-it-release-automation[bot]", mutation["if"])
+                self.assertIn(
+                    "security-release == 'false' || "
+                    "(needs.security-classification.outputs.security-release == "
+                    "'true' &&",
+                    normalized_condition,
+                )
+                self.assertNotIn("security-release != 'true'", normalized_condition)
+                self.assertIn(
+                    "lightning-it-release-automation[bot]",
+                    normalized_condition,
+                )
 
         for name in ("tiny-cells", "release-security"):
             with self.subTest(ci_job=name):
                 self.assertIn("security-classification", ci[name]["needs"])
+                normalized_condition = " ".join(ci[name]["if"].split())
                 self.assertIn(
-                    "needs.security-classification.outputs.security-release != 'true'",
-                    ci[name]["if"],
+                    "needs.security-classification.outputs.security-release == 'false'",
+                    normalized_condition,
                 )
-                self.assertIn("lightning-it-release-automation[bot]", ci[name]["if"])
+                self.assertIn(
+                    "security-release == 'false' || "
+                    "(needs.security-classification.outputs.security-release == "
+                    "'true' &&",
+                    normalized_condition,
+                )
+                self.assertNotIn("security-release != 'true'", normalized_condition)
+                self.assertIn(
+                    "lightning-it-release-automation[bot]",
+                    normalized_condition,
+                )
 
         self.assertEqual(
             "ansible-collection-release-prepare",


### PR DESCRIPTION
## Summary

- require an explicit `false` classifier result for every normal release path
- require an explicit `true` result plus the release App identity for MLX-90 Security Zero-Touch
- stop empty, malformed, or unexpectedly cased classifier output before protected environments and release credentials
- add fail-closed workflow regression coverage and a Security-fix changelog fragment

## Validation

- `python3 -m unittest tests.unit.test_workflow_security` (22 tests, PASS)
- isolated Python 3.14 `pre-commit run --all-files`: yamllint, ansible-lint, changelog, actionlint, Renovate, collection smoke, Galaxy role verification, coverage, source dependencies, Python unit/lint/format/type, Markdown and ShellCheck PASS
- existing diff-independent `molecule-light` host UID 501 lookup fails in `artifacts-basic` on macOS (`id -un` has no container passwd entry); no role or Molecule file is changed here

Tracks the fail-closed MLX-90 release chain in #568.