### PR TITLE
fix: protect Security classifier trust root

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@
 /galaxy.yml @lightning-it/lightning-it-security-and-compliance-maintainers
 /meta/role-coverage.yml @lightning-it/lightning-it-security-and-compliance-maintainers
 /meta/quality-impact.yml @lightning-it/lightning-it-security-and-compliance-maintainers
+/scripts/classify-security-release.py @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/enrich-cyclonedx-sbom.py @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/devtools-*.sh @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/quality_cell_identity.py @lightning-it/lightning-it-security-and-compliance-maintainers

--- a/changelogs/fragments/mlx90-security-classifier-codeowner.yml
+++ b/changelogs/fragments/mlx90-security-classifier-codeowner.yml
@@ -1,0 +1,6 @@
+---
+security_fixes:
+  - >-
+    Make the MLX-90 Security-release classifier an explicit Security &
+    Compliance CODEOWNERS trust root so its reviewed governance digest cannot
+    be changed without the protected ownership path.


### PR DESCRIPTION
## Summary

- make `scripts/classify-security-release.py` an explicit Security & Compliance CODEOWNERS trust root
- document the governance hardening in the collection changelog

## Why

The MLX-90 governance readiness auditor now binds the classifier script and each classification job to exact reviewed digests. The classifier therefore also needs an explicit protected ownership rule on both `develop` and `main` before live governance can be applied.

## Validation

- governance CODEOWNERS audit: PASS
- workflow security unit tests: 22 PASS
- changelog policy: PASS
- Python 3.14 / pre-commit 4.3.0: all hooks PASS except the existing diff-independent macOS host-UID failure in `artifacts-basic`; authoritative Linux Current-Head CI remains required