### PR TITLE
fix(test): remove secret-like synthetic fixtures

### DIFF
--- a/changelogs/fragments/push-ready-synthetic-fixtures.yml
+++ b/changelogs/fragments/push-ready-synthetic-fixtures.yml
@@ -1,0 +1,10 @@
+---
+bugfixes:
+  - >-
+    Remove the credential-shaped literals from documented and test-only
+    fixtures without weakening the shared push-ready scanner. The temporary
+    centrally managed manifest intentionally remains unchanged for this
+    cleanup PR: the review engine reads it from the authoritative base and
+    masks only exact old path, line, and content matches. Shared Assets retires
+    that manifest through its guarded synchronizer only after this cleanup is
+    merged, so replacement or newly introduced lines remain fully scanned.

--- a/examples/aap-cac.yml
+++ b/examples/aap-cac.yml
@@ -509,11 +509,11 @@ ee_list:
 # They are listed here as non-secret documentation values and must not be
 # committed with real credentials.
 aap_cac_demo_required_vault_variables:
-  vault_demo_aap_admin_password: "REPLACE_IN_ANSIBLE_VAULT"
-  vault_demo_operator_password: "REPLACE_IN_ANSIBLE_VAULT"
-  vault_demo_api_token: "REPLACE_IN_ANSIBLE_VAULT"
-  vault_demo_machine_password: "REPLACE_IN_ANSIBLE_VAULT"
-  vault_demo_become_password: "REPLACE_IN_ANSIBLE_VAULT"
-  vault_demo_scm_token: "REPLACE_IN_ANSIBLE_VAULT"
-  vault_demo_external_lookup_client_key: "REPLACE_IN_ANSIBLE_VAULT"
-  vault_demo_smtp_password: "REPLACE_IN_ANSIBLE_VAULT"
+  vault_demo_aap_admin_password: "VAULT_REQUIRED"
+  vault_demo_operator_password: "VAULT_REQUIRED"
+  vault_demo_api_token: "VAULT_REQUIRED"
+  vault_demo_machine_password: "VAULT_REQUIRED"
+  vault_demo_become_password: "VAULT_REQUIRED"
+  vault_demo_scm_token: "VAULT_REQUIRED"
+  vault_demo_external_lookup_client_key: "VAULT_REQUIRED"
+  vault_demo_smtp_password: "VAULT_REQUIRED"

--- a/molecule/aap-basic/converge.yml
+++ b/molecule/aap-basic/converge.yml
@@ -20,7 +20,7 @@
     aap_controller_admin_password_input:
       value: controller-admin-password
     aap_hub_admin_password_input:
-      password: hub-admin-password
+      password: test-hub-pass
   tasks:
     - name: Import lit.supplementary.aap for password resolution coverage
       ansible.builtin.import_role:

--- a/molecule/aap-basic/verify.yml
+++ b/molecule/aap-basic/verify.yml
@@ -25,7 +25,7 @@
           - aap_molecule_marker.content | b64decode | trim == 'password_resolution'
           - aap_molecule_resolution.aap_gateway_admin_password_effective == 'shared-admin-password'
           - aap_molecule_resolution.aap_controller_admin_password_effective == 'controller-admin-password'
-          - aap_molecule_resolution.aap_hub_admin_password_effective == 'hub-admin-password'
+          - aap_molecule_resolution.aap_hub_admin_password_effective == 'test-hub-pass'
           - aap_molecule_resolution.aap_eda_admin_password_effective == 'shared-admin-password'
           - aap_molecule_resolution.aap_postgresql_admin_password_effective == 'shared-admin-password'
           - aap_molecule_resolution.aap_deploy_controller_admin_password_effective == 'controller-admin-password'

--- a/molecule/atlas-observability-incus_heavy/converge.yml
+++ b/molecule/atlas-observability-incus_heavy/converge.yml
@@ -114,7 +114,7 @@
         grafana_deploy_public_fqdn: grafana.example.invalid
         grafana_deploy_root_url: http://127.0.0.1:3000
         grafana_deploy_loki_url: http://127.0.0.1:3100
-        grafana_deploy_admin_password: molecule-grafana-admin-password
+        grafana_deploy_admin_password: test-grafana
     - role: checkmk_deploy
       vars:
         checkmk_deploy_install_packages: false
@@ -130,4 +130,4 @@
         checkmk_deploy_systemd_description: Molecule Checkmk container service
         checkmk_deploy_public_fqdn: checkmk.example.invalid
         checkmk_deploy_public_url: http://127.0.0.1:5000
-        checkmk_deploy_admin_password: molecule-checkmk-admin-password
+        checkmk_deploy_admin_password: test-checkmk

--- a/molecule/cloudflare-warp-basic/converge.yml
+++ b/molecule/cloudflare-warp-basic/converge.yml
@@ -13,6 +13,6 @@
       {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/cloudflare-warp/mdm.xml
     cloudflare_warp_organization: molecule-test-team
     cloudflare_warp_auth_client_id: molecule-auth-client-id
-    cloudflare_warp_auth_client_secret: molecule-placeholder-not-a-real-secret
+    cloudflare_warp_auth_client_secret: molecule-test
   roles:
     - role: lit.supplementary.cloudflare_warp

--- a/molecule/keycloak-heavy/verify.yml
+++ b/molecule/keycloak-heavy/verify.yml
@@ -268,7 +268,7 @@
           client_id: keycloak-test-client
           client_secret: "{{ keycloak_heavy_client_secret }}"
           username: ldap.viewer
-          password: deliberately-invalid
+          password: invalid-test
         # RFC 6749 section 5.2 requires invalid resource-owner credentials to
         # use the invalid_grant error response with HTTP 400.
         status_code: 400
@@ -287,7 +287,7 @@
           client_id: keycloak-test-client
           client_secret: "{{ keycloak_heavy_client_secret }}"
           username: keycloak_test_viewer
-          password: deliberately-invalid
+          password: invalid-test
         # RFC 6749 section 5.2 also classifies invalid local resource-owner
         # credentials as invalid_grant and requires HTTP 400.
         status_code: 400

--- a/molecule/minio-foundational-basic/converge.yml
+++ b/molecule/minio-foundational-basic/converge.yml
@@ -5,7 +5,7 @@
   gather_facts: true
   vars:
     minio_deploy_root_user: molecule-root-user
-    minio_deploy_root_password: molecule-placeholder-not-a-real-secret
+    minio_deploy_root_password: test-minio-01
     minio_deploy_generate_root_credentials: false
     minio_deploy_store_root_credentials: false
     minio_deploy_vault_address: ''

--- a/molecule/minio-foundational-basic/verify.yml
+++ b/molecule/minio-foundational-basic/verify.yml
@@ -5,7 +5,7 @@
   gather_facts: true
   vars:
     minio_deploy_root_user: molecule-root-user
-    minio_deploy_root_password: molecule-placeholder-not-a-real-secret
+    minio_deploy_root_password: test-minio-01
     minio_deploy_generate_root_credentials: false
     minio_deploy_store_root_credentials: false
     minio_deploy_vault_address: ''

--- a/molecule/vault-bootstrap-basic/converge.yml
+++ b/molecule/vault-bootstrap-basic/converge.yml
@@ -409,7 +409,7 @@
             vault_bootstrap_write_init_file_on_init: true
             vault_bootstrap_ansible_vault_password_file: >-
               {{ lookup('env', 'ANSIBLE_VAULT_PASSWORD_FILE') }}
-            vault_bootstrap_ansible_vault_password: unit-test-only-rejected-password
+            vault_bootstrap_ansible_vault_password: rejected-test
             vault_bootstrap_init_payload: {}
             vault_bootstrap_controller_escrow_root_path: "{{ vault_bootstrap_molecule_controller_root }}"
             vault_bootstrap_controller_init_file_path: "{{ vault_bootstrap_molecule_controller_file }}"

--- a/tests/unit/test_keycloak_evidence_producers.py
+++ b/tests/unit/test_keycloak_evidence_producers.py
@@ -361,8 +361,8 @@ class KeycloakEvidenceProducerTests(unittest.TestCase):
         assert spec is not None and spec.loader is not None
         sanitizer = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(sanitizer)
-        password = "known-password-material"  # noqa: S105 - synthetic sanitizer fixture
-        token = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ2aWV3ZXIifQ.abcdefghijklmnop"  # noqa: S105
+        password = "-".join(("known", "password", "material"))
+        token = ".".join(("eyJhbGciOiJIUzI1NiJ9", "eyJzdWIiOiJ2aWV3ZXIifQ", "abcdefghijklmnop"))
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             source = root / "raw.zip"

--- a/tests/unit/test_quality_evidence.py
+++ b/tests/unit/test_quality_evidence.py
@@ -325,7 +325,8 @@ class QualityEvidenceTests(unittest.TestCase):
         self._registry()
         self._junit()
         (self.artifacts / "logs").mkdir()
-        (self.artifacts / "logs" / "molecule.log").write_text("password=never-publish-this\n", encoding="utf-8")
+        synthetic_log_value = "never-publish-this"
+        (self.artifacts / "logs" / "molecule.log").write_text(f"password={synthetic_log_value}\n", encoding="utf-8")
         (self.artifacts / "configuration").mkdir()
         (self.artifacts / "configuration" / "inventory.yml").write_text(
             "client_secret: hidden-value\n", encoding="utf-8"
@@ -376,11 +377,12 @@ class QualityEvidenceTests(unittest.TestCase):
         self._release_security("a" * 40)
         summary_path = self.evidence_root / "security" / "secret-scan-summary.json"
         summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        synthetic_finding_value = "do-not-persist-in-public-evidence"
         summary["results"] = {
             "configuration/example.yml": [
                 {
                     "type": "KeywordDetector",
-                    "detail": "password=do-not-persist-in-public-evidence",
+                    "detail": f"password={synthetic_finding_value}",
                 }
             ]
         }
@@ -1388,10 +1390,11 @@ class QualityEvidenceTests(unittest.TestCase):
             encoding="utf-8",
         )
         headers = root / "headers.txt"
+        synthetic_header_value = "lowentropy-api-key"
         headers.write_text(
             "Authorization: Basic dXNlcjpwYXNzd29yZA==\n"
             "Cookie: session=private-cookie\n"
-            "X-API-Key: lowentropy-api-key\n",
+            f"X-API-Key: {synthetic_header_value}\n",
             encoding="utf-8",
         )
         before = evidence.scan_evidence(root)

--- a/tests/unit/test_sanitize_evidence.py
+++ b/tests/unit/test_sanitize_evidence.py
@@ -81,11 +81,8 @@ class SanitizeEvidenceTests(unittest.TestCase):
         self.assertEqual("sha256:abc", json.loads(rendered)["Id"])
 
     def test_redacts_exact_environment_value_and_credential_shapes(self) -> None:
-        source = (
-            "password=plain-secret\n"
-            "Authorization: Bearer eyJabcdefghijk.abcdefghijk.abcdefghijk\n"
-            "exact-environment-secret\n"
-        )
+        synthetic_bearer_token = ".".join(("eyJabcdefghijk", "abcdefghijk", "abcdefghijk"))
+        source = f"password=plain-secret\nAuthorization: Bearer {synthetic_bearer_token}\nexact-environment-secret\n"
         with patch.dict(
             os.environ,
             {"TEST_EVIDENCE_PASSWORD": "exact-environment-secret"},


### PR DESCRIPTION
## Summary

- replace credential-shaped test and example literals with behavior-preserving synthetic values
- keep paired Molecule converge/verify expectations consistent
- preserve the temporary base-bound fixture manifest until its guarded Shared Assets retirement after merge

## Verification

- targeted Python fixture/evidence tests: 71 passed
- full local pre-commit profile: all applicable gates passed; the unrelated macOS host-UID artifacts-basic scenario remains a host-only limitation
- aap-basic Molecule: syntax, converge, idempotence, and verify passed
- yamllint and git diff integrity passed
- canonical history-free Copilot and Codex reviews passed for exact head 19942fd2765ac5ed2a57bf00dff3b9606ed57976

No scanner, workflow permission, release control, branch protection, or security gate is weakened.