### PR TITLE
chore: sync v3.2.3 release back to develop

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ Lightning IT Collection Release Notes Release Notes
 
 .. contents:: Topics
 
+v3.2.3
+======
+
+Bugfixes
+--------
+
+- Route MLX-90 release-App and GitHub-Actions execution through dedicated reviewer-free protected environments so evidence, preparation, publication, promotion, and back-sync can complete without a human deployment approval while retaining the existing manual environments for non-automation callers.
+
 v3.2.2
 ======
 

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -25,4 +25,4 @@ plugins:
   strategy: {}
   test: {}
   vars: {}
-version: 3.2.2
+version: 3.2.3

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -607,3 +607,16 @@ releases:
     fragments:
       - mlx90-v322-security-release-metadata.yml
     release_date: '2026-08-04'
+  3.2.3:
+    changes:
+      bugfixes:
+        - Route MLX-90 release-App and GitHub-Actions execution through dedicated
+          reviewer-free protected environments so evidence, preparation, publication,
+          promotion, and back-sync can complete without a human deployment approval
+          while retaining the existing manual environments for non-automation callers.
+    fragments:
+      - mlx90-zero-touch-release-chain.yml
+      - shared-assets-sync-30957250438.yml
+      - shared-assets-sync-31237016904.yml
+      - shared-assets-sync-31241646931.yml
+    release_date: '2026-08-08'

--- a/changelogs/fragments/mlx90-zero-touch-release-chain.yml
+++ b/changelogs/fragments/mlx90-zero-touch-release-chain.yml
@@ -1,8 +1,0 @@
----
-bugfixes:
-  - >-
-    Route MLX-90 release-App and GitHub-Actions execution through dedicated
-    reviewer-free protected environments so evidence, preparation,
-    publication, promotion, and back-sync can complete without a human
-    deployment approval while retaining the existing manual environments for
-    non-automation callers.

--- a/changelogs/fragments/shared-assets-sync-30957250438.yml
+++ b/changelogs/fragments/shared-assets-sync-30957250438.yml
@@ -1,3 +1,0 @@
----
-trivial:
-  - Synchronize centrally managed repository standards.

--- a/changelogs/fragments/shared-assets-sync-31237016904.yml
+++ b/changelogs/fragments/shared-assets-sync-31237016904.yml
@@ -1,3 +1,0 @@
----
-trivial:
-  - Synchronize centrally managed repository standards.

--- a/changelogs/fragments/shared-assets-sync-31241646931.yml
+++ b/changelogs/fragments/shared-assets-sync-31241646931.yml
@@ -1,3 +1,0 @@
----
-trivial:
-  - Synchronize centrally managed repository standards.

--- a/changelogs/release-preparation.json
+++ b/changelogs/release-preparation.json
@@ -1,14 +1,26 @@
 {
-  "base_sha": "3c2c3763971377afa7560b13c10af38236a07e16",
-  "current_version": "3.2.1",
+  "base_sha": "cb926421f2f4e623b01049e0075b0734c188bc21",
+  "current_version": "3.2.2",
   "fragments": [
     {
-      "path": "mlx90-v322-security-release-metadata.yml",
-      "sha256": "46466c712dc89a2dec8c473bebcf6c6c9cfc8184292c399c2dbb1fd25e6fdbb2"
+      "path": "mlx90-zero-touch-release-chain.yml",
+      "sha256": "8e98590270dd10d1ae78496c9207214bcee1c926918d6bc71e11d7fdaa84e2f4"
+    },
+    {
+      "path": "shared-assets-sync-30957250438.yml",
+      "sha256": "b637a090dd4cd427b7154c68ccb11efd1e13b7fc1974bd0bb36b7886a978a440"
+    },
+    {
+      "path": "shared-assets-sync-31237016904.yml",
+      "sha256": "b637a090dd4cd427b7154c68ccb11efd1e13b7fc1974bd0bb36b7886a978a440"
+    },
+    {
+      "path": "shared-assets-sync-31241646931.yml",
+      "sha256": "b637a090dd4cd427b7154c68ccb11efd1e13b7fc1974bd0bb36b7886a978a440"
     }
   ],
   "impact": "patch",
-  "next_version": "3.2.2",
+  "next_version": "3.2.3",
   "preparer": {
     "account_id": "307565056",
     "email": "307565056+lightning-it-release-automation[bot]@users.noreply.github.com",
@@ -24,7 +36,7 @@
     "path": ".github/workflows/release-prepare.yml",
     "ref": "lightning-it/ansible-collection-supplementary/.github/workflows/release-prepare.yml@refs/heads/main",
     "run_attempt": "1",
-    "run_id": "30908180982",
-    "source_sha": "3c2c3763971377afa7560b13c10af38236a07e16"
+    "run_id": "31245804025",
+    "source_sha": "cb926421f2f4e623b01049e0075b0734c188bc21"
   }
 }

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: lit
 name: supplementary
-version: 3.2.2
+version: 3.2.3
 readme: README.md
 description: 'Supplementary Ansible collection for ModuLix, providing configuration
   and integration roles for platform services and Terraform-backed workflows.


### PR DESCRIPTION
## Summary

- merge the protected `main@cca714b9c11714ae984c028b02915c38832c8a07` release-preparation state into current `develop@d0e56de8be7910d2544858757dd67e1966042803`
- preserve the prepared `v3.2.3` version and generated changelog metadata
- retain the newer MLX-90 fail-closed classifier and explicit CODEOWNERS protection from `develop`
- establish correct `main` ancestry before the later normal `develop` → `main` promotion

## Why this is required

The earlier file-identical ancestry candidate was closed because it would have kept the older `3.2.2` develop metadata and caused the next promotion to discard the prepared `v3.2.3` main state. This content-preserving merge is the fail-closed replacement.

## Validation

- exact head: `23426323ca88326653f633deb916a09d991f244d`
- first parent: `d0e56de8be7910d2544858757dd67e1966042803` (`develop`)
- second parent: `cca714b9c11714ae984c028b02915c38832c8a07` (`main`)
- `galaxy.yml`: `3.2.3`
- workflow security tests: 22 passed, 17 subtests passed
- canonical changelog policy: passed
- yamllint, ansible-lint, smoke, Galaxy verification, role/dependency policies: passed
- local macOS-only `artifacts-basic` cannot resolve host UID 501; the unchanged Linux Current-Head gate is authoritative

This is a normal release-state synchronization, not a Security Zero-Touch release and not a bypass.