### PR TITLE
fix(ci): stream large shared-assets check evidence

### DIFF
--- a/.github/workflows/shared-assets-guarded-automerge.yml
+++ b/.github/workflows/shared-assets-guarded-automerge.yml
@@ -506,9 +506,11 @@ jobs:
               return 1
             fi
             evidence="$(
-              jq -nc \
-                --argjson check_pages "$check_runs" \
-                --argjson status_pages "$status_pages" '
+              printf '%s\n%s\n' "$check_runs" "$status_pages" |
+                jq -s '
+                .[0] as $check_pages
+                | .[1] as $status_pages
+                |
                 (([ $check_pages[] | .check_runs[] ]
                   | sort_by(.name, .app.id, .id)
                   | group_by([.name, .app.id])

--- a/changelogs/fragments/mlx90-shared-assets-guard-argv-limit.yml
+++ b/changelogs/fragments/mlx90-shared-assets-guard-argv-limit.yml
@@ -1,0 +1,6 @@
+---
+security_fixes:
+  - >-
+    Stream paginated Current-Head check evidence into the trusted Shared Assets
+    auto-merge guard instead of passing it through process arguments, so large
+    protected matrices remain fail-closed without exceeding the host ARG_MAX.

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -177,6 +177,56 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("contains(github.event.pull_request.labels.*.name, 'safe-automerge')", require_fragment)
         self.assertIn("!contains(github.event.pull_request.labels.*.name, 'breaking-update')", require_fragment)
 
+    def test_shared_assets_guard_streams_large_check_evidence_via_stdin(self) -> None:
+        workflow = (WORKFLOWS / "shared-assets-guarded-automerge.yml").read_text(encoding="utf-8")
+        self.assertNotIn('--argjson check_pages "$check_runs"', workflow)
+        self.assertNotIn('--argjson status_pages "$status_pages"', workflow)
+
+        start_marker = (
+            '            evidence="$(\n'
+            '              printf \'%s\\n%s\\n\' "$check_runs" "$status_pages" |\n'
+            "                jq -s '\n"
+        )
+        end_marker = "\n              '\n            )\"\n            pending=false"
+        start = workflow.index(start_marker) + len(start_marker)
+        jq_program = workflow[start : workflow.index(end_marker, start)]
+
+        check_pages = [
+            {
+                "check_runs": [
+                    {
+                        "id": 1,
+                        "name": "required / large evidence",
+                        "app": {"id": 15368},
+                        "status": "completed",
+                        "conclusion": "success",
+                        "ignored_payload": "x" * (3 * 1024 * 1024),
+                    }
+                ]
+            }
+        ]
+        jq = shutil.which("jq")
+        if jq is None:
+            self.fail("jq is required for the workflow evidence regression test")
+        result = subprocess.run(  # noqa: S603
+            [jq, "-s", jq_program],
+            input=f"{json.dumps(check_pages)}\n{json.dumps([[]])}\n",
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(
+            [
+                {
+                    "context": "required / large evidence",
+                    "app_id": 15368,
+                    "state": "success",
+                }
+            ],
+            json.loads(result.stdout),
+        )
+
     def test_collection_ci_concurrency_isolated_by_pr_and_exact_head(self) -> None:
         workflow = load_yaml(WORKFLOWS / "collection-ci.yml")
         top_group = workflow["concurrency"]["group"]


### PR DESCRIPTION
## Summary

- stream paginated check/status evidence into `jq` over stdin instead of process arguments
- preserve the existing fail-closed Current-Head grouping and state evaluation unchanged
- add a 3 MiB regression that exercises the exact embedded `jq` program

## Why

The Shared Assets guarded auto-merge for PR #650 passed provenance validation but failed before enabling auto-merge with `jq: Argument list too long`. Supplementary's large protected matrix exceeded the host argument-size limit when the complete GitHub check evidence was supplied through `--argjson`.

## Validation

- `python3 -m unittest tests.unit.test_workflow_security` — 23/23 passed
- Ruff lint and format — passed
- Mypy — passed
- YAML parsing, actionlint, changelog policy and `git diff --check` — passed
- full collection smoke and Galaxy role verification — passed

The full local pre-commit run also exposed the already-existing macOS host-UID name-resolution failure in the unrelated Molecule-light artifact scenario (`id -un` for UID 501). No product or security semantics were relaxed to mask it; protected GitHub Current-Head gates remain authoritative.

Related governance tracking: lightning-it/github-management-lit#267
