### PR TITLE
feat(security): add MLX-90 contract foundation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,3 +7,6 @@
 - Require new or modified third-party GitHub Actions dependencies to use immutable commit SHAs.
 - Explain each finding's impact and propose a concrete fix.
 - Prefer a regression test for bugs and security issues.
+
+<!-- Managed contract: Codex and Copilot must apply AGENTS.md. -->
+<!-- AGENTS_SHA256: a0162704193f51350d43ad4873462490f6ead53919ebb37e07c15ef72dacbf04 -->

--- a/changelogs/fragments/chrome-linux-151.0.7922.108-cpe.yml
+++ b/changelogs/fragments/chrome-linux-151.0.7922.108-cpe.yml
@@ -1,0 +1,6 @@
+---
+security_fixes:
+  - >-
+    Bind the observed Chrome for Linux 151.0.7922.108 runtime to the reviewed
+    paired 151.0.7922.109 platform-neutral scanner CPE while preserving the
+    observed package URL, binary digest, and source evidence.

--- a/changelogs/fragments/mlx90-history-free-review-contract.yml
+++ b/changelogs/fragments/mlx90-history-free-review-contract.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    Bind Copilot review instructions to the exact repository agent contract so
+    history-free review fails closed on instruction drift.

--- a/changelogs/fragments/mlx90-main-promotion-merge-gate.yml
+++ b/changelogs/fragments/mlx90-main-promotion-merge-gate.yml
@@ -1,0 +1,8 @@
+---
+security_fixes:
+  - >-
+    Add the stable Main promotion merge gate required context. It always
+    materializes for pull requests to main and succeeds only after both exact
+    promotion classification and the selected protected environment
+    authorization succeed, while ordinary promotions retain their human
+    approval environment.

--- a/changelogs/fragments/mlx90-security-contract-library.yml
+++ b/changelogs/fragments/mlx90-security-contract-library.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - >-
+    Add the inert, versioned MLX-90 Security release contract library and its
+    fail-closed unit contract before activating any production consumer.

--- a/scripts/enrich-cyclonedx-sbom.py
+++ b/scripts/enrich-cyclonedx-sbom.py
@@ -44,6 +44,10 @@ CHROME_LINUX_CPE_EQUIVALENCE = {
         "151.0.7922.72",
         "https://chromereleases.googleblog.com/2026/07/stable-channel-update-for-desktop_0887107924.html",
     ),
+    "151.0.7922.108": (
+        "151.0.7922.109",
+        "https://chromereleases.googleblog.com/2026/08/stable-channel-update-for-desktop_01193673229.html",
+    ),
 }
 
 

--- a/scripts/security_release_contract.py
+++ b/scripts/security_release_contract.py
@@ -1,0 +1,666 @@
+"""Canonical data contract for the MLX-90 Security release chain.
+
+This module contains only deterministic validation and serialization helpers.
+Network calls and GitHub mutations deliberately stay in the calling workflows.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, NoReturn
+
+PRODUCER_REPOSITORY = "lightning-it/ansible-collection-supplementary"
+PRODUCER_REPOSITORY_ID = "1103407173"
+CONSUMER_REPOSITORY = "lightning-it/container-ee-wunder-ansible-ubi9"
+RELEASE_APP_SLUG = "lightning-it-release-automation"
+RELEASE_APP_INSTALLATION_ID = "148019054"
+RELEASE_APP_LOGIN = f"{RELEASE_APP_SLUG}[bot]"
+RELEASE_APP_ACCOUNT_ID = "307565056"
+RELEASE_APP_EMAIL = f"{RELEASE_APP_ACCOUNT_ID}+{RELEASE_APP_LOGIN}@users.noreply.github.com"
+RELEASE_APP_IDENTITY = {
+    "slug": RELEASE_APP_SLUG,
+    "installationId": RELEASE_APP_INSTALLATION_ID,
+    "login": RELEASE_APP_LOGIN,
+    "accountId": RELEASE_APP_ACCOUNT_ID,
+    "type": "Bot",
+}
+
+SHA = re.compile(r"^[0-9a-f]{40}$")
+DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+EVIDENCE_ID = re.compile(r"^MLX90-[A-Z0-9][A-Z0-9._-]{2,127}$")
+SEMVER = re.compile(r"^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$")
+REF = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,199}$")
+PROFILE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{2,127}$")
+SECURITY_ID = re.compile(
+    r"^(?:CVE-[0-9]{4}-[0-9]{4,}|"
+    r"GHSA-[23456789cfghjmpqrvwx]{4}(?:-[23456789cfghjmpqrvwx]{4}){2}|"
+    r"LIT-SEC-[A-Z0-9._-]+)$"
+)
+CANONICAL_TIME = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
+METADATA_PATH = re.compile(r"^\.lit/security-releases/([0-9]+\.[0-9]+\.[0-9]+)\.json$")
+INTAKE_PATH = re.compile(r"^\.lit/security-release-intakes/([0-9]+\.[0-9]+\.[0-9]+)\.json$")
+
+INTAKE_REQUEST_SCHEMA_VERSION = 2
+INTAKE_RECEIPT_SCHEMA_VERSION = 2
+INTAKE_RESULT_SCHEMA_VERSION = 2
+MAX_JSON_BYTES = 1024 * 1024
+MAX_SECURITY_FRAGMENT_BYTES = 1024 * 1024
+PROFILE_KEYS = {"description", "releaseEligible"}
+
+REQUEST_KEYS = {
+    "schemaVersion",
+    "event",
+    "repository",
+    "repositoryId",
+    "baseSha",
+    "candidateRef",
+    "candidateBaseSha",
+    "candidateHeadSha",
+    "candidateDiffSha256",
+    "evidenceId",
+    "fixedVersion",
+    "acceptanceProfile",
+    "metadataSha256",
+    "chainId",
+    "issuedAt",
+    "expiresAt",
+    "humanActions",
+}
+METADATA_KEYS = {
+    "schemaVersion",
+    "evidenceId",
+    "createdAt",
+    "securityIdentifiers",
+    "affectedVersion",
+    "fixedVersion",
+    "consumers",
+    "acceptanceProfile",
+    "validity",
+}
+VALIDITY_KEYS = {"notBefore", "expiresAt", "revoked"}
+VERIFIED_KEYS = {
+    "schemaVersion",
+    "chainId",
+    "branch",
+    "baseSha",
+    "candidateBaseSha",
+    "candidateHeadSha",
+    "candidateDiffSha256",
+    "evidenceId",
+    "fixedVersion",
+    "metadataPath",
+    "metadataSha256",
+    "acceptanceProfile",
+    "changelogFragmentPath",
+    "changelogFragmentSha256",
+    "changedPaths",
+    "humanActions",
+}
+INTAKE_RECEIPT_KEYS = {
+    "schemaVersion",
+    "chainId",
+    "request",
+    "verified",
+    "automation",
+    "controller",
+}
+CONTROLLER_KEYS = {
+    "path",
+    "ref",
+    "sourceSha",
+    "runId",
+    "runAttempt",
+    "event",
+    "gitRef",
+    "actor",
+}
+CHAIN_BINDING_KEYS = {
+    "repository",
+    "repositoryId",
+    "baseSha",
+    "candidateHeadSha",
+    "candidateDiffSha256",
+    "evidenceId",
+    "fixedVersion",
+    "acceptanceProfile",
+}
+
+
+class ContractError(ValueError):
+    """Raised when an MLX-90 contract cannot be proven exact."""
+
+
+def fail(message: str) -> NoReturn:
+    raise ContractError(message)
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            fail(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def load_json_bytes(raw: bytes, label: str) -> dict[str, Any]:
+    if len(raw) > MAX_JSON_BYTES:
+        fail(f"{label} exceeds {MAX_JSON_BYTES} bytes")
+    try:
+        value = json.loads(
+            raw.decode("utf-8"),
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=lambda value: fail(f"invalid JSON constant: {value}"),
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ContractError(f"{label} is not valid UTF-8 JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        fail(f"{label} must be a JSON object")
+    return value
+
+
+def load_json_file(path: Path, label: str) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        fail(f"{label} must be a regular non-symlink file")
+    return load_json_bytes(path.read_bytes(), label)
+
+
+def exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
+    if set(value) != expected:
+        missing = sorted(expected - set(value))
+        unknown = sorted(set(value) - expected)
+        fail(f"{label} fields mismatch; missing={missing}, unknown={unknown}")
+
+
+def require_string(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        fail(f"{label} must be a non-empty trimmed string")
+    if "\n" in value or "\r" in value or "\x00" in value:
+        fail(f"{label} must be a single-line string")
+    return value
+
+
+def timestamp(value: object, label: str) -> datetime:
+    text = require_string(value, label)
+    if CANONICAL_TIME.fullmatch(text) is None:
+        fail(f"{label} must be canonical UTC RFC3339")
+    try:
+        return datetime.strptime(text, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise ContractError(f"{label} is not a valid timestamp") from exc
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    try:
+        rendered = json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ContractError(f"value is not canonical JSON: {exc}") from exc
+    return rendered.encode("utf-8")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return "sha256:" + hashlib.sha256(value).hexdigest()
+
+
+def canonical_sha256(value: object) -> str:
+    return sha256_bytes(canonical_json_bytes(value))
+
+
+def canonical_document_bytes(value: object) -> bytes:
+    return canonical_json_bytes(value) + b"\n"
+
+
+def chain_binding(
+    *,
+    repository: str,
+    repository_id: str,
+    base_sha: str,
+    candidate_head_sha: str,
+    candidate_diff_sha256: str,
+    evidence_id: str,
+    fixed_version: str,
+    acceptance_profile: str,
+) -> dict[str, str]:
+    binding = {
+        "repository": repository,
+        "repositoryId": repository_id,
+        "baseSha": base_sha,
+        "candidateHeadSha": candidate_head_sha,
+        "candidateDiffSha256": candidate_diff_sha256,
+        "evidenceId": evidence_id,
+        "fixedVersion": fixed_version,
+        "acceptanceProfile": acceptance_profile,
+    }
+    exact_keys(binding, CHAIN_BINDING_KEYS, "Security chain binding")
+    if repository != PRODUCER_REPOSITORY or repository_id != PRODUCER_REPOSITORY_ID:
+        fail("Security chain repository identity is unauthorized")
+    if SHA.fullmatch(base_sha) is None or SHA.fullmatch(candidate_head_sha) is None:
+        fail("Security chain commit identity is invalid")
+    if DIGEST.fullmatch(candidate_diff_sha256) is None:
+        fail("Security chain candidate digest is invalid")
+    if EVIDENCE_ID.fullmatch(evidence_id) is None:
+        fail("Security chain evidenceId is invalid")
+    if SEMVER.fullmatch(fixed_version) is None:
+        fail("Security chain fixedVersion is invalid")
+    if PROFILE.fullmatch(acceptance_profile) is None:
+        fail("Security chain acceptanceProfile is invalid")
+    return binding
+
+
+def compute_chain_id(**values: str) -> str:
+    return canonical_sha256(chain_binding(**values))
+
+
+def validate_request(request: dict[str, Any], repository: str, now: datetime) -> dict[str, Any]:
+    exact_keys(request, REQUEST_KEYS, "Security intake request")
+    if type(request["schemaVersion"]) is not int or request["schemaVersion"] != INTAKE_REQUEST_SCHEMA_VERSION:
+        fail(f"Security intake schemaVersion must be {INTAKE_REQUEST_SCHEMA_VERSION}")
+    if repository != PRODUCER_REPOSITORY or request["repository"] != repository:
+        fail("Security intake repository does not match the exact producer repository")
+    if request["repositoryId"] != PRODUCER_REPOSITORY_ID:
+        fail("Security intake repositoryId does not match the exact producer repository")
+    if request["event"] != "mlx90-security-release":
+        fail("Security intake event is unsupported")
+    if type(request["humanActions"]) is not int or request["humanActions"] != 0:
+        fail("Security Zero-Touch intake must declare humanActions=0")
+
+    for field in ("baseSha", "candidateBaseSha", "candidateHeadSha"):
+        value = require_string(request[field], field)
+        if SHA.fullmatch(value) is None:
+            fail(f"{field} must be a full lowercase commit SHA")
+    if request["candidateBaseSha"] == request["candidateHeadSha"]:
+        fail("candidate source range must not be empty")
+    if request["candidateBaseSha"] != request["baseSha"]:
+        fail("candidate source range must start at the authorized protected-main SHA")
+    digest = require_string(request["candidateDiffSha256"], "candidateDiffSha256")
+    if DIGEST.fullmatch(digest) is None:
+        fail("candidateDiffSha256 must be a canonical SHA-256 digest")
+    metadata_digest = require_string(request["metadataSha256"], "metadataSha256")
+    if DIGEST.fullmatch(metadata_digest) is None:
+        fail("metadataSha256 must be a canonical SHA-256 digest")
+    evidence_id = require_string(request["evidenceId"], "evidenceId")
+    if EVIDENCE_ID.fullmatch(evidence_id) is None:
+        fail("evidenceId is invalid")
+    version = require_string(request["fixedVersion"], "fixedVersion")
+    if SEMVER.fullmatch(version) is None:
+        fail("fixedVersion must be stable SemVer")
+    profile = require_string(request["acceptanceProfile"], "acceptanceProfile")
+    if PROFILE.fullmatch(profile) is None:
+        fail("acceptanceProfile is invalid")
+    candidate_ref = require_string(request["candidateRef"], "candidateRef")
+    if REF.fullmatch(candidate_ref) is None or candidate_ref.startswith("/"):
+        fail("candidateRef is invalid")
+    if candidate_ref != "develop":
+        fail("candidateRef must be the protected develop integration branch")
+
+    issued = timestamp(request["issuedAt"], "issuedAt")
+    expires = timestamp(request["expiresAt"], "expiresAt")
+    if expires <= issued:
+        fail("Security intake validity interval is empty")
+    if now < issued or now >= expires:
+        fail("Security intake request is not currently valid")
+
+    expected_chain_id = compute_chain_id(
+        repository=repository,
+        repository_id=PRODUCER_REPOSITORY_ID,
+        base_sha=request["baseSha"],
+        candidate_head_sha=request["candidateHeadSha"],
+        candidate_diff_sha256=digest,
+        evidence_id=evidence_id,
+        fixed_version=version,
+        acceptance_profile=profile,
+    )
+    if request["chainId"] != expected_chain_id:
+        fail("Security intake chainId does not match its canonical binding")
+    return request
+
+
+def validate_metadata_payload(
+    metadata: dict[str, Any],
+    *,
+    expected_evidence_id: str,
+    expected_version: str,
+    expected_profile: str,
+    checked_at: datetime,
+) -> dict[str, Any]:
+    exact_keys(metadata, METADATA_KEYS, "Security release metadata")
+    if type(metadata["schemaVersion"]) is not int or metadata["schemaVersion"] != 1:
+        fail("Security release metadata schemaVersion must be 1")
+    if metadata["evidenceId"] != expected_evidence_id:
+        fail("Security metadata evidenceId does not match the intake")
+    if metadata["fixedVersion"] != expected_version:
+        fail("Security metadata fixedVersion does not match the intake")
+    if metadata["acceptanceProfile"] != expected_profile:
+        fail("Security metadata acceptanceProfile does not match the intake")
+    identifiers = metadata["securityIdentifiers"]
+    if (
+        not isinstance(identifiers, list)
+        or not identifiers
+        or any(not isinstance(item, str) or SECURITY_ID.fullmatch(item) is None for item in identifiers)
+        or len(identifiers) != len(set(identifiers))
+    ):
+        fail("Security metadata identifiers are invalid")
+    affected_version = require_string(metadata["affectedVersion"], "affectedVersion")
+    if SEMVER.fullmatch(affected_version) is None or affected_version == expected_version:
+        fail("Security metadata affectedVersion is invalid")
+    if metadata["consumers"] != [CONSUMER_REPOSITORY]:
+        fail("Security metadata consumer allowlist must contain only the exact MLX-90 consumer")
+    validity = metadata["validity"]
+    if validity.__class__ is not dict:
+        fail("Security metadata validity must be an object")
+    exact_keys(validity, VALIDITY_KEYS, "Security release validity")
+    if validity["revoked"] is not False:
+        fail("Security release metadata is revoked")
+    created = timestamp(metadata["createdAt"], "createdAt")
+    not_before = timestamp(validity["notBefore"], "validity.notBefore")
+    expires = timestamp(validity["expiresAt"], "validity.expiresAt")
+    if created < not_before or created >= expires:
+        fail("Security metadata createdAt is outside its validity interval")
+    if checked_at < not_before or checked_at >= expires:
+        fail("Security release metadata is not currently valid")
+    return metadata
+
+
+def validate_request_metadata_binding(request: dict[str, Any], metadata: dict[str, Any]) -> None:
+    """Bind the request validity envelope to the reviewed metadata exactly."""
+
+    if request["issuedAt"] != metadata["createdAt"]:
+        fail("Security intake issuedAt differs from metadata createdAt")
+    validity = metadata["validity"]
+    if request["expiresAt"] != validity["expiresAt"]:
+        fail("Security intake expiresAt differs from metadata validity.expiresAt")
+
+
+def validate_profile_registry(registry: dict[str, Any], profile_id: str) -> dict[str, Any]:
+    """Validate the exact protected-main profile registry and selected profile."""
+
+    exact_keys(registry, {"schemaVersion", "profiles"}, "acceptance-profile registry")
+    if type(registry["schemaVersion"]) is not int or registry["schemaVersion"] != 1:
+        fail("acceptance-profile registry is unsupported")
+    profiles = registry["profiles"]
+    if not isinstance(profiles, dict) or not profiles:
+        fail("acceptance-profile registry profiles must be a non-empty object")
+    for name, profile in profiles.items():
+        if not isinstance(name, str) or PROFILE.fullmatch(name) is None:
+            fail("acceptance-profile registry contains an invalid profile id")
+        if not isinstance(profile, dict):
+            fail(f"acceptance profile {name} must be an object")
+        exact_keys(profile, PROFILE_KEYS, f"acceptance profile {name}")
+        require_string(profile["description"], f"acceptance profile {name} description")
+        if type(profile["releaseEligible"]) is not bool:
+            fail(f"acceptance profile {name} releaseEligible must be boolean")
+    selected = profiles.get(profile_id)
+    if not isinstance(selected, dict) or selected["releaseEligible"] is not True:
+        fail("acceptance profile was not pre-approved on protected main")
+    return selected
+
+
+def validate_security_fragment(raw: bytes, label: str) -> dict[str, list[str]]:
+    if len(raw) > MAX_SECURITY_FRAGMENT_BYTES:
+        fail(f"{label} exceeds {MAX_SECURITY_FRAGMENT_BYTES} bytes")
+    payload = load_json_bytes(raw, label)
+    if raw != canonical_document_bytes(payload):
+        fail(f"{label} must be canonical JSON with one trailing newline")
+    exact_keys(payload, {"security_fixes"}, label)
+    entries = payload["security_fixes"]
+    if (
+        not isinstance(entries, list)
+        or not entries
+        or len(entries) > 64
+        or any(not isinstance(entry, str) or not entry.strip() or entry != entry.strip() for entry in entries)
+    ):
+        fail(f"{label} must contain 1..64 non-empty trimmed security_fixes entries")
+    return {"security_fixes": entries}
+
+
+def validate_immutable_marker_changes(changes: list[tuple[str, str]], fixed_version: str) -> None:
+    expected_metadata = f".lit/security-releases/{fixed_version}.json"
+    metadata_changes = [item for item in changes if item[1].startswith(".lit/security-releases/")]
+    intake_changes = [item for item in changes if item[1].startswith(".lit/security-release-intakes/")]
+    if metadata_changes != [("A", expected_metadata)]:
+        fail("candidate must add exactly one immutable Security metadata file and preserve every existing marker")
+    if intake_changes:
+        fail("candidate must not create, modify, or delete App-owned Security intake receipts")
+    if any(path == ".lit/security-release-profiles.json" for _status, path in changes):
+        fail("candidate must not modify the protected-main Security profile registry")
+
+
+def validate_intake_result(request: dict[str, Any], verified: dict[str, Any]) -> dict[str, Any]:
+    exact_keys(verified, VERIFIED_KEYS, "verified Security intake")
+    if type(verified["schemaVersion"]) is not int or verified["schemaVersion"] != INTAKE_RESULT_SCHEMA_VERSION:
+        fail(f"verified Security intake schemaVersion must be {INTAKE_RESULT_SCHEMA_VERSION}")
+    if type(verified["humanActions"]) is not int or verified["humanActions"] != 0:
+        fail("verified Security intake must declare humanActions=0")
+    expected = {
+        "chainId": request["chainId"],
+        "branch": f"security-release/{request['evidenceId']}",
+        "baseSha": request["baseSha"],
+        "candidateBaseSha": request["candidateBaseSha"],
+        "candidateHeadSha": request["candidateHeadSha"],
+        "candidateDiffSha256": request["candidateDiffSha256"],
+        "evidenceId": request["evidenceId"],
+        "fixedVersion": request["fixedVersion"],
+        "metadataPath": f".lit/security-releases/{request['fixedVersion']}.json",
+        "metadataSha256": request["metadataSha256"],
+        "acceptanceProfile": request["acceptanceProfile"],
+        "humanActions": 0,
+    }
+    for field, value in expected.items():
+        if verified[field] != value:
+            fail(f"verified Security intake {field} differs from its request")
+    fragment_path = verified["changelogFragmentPath"]
+    if not isinstance(fragment_path, str) or re.fullmatch(r"changelogs/fragments/[^/]+\.ya?ml", fragment_path) is None:
+        fail("verified Security intake changelog fragment path is invalid")
+    if DIGEST.fullmatch(str(verified["changelogFragmentSha256"])) is None:
+        fail("verified Security intake changelog fragment digest is invalid")
+    changed_paths = verified["changedPaths"]
+    if (
+        not isinstance(changed_paths, list)
+        or not changed_paths
+        or any(not isinstance(path, str) or not path for path in changed_paths)
+        or changed_paths != sorted(set(changed_paths))
+        or expected["metadataPath"] not in changed_paths
+        or fragment_path not in changed_paths
+    ):
+        fail("verified Security intake changedPaths are incomplete, duplicate, or unsorted")
+    return verified
+
+
+def build_intake_receipt(
+    request: dict[str, Any],
+    verified: dict[str, Any],
+    *,
+    workflow_run_id: str,
+    workflow_attempt: str,
+    workflow_ref: str,
+    workflow_event: str,
+    workflow_actor: str,
+    observed_automation: dict[str, Any],
+) -> dict[str, Any]:
+    validate_request(request, PRODUCER_REPOSITORY, timestamp(request["issuedAt"], "issuedAt"))
+    validate_intake_result(request, verified)
+    if observed_automation != RELEASE_APP_IDENTITY:
+        fail("observed release automation identity is unauthorized")
+    receipt = {
+        "schemaVersion": INTAKE_RECEIPT_SCHEMA_VERSION,
+        "chainId": request["chainId"],
+        "request": request,
+        "verified": verified,
+        "automation": dict(observed_automation),
+        "controller": {
+            "path": ".github/workflows/security-release-intake.yml",
+            "ref": workflow_ref,
+            "sourceSha": request["baseSha"],
+            "runId": workflow_run_id,
+            "runAttempt": workflow_attempt,
+            "event": workflow_event,
+            "gitRef": "refs/heads/main",
+            "actor": workflow_actor,
+        },
+    }
+    verify_intake_receipt(receipt)
+    return receipt
+
+
+def verify_intake_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+    exact_keys(receipt, INTAKE_RECEIPT_KEYS, "Security intake receipt")
+    if type(receipt["schemaVersion"]) is not int or receipt["schemaVersion"] != INTAKE_RECEIPT_SCHEMA_VERSION:
+        fail(f"Security intake receipt schemaVersion must be {INTAKE_RECEIPT_SCHEMA_VERSION}")
+    request = receipt["request"]
+    verified = receipt["verified"]
+    if not isinstance(request, dict) or not isinstance(verified, dict):
+        fail("Security intake receipt request and verified values must be objects")
+    validate_request(request, PRODUCER_REPOSITORY, timestamp(request.get("issuedAt"), "issuedAt"))
+    validate_intake_result(request, verified)
+    if receipt["chainId"] != request["chainId"]:
+        fail("Security intake receipt chainId differs from its request")
+    if receipt["automation"] != RELEASE_APP_IDENTITY:
+        fail("Security intake receipt automation identity is unauthorized")
+    controller = receipt["controller"]
+    if not isinstance(controller, dict):
+        fail("Security intake receipt controller must be an object")
+    exact_keys(controller, CONTROLLER_KEYS, "Security intake receipt controller")
+    expected_ref = f"{PRODUCER_REPOSITORY}/.github/workflows/security-release-intake.yml@refs/heads/main"
+    if (
+        controller["path"] != ".github/workflows/security-release-intake.yml"
+        or controller["ref"] != expected_ref
+        or controller["sourceSha"] != request["baseSha"]
+        or controller["event"] != "repository_dispatch"
+        or controller["gitRef"] != "refs/heads/main"
+        or controller["actor"] != RELEASE_APP_LOGIN
+        or not isinstance(controller["runId"], str)
+        or re.fullmatch(r"[1-9][0-9]*", controller["runId"]) is None
+        or not isinstance(controller["runAttempt"], str)
+        or re.fullmatch(r"[1-9][0-9]*", controller["runAttempt"]) is None
+    ):
+        fail("Security intake receipt controller identity is unauthorized")
+    return receipt
+
+
+def load_security_binding(
+    root: Path,
+    version: str,
+    *,
+    checked_at: datetime,
+) -> dict[str, Any] | None:
+    if SEMVER.fullmatch(version) is None:
+        fail("Security binding version must be stable SemVer")
+    metadata_path = root / ".lit" / "security-releases" / f"{version}.json"
+    intake_path = root / ".lit" / "security-release-intakes" / f"{version}.json"
+    metadata_exists = metadata_path.exists() or metadata_path.is_symlink()
+    intake_exists = intake_path.exists() or intake_path.is_symlink()
+    if not metadata_exists and not intake_exists:
+        return None
+    if metadata_exists != intake_exists:
+        fail("partial Security marker: metadata and App-owned intake receipt must exist together")
+
+    metadata_raw = metadata_path.read_bytes() if metadata_path.is_file() and not metadata_path.is_symlink() else b""
+    if not metadata_raw:
+        fail("Security metadata must be a non-empty regular non-symlink file")
+    if intake_path.is_symlink() or not intake_path.is_file():
+        fail("Security intake receipt must be a regular non-symlink file")
+    metadata = load_json_bytes(metadata_raw, "Security release metadata")
+    intake_raw = intake_path.read_bytes()
+    receipt = load_json_bytes(intake_raw, "Security intake receipt")
+    if intake_raw != canonical_document_bytes(receipt):
+        fail("Security intake receipt is not canonical JSON")
+    verify_intake_receipt(receipt)
+    request = receipt["request"]
+    verified = receipt["verified"]
+    if request["fixedVersion"] != version:
+        fail("Security intake receipt fixedVersion differs from its path")
+    metadata_digest = sha256_bytes(metadata_raw)
+    if request["metadataSha256"] != metadata_digest or verified["metadataSha256"] != metadata_digest:
+        fail("Security metadata digest differs from the immutable intake binding")
+    validate_metadata_payload(
+        metadata,
+        expected_evidence_id=request["evidenceId"],
+        expected_version=version,
+        expected_profile=request["acceptanceProfile"],
+        checked_at=checked_at,
+    )
+    validate_request_metadata_binding(request, metadata)
+    fragment_path_text = verified["changelogFragmentPath"]
+    fragment_path = root / fragment_path_text
+    if fragment_path.is_symlink() or not fragment_path.is_file():
+        fail("Security changelog fragment must be a regular non-symlink file")
+    fragment_raw = fragment_path.read_bytes()
+    validate_security_fragment(fragment_raw, "Security changelog fragment")
+    fragment_digest = sha256_bytes(fragment_raw)
+    if verified["changelogFragmentSha256"] != fragment_digest:
+        fail("Security changelog fragment digest differs from the immutable intake binding")
+    profiles = load_json_file(
+        root / ".lit" / "security-release-profiles.json",
+        "protected-main acceptance-profile registry",
+    )
+    validate_profile_registry(profiles, request["acceptanceProfile"])
+    return {
+        "chain_id": request["chainId"],
+        "evidence_id": request["evidenceId"],
+        "fixed_version": version,
+        "acceptance_profile": request["acceptanceProfile"],
+        "candidate_diff_sha256": request["candidateDiffSha256"],
+        "metadata_path": metadata_path.relative_to(root).as_posix(),
+        "metadata_sha256": metadata_digest,
+        "intake_receipt_path": intake_path.relative_to(root).as_posix(),
+        "intake_receipt_sha256": sha256_bytes(intake_raw),
+        "changelog_fragment_path": fragment_path_text,
+        "changelog_fragment_sha256": fragment_digest,
+        "human_actions": 0,
+    }
+
+
+def _security_marker_versions(root: Path, relative_directory: str) -> set[tuple[int, int, int]]:
+    directory = root / relative_directory
+    if not directory.exists() and not directory.is_symlink():
+        return set()
+    if directory.is_symlink() or not directory.is_dir():
+        fail(f"Security marker namespace {relative_directory} must be a regular directory")
+    versions: set[tuple[int, int, int]] = set()
+    for path in directory.iterdir():
+        if path.name == ".gitkeep":
+            continue
+        match = re.fullmatch(r"((?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))\.json", path.name)
+        if match is None:
+            fail(f"Security marker namespace contains an invalid entry: {relative_directory}/{path.name}")
+        if path.is_symlink() or not path.is_file():
+            fail(f"Security marker must be a regular non-symlink file: {relative_directory}/{path.name}")
+        major, minor, patch = match.group(1).split(".")
+        versions.add((int(major), int(minor), int(patch)))
+    return versions
+
+
+def load_release_security_binding(
+    root: Path,
+    current_version: str,
+    target_version: str,
+    *,
+    checked_at: datetime,
+) -> dict[str, Any] | None:
+    """Select an exact pending Security binding without normal-mode fallback."""
+
+    if SEMVER.fullmatch(current_version) is None or SEMVER.fullmatch(target_version) is None:
+        fail("release Security marker versions must be stable SemVer")
+    current = tuple(int(part) for part in current_version.split("."))
+    target = tuple(int(part) for part in target_version.split("."))
+    if target <= current:
+        fail("release Security marker target must be newer than the current version")
+    metadata_versions = _security_marker_versions(root, ".lit/security-releases")
+    intake_versions = _security_marker_versions(root, ".lit/security-release-intakes")
+    pending = {version for version in metadata_versions | intake_versions if version > current}
+    if pending and pending != {target}:
+        rendered = [".".join(map(str, version)) for version in sorted(pending)]
+        fail("pending Security marker does not match the selected release target: " + ", ".join(rendered))
+    if target not in pending:
+        return None
+    return load_security_binding(root, target_version, checked_at=checked_at)

--- a/scripts/security_release_contract.py
+++ b/scripts/security_release_contract.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
+import stat
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, NoReturn
@@ -163,10 +165,37 @@ def load_json_bytes(raw: bytes, label: str) -> dict[str, Any]:
     return value
 
 
+def read_bounded_regular_file(path: Path, label: str, limit: int) -> bytes:
+    """Read at most ``limit`` bytes from one non-symlink regular file."""
+    flags = os.O_RDONLY
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except (FileNotFoundError, NotADirectoryError, OSError) as exc:
+        raise ContractError(f"{label} must be a regular non-symlink file") from exc
+    try:
+        file_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(file_stat.st_mode):
+            fail(f"{label} must be a regular non-symlink file")
+        if file_stat.st_size > limit:
+            fail(f"{label} exceeds {limit} bytes")
+        with os.fdopen(descriptor, "rb", closefd=False) as stream:
+            raw = stream.read(limit + 1)
+    finally:
+        os.close(descriptor)
+    if len(raw) > limit:
+        fail(f"{label} exceeds {limit} bytes")
+    return raw
+
+
 def load_json_file(path: Path, label: str) -> dict[str, Any]:
-    if path.is_symlink() or not path.is_file():
-        fail(f"{label} must be a regular non-symlink file")
-    return load_json_bytes(path.read_bytes(), label)
+    return load_json_bytes(
+        read_bounded_regular_file(path, label, MAX_JSON_BYTES),
+        label,
+    )
 
 
 def exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
@@ -569,13 +598,19 @@ def load_security_binding(
     if metadata_exists != intake_exists:
         fail("partial Security marker: metadata and App-owned intake receipt must exist together")
 
-    metadata_raw = metadata_path.read_bytes() if metadata_path.is_file() and not metadata_path.is_symlink() else b""
+    metadata_raw = read_bounded_regular_file(
+        metadata_path,
+        "Security metadata",
+        MAX_JSON_BYTES,
+    )
     if not metadata_raw:
         fail("Security metadata must be a non-empty regular non-symlink file")
-    if intake_path.is_symlink() or not intake_path.is_file():
-        fail("Security intake receipt must be a regular non-symlink file")
     metadata = load_json_bytes(metadata_raw, "Security release metadata")
-    intake_raw = intake_path.read_bytes()
+    intake_raw = read_bounded_regular_file(
+        intake_path,
+        "Security intake receipt",
+        MAX_JSON_BYTES,
+    )
     receipt = load_json_bytes(intake_raw, "Security intake receipt")
     if intake_raw != canonical_document_bytes(receipt):
         fail("Security intake receipt is not canonical JSON")
@@ -597,9 +632,11 @@ def load_security_binding(
     validate_request_metadata_binding(request, metadata)
     fragment_path_text = verified["changelogFragmentPath"]
     fragment_path = root / fragment_path_text
-    if fragment_path.is_symlink() or not fragment_path.is_file():
-        fail("Security changelog fragment must be a regular non-symlink file")
-    fragment_raw = fragment_path.read_bytes()
+    fragment_raw = read_bounded_regular_file(
+        fragment_path,
+        "Security changelog fragment",
+        MAX_SECURITY_FRAGMENT_BYTES,
+    )
     validate_security_fragment(fragment_raw, "Security changelog fragment")
     fragment_digest = sha256_bytes(fragment_raw)
     if verified["changelogFragmentSha256"] != fragment_digest:
@@ -635,7 +672,10 @@ def _security_marker_versions(root: Path, relative_directory: str) -> set[tuple[
     for path in directory.iterdir():
         if path.name == ".gitkeep":
             continue
-        match = re.fullmatch(r"((?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))\.json", path.name)
+        match = re.fullmatch(
+            r"((?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))\.json",
+            path.name,
+        )
         if match is None:
             fail(f"Security marker namespace contains an invalid entry: {relative_directory}/{path.name}")
         if path.is_symlink() or not path.is_file():

--- a/scripts/security_release_contract.py
+++ b/scripts/security_release_contract.py
@@ -167,11 +167,13 @@ def load_json_bytes(raw: bytes, label: str) -> dict[str, Any]:
 
 def read_bounded_regular_file(path: Path, label: str, limit: int) -> bytes:
     """Read at most ``limit`` bytes from one non-symlink regular file."""
+    nofollow_flag = getattr(os, "O_NOFOLLOW", None)
+    if type(nofollow_flag) is not int:
+        fail(f"{label} cannot prove non-symlink reads on this platform")
     flags = os.O_RDONLY
     if hasattr(os, "O_CLOEXEC"):
         flags |= os.O_CLOEXEC
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
+    flags |= nofollow_flag
     try:
         descriptor = os.open(path, flags)
     except (FileNotFoundError, NotADirectoryError, OSError) as exc:

--- a/scripts/security_release_contract.py
+++ b/scripts/security_release_contract.py
@@ -478,9 +478,19 @@ def validate_profile_registry(registry: dict[str, Any], profile_id: str) -> dict
 
 def canonical_security_fragment_bytes(entries: list[str]) -> bytes:
     """Serialize security fixes as deterministic repository-standard YAML."""
+    if not isinstance(entries, list) or not 1 <= len(entries) <= 64:
+        fail("security_fixes entries must be a list containing 1..64 items")
+    validated_entries = [
+        require_string(entry, "security_fixes entry") for entry in entries
+    ]
     lines = ["---", "security_fixes:"]
-    lines.extend(f"  - {json.dumps(entry, ensure_ascii=True)}" for entry in entries)
-    return ("\n".join(lines) + "\n").encode("utf-8")
+    lines.extend(
+        f"  - {json.dumps(entry, ensure_ascii=True)}" for entry in validated_entries
+    )
+    raw = ("\n".join(lines) + "\n").encode("utf-8")
+    if len(raw) > MAX_SECURITY_FRAGMENT_BYTES:
+        fail(f"security_fixes fragment exceeds {MAX_SECURITY_FRAGMENT_BYTES} bytes")
+    return raw
 
 
 def validate_security_fragment(raw: bytes, label: str) -> dict[str, list[str]]:

--- a/scripts/security_release_contract.py
+++ b/scripts/security_release_contract.py
@@ -480,6 +480,7 @@ def build_intake_receipt(
     request: dict[str, Any],
     verified: dict[str, Any],
     *,
+    checked_at: datetime,
     workflow_run_id: str,
     workflow_attempt: str,
     workflow_ref: str,
@@ -487,7 +488,7 @@ def build_intake_receipt(
     workflow_actor: str,
     observed_automation: dict[str, Any],
 ) -> dict[str, Any]:
-    validate_request(request, PRODUCER_REPOSITORY, timestamp(request["issuedAt"], "issuedAt"))
+    validate_request(request, PRODUCER_REPOSITORY, checked_at)
     validate_intake_result(request, verified)
     if observed_automation != RELEASE_APP_IDENTITY:
         fail("observed release automation identity is unauthorized")
@@ -508,11 +509,15 @@ def build_intake_receipt(
             "actor": workflow_actor,
         },
     }
-    verify_intake_receipt(receipt)
+    verify_intake_receipt(receipt, checked_at=checked_at)
     return receipt
 
 
-def verify_intake_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
+def verify_intake_receipt(
+    receipt: dict[str, Any],
+    *,
+    checked_at: datetime,
+) -> dict[str, Any]:
     exact_keys(receipt, INTAKE_RECEIPT_KEYS, "Security intake receipt")
     if type(receipt["schemaVersion"]) is not int or receipt["schemaVersion"] != INTAKE_RECEIPT_SCHEMA_VERSION:
         fail(f"Security intake receipt schemaVersion must be {INTAKE_RECEIPT_SCHEMA_VERSION}")
@@ -520,7 +525,7 @@ def verify_intake_receipt(receipt: dict[str, Any]) -> dict[str, Any]:
     verified = receipt["verified"]
     if not isinstance(request, dict) or not isinstance(verified, dict):
         fail("Security intake receipt request and verified values must be objects")
-    validate_request(request, PRODUCER_REPOSITORY, timestamp(request.get("issuedAt"), "issuedAt"))
+    validate_request(request, PRODUCER_REPOSITORY, checked_at)
     validate_intake_result(request, verified)
     if receipt["chainId"] != request["chainId"]:
         fail("Security intake receipt chainId differs from its request")
@@ -574,7 +579,7 @@ def load_security_binding(
     receipt = load_json_bytes(intake_raw, "Security intake receipt")
     if intake_raw != canonical_document_bytes(receipt):
         fail("Security intake receipt is not canonical JSON")
-    verify_intake_receipt(receipt)
+    verify_intake_receipt(receipt, checked_at=checked_at)
     request = receipt["request"]
     verified = receipt["verified"]
     if request["fixedVersion"] != version:

--- a/scripts/security_release_contract.py
+++ b/scripts/security_release_contract.py
@@ -11,6 +11,7 @@ import json
 import os
 import re
 import stat
+from contextlib import ExitStack
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, NoReturn
@@ -165,37 +166,50 @@ def load_json_bytes(raw: bytes, label: str) -> dict[str, Any]:
     return value
 
 
-def read_bounded_regular_file(path: Path, label: str, limit: int) -> bytes:
-    """Read at most ``limit`` bytes from one non-symlink regular file."""
+def read_bounded_regular_file(root: Path, relative_path: Path, label: str, limit: int) -> bytes:
+    """Read a bounded regular file through non-symlink descendants of ``root``."""
     nofollow_flag = getattr(os, "O_NOFOLLOW", None)
-    if type(nofollow_flag) is not int:
+    directory_flag = getattr(os, "O_DIRECTORY", None)
+    if type(nofollow_flag) is not int or type(directory_flag) is not int or os.open not in os.supports_dir_fd:
         fail(f"{label} cannot prove non-symlink reads on this platform")
-    flags = os.O_RDONLY
+    parts = relative_path.parts
+    if relative_path.is_absolute() or not parts or any(part in {"", ".", ".."} for part in parts):
+        fail(f"{label} path must be a canonical relative path beneath the trusted root")
+    file_flags = os.O_RDONLY | nofollow_flag
+    directory_flags = file_flags | directory_flag
     if hasattr(os, "O_CLOEXEC"):
-        flags |= os.O_CLOEXEC
-    flags |= nofollow_flag
+        file_flags |= os.O_CLOEXEC
+        directory_flags |= os.O_CLOEXEC
     try:
-        descriptor = os.open(path, flags)
-    except (FileNotFoundError, NotADirectoryError, OSError) as exc:
+        with ExitStack() as descriptors:
+            current_directory = os.open(root, directory_flags)
+            descriptors.callback(os.close, current_directory)
+            for component in parts[:-1]:
+                current_directory = os.open(
+                    component,
+                    directory_flags,
+                    dir_fd=current_directory,
+                )
+                descriptors.callback(os.close, current_directory)
+            descriptor = os.open(parts[-1], file_flags, dir_fd=current_directory)
+            descriptors.callback(os.close, descriptor)
+            file_stat = os.fstat(descriptor)
+            if not stat.S_ISREG(file_stat.st_mode):
+                fail(f"{label} must be a regular non-symlink file")
+            if file_stat.st_size > limit:
+                fail(f"{label} exceeds {limit} bytes")
+            with os.fdopen(descriptor, "rb", closefd=False) as stream:
+                raw = stream.read(limit + 1)
+    except OSError as exc:
         raise ContractError(f"{label} must be a regular non-symlink file") from exc
-    try:
-        file_stat = os.fstat(descriptor)
-        if not stat.S_ISREG(file_stat.st_mode):
-            fail(f"{label} must be a regular non-symlink file")
-        if file_stat.st_size > limit:
-            fail(f"{label} exceeds {limit} bytes")
-        with os.fdopen(descriptor, "rb", closefd=False) as stream:
-            raw = stream.read(limit + 1)
-    finally:
-        os.close(descriptor)
     if len(raw) > limit:
         fail(f"{label} exceeds {limit} bytes")
     return raw
 
 
-def load_json_file(path: Path, label: str) -> dict[str, Any]:
+def load_json_file(root: Path, relative_path: Path, label: str) -> dict[str, Any]:
     return load_json_bytes(
-        read_bounded_regular_file(path, label, MAX_JSON_BYTES),
+        read_bounded_regular_file(root, relative_path, label, MAX_JSON_BYTES),
         label,
     )
 
@@ -601,7 +615,8 @@ def load_security_binding(
         fail("partial Security marker: metadata and App-owned intake receipt must exist together")
 
     metadata_raw = read_bounded_regular_file(
-        metadata_path,
+        root,
+        metadata_path.relative_to(root),
         "Security metadata",
         MAX_JSON_BYTES,
     )
@@ -609,7 +624,8 @@ def load_security_binding(
         fail("Security metadata must be a non-empty regular non-symlink file")
     metadata = load_json_bytes(metadata_raw, "Security release metadata")
     intake_raw = read_bounded_regular_file(
-        intake_path,
+        root,
+        intake_path.relative_to(root),
         "Security intake receipt",
         MAX_JSON_BYTES,
     )
@@ -635,7 +651,8 @@ def load_security_binding(
     fragment_path_text = verified["changelogFragmentPath"]
     fragment_path = root / fragment_path_text
     fragment_raw = read_bounded_regular_file(
-        fragment_path,
+        root,
+        fragment_path.relative_to(root),
         "Security changelog fragment",
         MAX_SECURITY_FRAGMENT_BYTES,
     )
@@ -644,7 +661,8 @@ def load_security_binding(
     if verified["changelogFragmentSha256"] != fragment_digest:
         fail("Security changelog fragment digest differs from the immutable intake binding")
     profiles = load_json_file(
-        root / ".lit" / "security-release-profiles.json",
+        root,
+        Path(".lit/security-release-profiles.json"),
         "protected-main acceptance-profile registry",
     )
     validate_profile_registry(profiles, request["acceptanceProfile"])

--- a/scripts/security_release_contract.py
+++ b/scripts/security_release_contract.py
@@ -476,21 +476,37 @@ def validate_profile_registry(registry: dict[str, Any], profile_id: str) -> dict
     return selected
 
 
+def canonical_security_fragment_bytes(entries: list[str]) -> bytes:
+    """Serialize security fixes as deterministic repository-standard YAML."""
+    lines = ["---", "security_fixes:"]
+    lines.extend(f"  - {json.dumps(entry, ensure_ascii=True)}" for entry in entries)
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
 def validate_security_fragment(raw: bytes, label: str) -> dict[str, list[str]]:
     if len(raw) > MAX_SECURITY_FRAGMENT_BYTES:
         fail(f"{label} exceeds {MAX_SECURITY_FRAGMENT_BYTES} bytes")
-    payload = load_json_bytes(raw, label)
-    if raw != canonical_document_bytes(payload):
-        fail(f"{label} must be canonical JSON with one trailing newline")
-    exact_keys(payload, {"security_fixes"}, label)
-    entries = payload["security_fixes"]
-    if (
-        not isinstance(entries, list)
-        or not entries
-        or len(entries) > 64
-        or any(not isinstance(entry, str) or not entry.strip() or entry != entry.strip() for entry in entries)
-    ):
+    try:
+        lines = raw.decode("utf-8").splitlines()
+    except UnicodeDecodeError as exc:
+        raise ContractError(f"{label} is not valid UTF-8 YAML: {exc}") from exc
+    if len(lines) < 3 or lines[:2] != ["---", "security_fixes:"]:
+        fail(f"{label} must use canonical repository security_fixes YAML")
+    entries: list[str] = []
+    for line in lines[2:]:
+        if not line.startswith("  - "):
+            fail(f"{label} must use canonical repository security_fixes YAML")
+        try:
+            entry = json.loads(line[4:], parse_constant=lambda value: fail(f"{label} has invalid scalar: {value}"))
+        except json.JSONDecodeError as exc:
+            raise ContractError(f"{label} contains an invalid quoted YAML scalar: {exc}") from exc
+        if not isinstance(entry, str):
+            fail(f"{label} security_fixes entries must be strings")
+        entries.append(require_string(entry, f"{label} security_fixes entry"))
+    if not entries or len(entries) > 64:
         fail(f"{label} must contain 1..64 non-empty trimmed security_fixes entries")
+    if raw != canonical_security_fragment_bytes(entries):
+        fail(f"{label} must be canonical repository YAML with one trailing newline")
     return {"security_fixes": entries}
 
 

--- a/scripts/security_release_contract.py
+++ b/scripts/security_release_contract.py
@@ -166,11 +166,16 @@ def load_json_bytes(raw: bytes, label: str) -> dict[str, Any]:
     return value
 
 
+def is_exact_int(value: object) -> bool:
+    """Accept integers while rejecting bool, which is an int subclass."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
 def read_bounded_regular_file(root: Path, relative_path: Path, label: str, limit: int) -> bytes:
     """Read a bounded regular file through non-symlink descendants of ``root``."""
     nofollow_flag = getattr(os, "O_NOFOLLOW", None)
     directory_flag = getattr(os, "O_DIRECTORY", None)
-    if type(nofollow_flag) is not int or type(directory_flag) is not int or os.open not in os.supports_dir_fd:
+    if not is_exact_int(nofollow_flag) or not is_exact_int(directory_flag) or os.open not in os.supports_dir_fd:
         fail(f"{label} cannot prove non-symlink reads on this platform")
     parts = relative_path.parts
     if relative_path.is_absolute() or not parts or any(part in {"", ".", ".."} for part in parts):
@@ -302,13 +307,34 @@ def chain_binding(
     return binding
 
 
-def compute_chain_id(**values: str) -> str:
-    return canonical_sha256(chain_binding(**values))
+def compute_chain_id(
+    *,
+    repository: str,
+    repository_id: str,
+    base_sha: str,
+    candidate_head_sha: str,
+    candidate_diff_sha256: str,
+    evidence_id: str,
+    fixed_version: str,
+    acceptance_profile: str,
+) -> str:
+    return canonical_sha256(
+        chain_binding(
+            repository=repository,
+            repository_id=repository_id,
+            base_sha=base_sha,
+            candidate_head_sha=candidate_head_sha,
+            candidate_diff_sha256=candidate_diff_sha256,
+            evidence_id=evidence_id,
+            fixed_version=fixed_version,
+            acceptance_profile=acceptance_profile,
+        )
+    )
 
 
 def validate_request(request: dict[str, Any], repository: str, now: datetime) -> dict[str, Any]:
     exact_keys(request, REQUEST_KEYS, "Security intake request")
-    if type(request["schemaVersion"]) is not int or request["schemaVersion"] != INTAKE_REQUEST_SCHEMA_VERSION:
+    if not is_exact_int(request["schemaVersion"]) or request["schemaVersion"] != INTAKE_REQUEST_SCHEMA_VERSION:
         fail(f"Security intake schemaVersion must be {INTAKE_REQUEST_SCHEMA_VERSION}")
     if repository != PRODUCER_REPOSITORY or request["repository"] != repository:
         fail("Security intake repository does not match the exact producer repository")
@@ -316,7 +342,7 @@ def validate_request(request: dict[str, Any], repository: str, now: datetime) ->
         fail("Security intake repositoryId does not match the exact producer repository")
     if request["event"] != "mlx90-security-release":
         fail("Security intake event is unsupported")
-    if type(request["humanActions"]) is not int or request["humanActions"] != 0:
+    if not is_exact_int(request["humanActions"]) or request["humanActions"] != 0:
         fail("Security Zero-Touch intake must declare humanActions=0")
 
     for field in ("baseSha", "candidateBaseSha", "candidateHeadSha"):
@@ -379,7 +405,7 @@ def validate_metadata_payload(
     checked_at: datetime,
 ) -> dict[str, Any]:
     exact_keys(metadata, METADATA_KEYS, "Security release metadata")
-    if type(metadata["schemaVersion"]) is not int or metadata["schemaVersion"] != 1:
+    if not is_exact_int(metadata["schemaVersion"]) or metadata["schemaVersion"] != 1:
         fail("Security release metadata schemaVersion must be 1")
     if metadata["evidenceId"] != expected_evidence_id:
         fail("Security metadata evidenceId does not match the intake")
@@ -430,7 +456,7 @@ def validate_profile_registry(registry: dict[str, Any], profile_id: str) -> dict
     """Validate the exact protected-main profile registry and selected profile."""
 
     exact_keys(registry, {"schemaVersion", "profiles"}, "acceptance-profile registry")
-    if type(registry["schemaVersion"]) is not int or registry["schemaVersion"] != 1:
+    if not is_exact_int(registry["schemaVersion"]) or registry["schemaVersion"] != 1:
         fail("acceptance-profile registry is unsupported")
     profiles = registry["profiles"]
     if not isinstance(profiles, dict) or not profiles:
@@ -442,7 +468,7 @@ def validate_profile_registry(registry: dict[str, Any], profile_id: str) -> dict
             fail(f"acceptance profile {name} must be an object")
         exact_keys(profile, PROFILE_KEYS, f"acceptance profile {name}")
         require_string(profile["description"], f"acceptance profile {name} description")
-        if type(profile["releaseEligible"]) is not bool:
+        if not isinstance(profile["releaseEligible"], bool):
             fail(f"acceptance profile {name} releaseEligible must be boolean")
     selected = profiles.get(profile_id)
     if not isinstance(selected, dict) or selected["releaseEligible"] is not True:
@@ -482,9 +508,9 @@ def validate_immutable_marker_changes(changes: list[tuple[str, str]], fixed_vers
 
 def validate_intake_result(request: dict[str, Any], verified: dict[str, Any]) -> dict[str, Any]:
     exact_keys(verified, VERIFIED_KEYS, "verified Security intake")
-    if type(verified["schemaVersion"]) is not int or verified["schemaVersion"] != INTAKE_RESULT_SCHEMA_VERSION:
+    if not is_exact_int(verified["schemaVersion"]) or verified["schemaVersion"] != INTAKE_RESULT_SCHEMA_VERSION:
         fail(f"verified Security intake schemaVersion must be {INTAKE_RESULT_SCHEMA_VERSION}")
-    if type(verified["humanActions"]) is not int or verified["humanActions"] != 0:
+    if not is_exact_int(verified["humanActions"]) or verified["humanActions"] != 0:
         fail("verified Security intake must declare humanActions=0")
     expected = {
         "chainId": request["chainId"],
@@ -564,7 +590,7 @@ def verify_intake_receipt(
     checked_at: datetime,
 ) -> dict[str, Any]:
     exact_keys(receipt, INTAKE_RECEIPT_KEYS, "Security intake receipt")
-    if type(receipt["schemaVersion"]) is not int or receipt["schemaVersion"] != INTAKE_RECEIPT_SCHEMA_VERSION:
+    if not is_exact_int(receipt["schemaVersion"]) or receipt["schemaVersion"] != INTAKE_RECEIPT_SCHEMA_VERSION:
         fail(f"Security intake receipt schemaVersion must be {INTAKE_RECEIPT_SCHEMA_VERSION}")
     request = receipt["request"]
     verified = receipt["verified"]

--- a/tests/unit/test_enrich_cyclonedx_sbom.py
+++ b/tests/unit/test_enrich_cyclonedx_sbom.py
@@ -535,6 +535,15 @@ class EnrichCycloneDxSbomTests(unittest.TestCase):
             SBOM._chrome_linux_scanner_cpe("152.0.8000.1"),
         )
 
+    def test_reviewed_chrome_linux_version_uses_paired_scanner_cpe_version(self) -> None:
+        self.assertEqual(
+            (
+                "151.0.7922.109",
+                "https://chromereleases.googleblog.com/2026/08/stable-channel-update-for-desktop_01193673229.html",
+            ),
+            SBOM._chrome_linux_scanner_cpe("151.0.7922.108"),
+        )
+
     def test_root_version_mismatch_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             paths = self._fixture(Path(directory))

--- a/tests/unit/test_main_promotion_merge_gate.py
+++ b/tests/unit/test_main_promotion_merge_gate.py
@@ -1,0 +1,98 @@
+"""Regression tests for the stable protected-main promotion result."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "main-promotion-authorization.yml"
+FINAL_JOB_ID = "merge-gate"
+FINAL_JOB_NAME = "Main promotion merge gate"
+FINAL_STEP = {
+    "name": "Require successful classification and authorization",
+    "env": {
+        "CLASSIFY_RESULT": "${{ needs.classify.result }}",
+        "AUTHORIZE_RESULT": "${{ needs.authorize.result }}",
+    },
+    "run": ('test "${CLASSIFY_RESULT}" = "success"\ntest "${AUTHORIZE_RESULT}" = "success"\n'),
+}
+
+
+def load_workflow() -> dict[str, Any]:
+    """Load the workflow as one mapping."""
+
+    payload = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise AssertionError("main-promotion workflow is not a YAML mapping")
+    return payload
+
+
+class MainPromotionMergeGateTests(unittest.TestCase):
+    """Keep the required context stable, deterministic, and fail-closed."""
+
+    def test_final_gate_has_the_exact_protected_contract(self) -> None:
+        jobs = load_workflow()["jobs"]
+        gate = jobs[FINAL_JOB_ID]
+
+        self.assertEqual(gate["name"], FINAL_JOB_NAME)
+        self.assertEqual(gate["if"], "${{ always() }}")
+        self.assertEqual(gate["needs"], ["classify", "authorize"])
+        self.assertEqual(gate["steps"], [FINAL_STEP])
+        self.assertEqual(
+            sum(job.get("name") == FINAL_JOB_NAME for job in jobs.values() if isinstance(job, dict)),
+            1,
+        )
+
+    def test_normal_promotion_still_uses_the_classified_human_environment(
+        self,
+    ) -> None:
+        jobs = load_workflow()["jobs"]
+
+        self.assertEqual(jobs["authorize"]["needs"], "classify")
+        self.assertEqual(
+            jobs["authorize"]["environment"],
+            {"name": "${{ needs.classify.outputs.environment }}"},
+        )
+        self.assertEqual(
+            jobs["classify"]["outputs"]["environment"],
+            "${{ steps.classify.outputs.environment }}",
+        )
+
+    def test_final_gate_succeeds_only_when_both_upstreams_succeed(self) -> None:
+        command = "set -euo pipefail\n" + FINAL_STEP["run"]
+        bash = shutil.which("bash")
+        if bash is None:
+            self.fail("bash is required for the final-gate regression test")
+        for classify_result in ("success", "failure", "cancelled", "skipped"):
+            for authorize_result in ("success", "failure", "cancelled", "skipped"):
+                with self.subTest(
+                    classify_result=classify_result,
+                    authorize_result=authorize_result,
+                ):
+                    environment = {
+                        **os.environ,
+                        "CLASSIFY_RESULT": classify_result,
+                        "AUTHORIZE_RESULT": authorize_result,
+                    }
+                    result = subprocess.run(  # noqa: S603 -- fixed shell and test-owned command.
+                        [bash, "-c", command],
+                        check=False,
+                        env=environment,
+                        capture_output=True,
+                        text=True,
+                    )
+                    self.assertEqual(
+                        result.returncode == 0,
+                        classify_result == authorize_result == "success",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_main_promotion_merge_gate.py
+++ b/tests/unit/test_main_promotion_merge_gate.py
@@ -70,7 +70,7 @@ class MainPromotionMergeGateTests(unittest.TestCase):
         )
 
     def test_final_gate_succeeds_only_when_both_upstreams_succeed(self) -> None:
-        command = "set -euo pipefail\n" + FINAL_STEP["run"]
+        command = FINAL_STEP["run"]
         bash = shutil.which("bash")
         if bash is None:
             self.fail("bash is required for the final-gate regression test")

--- a/tests/unit/test_main_promotion_merge_gate.py
+++ b/tests/unit/test_main_promotion_merge_gate.py
@@ -16,12 +16,15 @@ WORKFLOW = ROOT / ".github" / "workflows" / "main-promotion-authorization.yml"
 FINAL_JOB_ID = "merge-gate"
 FINAL_JOB_NAME = "Main promotion merge gate"
 FINAL_STEP = {
-    "name": "Require successful classification and authorization",
+    "name": "Require successful protected authorization",
     "env": {
-        "CLASSIFY_RESULT": "${{ needs.classify.result }}",
         "AUTHORIZE_RESULT": "${{ needs.authorize.result }}",
+        "CLASSIFY_RESULT": "${{ needs.classify.result }}",
     },
-    "run": ('test "${CLASSIFY_RESULT}" = "success"\ntest "${AUTHORIZE_RESULT}" = "success"\n'),
+    "run": (
+        'set -euo pipefail\ntest "$CLASSIFY_RESULT" = success\n'
+        'test "$AUTHORIZE_RESULT" = success\n'
+    ),
 }
 
 
@@ -44,6 +47,7 @@ class MainPromotionMergeGateTests(unittest.TestCase):
         self.assertEqual(gate["name"], FINAL_JOB_NAME)
         self.assertEqual(gate["if"], "${{ always() }}")
         self.assertEqual(gate["needs"], ["classify", "authorize"])
+        self.assertEqual(gate["permissions"], {})
         self.assertEqual(gate["steps"], [FINAL_STEP])
         self.assertEqual(
             sum(job.get("name") == FINAL_JOB_NAME for job in jobs.values() if isinstance(job, dict)),

--- a/tests/unit/test_main_promotion_merge_gate.py
+++ b/tests/unit/test_main_promotion_merge_gate.py
@@ -21,10 +21,7 @@ FINAL_STEP = {
         "AUTHORIZE_RESULT": "${{ needs.authorize.result }}",
         "CLASSIFY_RESULT": "${{ needs.classify.result }}",
     },
-    "run": (
-        'set -euo pipefail\ntest "$CLASSIFY_RESULT" = success\n'
-        'test "$AUTHORIZE_RESULT" = success\n'
-    ),
+    "run": ('set -euo pipefail\ntest "$CLASSIFY_RESULT" = success\ntest "$AUTHORIZE_RESULT" = success\n'),
 }
 
 

--- a/tests/unit/test_security_release_contract.py
+++ b/tests/unit/test_security_release_contract.py
@@ -1,0 +1,362 @@
+"""Tests for the canonical MLX-90 Security release contract."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import security_release_contract as CONTRACT  # noqa: E402
+
+VERSION = "3.2.4"
+EVIDENCE_ID = "MLX90-KEYCLOAK-26.7.1-3.2.4"
+PROFILE = "lit.supplementary/keycloak-26.7.1-security-v1"
+NOW = datetime(2026, 8, 8, 23, 0, tzinfo=UTC)
+
+
+class SecurityReleaseContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        profiles = self.root / ".lit/security-release-profiles.json"
+        profiles.parent.mkdir(parents=True)
+        profiles.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "profiles": {
+                        PROFILE: {
+                            "description": "Exact Keycloak acceptance",
+                            "releaseEligible": True,
+                        }
+                    },
+                },
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        self.metadata = {
+            "schemaVersion": 1,
+            "evidenceId": EVIDENCE_ID,
+            "createdAt": "2026-08-08T22:30:00Z",
+            "securityIdentifiers": ["CVE-2026-9793"],
+            "affectedVersion": "3.2.3",
+            "fixedVersion": VERSION,
+            "consumers": [CONTRACT.CONSUMER_REPOSITORY],
+            "acceptanceProfile": PROFILE,
+            "validity": {
+                "notBefore": "2026-08-08T22:30:00Z",
+                "expiresAt": "2026-09-08T22:30:00Z",
+                "revoked": False,
+            },
+        }
+        self.metadata_raw = (json.dumps(self.metadata, indent=2, sort_keys=True) + "\n").encode()
+        candidate_digest = "sha256:" + "c" * 64
+        chain_id = CONTRACT.compute_chain_id(
+            repository=CONTRACT.PRODUCER_REPOSITORY,
+            repository_id=CONTRACT.PRODUCER_REPOSITORY_ID,
+            base_sha="a" * 40,
+            candidate_head_sha="b" * 40,
+            candidate_diff_sha256=candidate_digest,
+            evidence_id=EVIDENCE_ID,
+            fixed_version=VERSION,
+            acceptance_profile=PROFILE,
+        )
+        self.request = {
+            "schemaVersion": 2,
+            "event": "mlx90-security-release",
+            "repository": CONTRACT.PRODUCER_REPOSITORY,
+            "repositoryId": CONTRACT.PRODUCER_REPOSITORY_ID,
+            "baseSha": "a" * 40,
+            "candidateRef": "develop",
+            "candidateBaseSha": "a" * 40,
+            "candidateHeadSha": "b" * 40,
+            "candidateDiffSha256": candidate_digest,
+            "evidenceId": EVIDENCE_ID,
+            "fixedVersion": VERSION,
+            "acceptanceProfile": PROFILE,
+            "metadataSha256": CONTRACT.sha256_bytes(self.metadata_raw),
+            "chainId": chain_id,
+            "issuedAt": "2026-08-08T22:30:00Z",
+            "expiresAt": "2026-09-08T22:30:00Z",
+            "humanActions": 0,
+        }
+        fragment = b'{"security_fixes":["Keycloak fix."]}\n'
+        self.verified = {
+            "schemaVersion": 2,
+            "chainId": chain_id,
+            "branch": f"security-release/{EVIDENCE_ID}",
+            "baseSha": "a" * 40,
+            "candidateBaseSha": "a" * 40,
+            "candidateHeadSha": "b" * 40,
+            "candidateDiffSha256": candidate_digest,
+            "evidenceId": EVIDENCE_ID,
+            "fixedVersion": VERSION,
+            "metadataPath": f".lit/security-releases/{VERSION}.json",
+            "metadataSha256": CONTRACT.sha256_bytes(self.metadata_raw),
+            "acceptanceProfile": PROFILE,
+            "changelogFragmentPath": "changelogs/fragments/keycloak-security.yml",
+            "changelogFragmentSha256": CONTRACT.sha256_bytes(fragment),
+            "changedPaths": [
+                f".lit/security-releases/{VERSION}.json",
+                "changelogs/fragments/keycloak-security.yml",
+                "roles/keycloak_deploy/defaults/main.yml",
+            ],
+            "humanActions": 0,
+        }
+        self.fragment_raw = fragment
+
+    def _receipt(self) -> dict[str, object]:
+        return CONTRACT.build_intake_receipt(
+            self.request,
+            self.verified,
+            workflow_run_id="123456",
+            workflow_attempt="1",
+            workflow_ref=(
+                f"{CONTRACT.PRODUCER_REPOSITORY}/.github/workflows/security-release-intake.yml@refs/heads/main"
+            ),
+            workflow_event="repository_dispatch",
+            workflow_actor=CONTRACT.RELEASE_APP_LOGIN,
+            observed_automation=CONTRACT.RELEASE_APP_IDENTITY,
+        )
+
+    def _write_binding(self) -> dict[str, object]:
+        metadata_path = self.root / f".lit/security-releases/{VERSION}.json"
+        metadata_path.parent.mkdir(parents=True)
+        metadata_path.write_bytes(self.metadata_raw)
+        receipt = self._receipt()
+        receipt_path = self.root / f".lit/security-release-intakes/{VERSION}.json"
+        receipt_path.parent.mkdir(parents=True)
+        receipt_path.write_bytes(CONTRACT.canonical_document_bytes(receipt))
+        fragment_path = self.root / self.verified["changelogFragmentPath"]
+        fragment_path.parent.mkdir(parents=True)
+        fragment_path.write_bytes(self.fragment_raw)
+        return receipt
+
+    def test_chain_id_uses_one_canonical_exact_binding(self) -> None:
+        binding = CONTRACT.chain_binding(
+            repository=CONTRACT.PRODUCER_REPOSITORY,
+            repository_id=CONTRACT.PRODUCER_REPOSITORY_ID,
+            base_sha="a" * 40,
+            candidate_head_sha="b" * 40,
+            candidate_diff_sha256="sha256:" + "c" * 64,
+            evidence_id=EVIDENCE_ID,
+            fixed_version=VERSION,
+            acceptance_profile=PROFILE,
+        )
+        expected = (
+            "sha256:" + hashlib.sha256(json.dumps(binding, separators=(",", ":"), sort_keys=True).encode()).hexdigest()
+        )
+        self.assertEqual(expected, self.request["chainId"])
+        reordered = dict(reversed(list(binding.items())))
+        self.assertEqual(expected, CONTRACT.canonical_sha256(reordered))
+
+    def test_request_and_receipt_are_exact_duplicate_safe_and_app_bound(self) -> None:
+        CONTRACT.validate_request(self.request, CONTRACT.PRODUCER_REPOSITORY, NOW)
+        receipt = self._receipt()
+        CONTRACT.verify_intake_receipt(receipt)
+        self.assertEqual(CONTRACT.RELEASE_APP_IDENTITY, receipt["automation"])
+
+        mutations = (
+            lambda value: value["automation"].__setitem__("installationId", "1"),
+            lambda value: value["controller"].__setitem__("actor", "human"),
+            lambda value: value.__setitem__("unknown", True),
+            lambda value: value["request"].__setitem__("chainId", "sha256:" + "0" * 64),
+            lambda value: value["request"].__setitem__("schemaVersion", 2.0),
+            lambda value: value["request"].__setitem__("humanActions", False),
+            lambda value: value["controller"].__setitem__("runId", 123456),
+        )
+        for mutate in mutations:
+            with self.subTest(mutate=mutate):
+                tampered = copy.deepcopy(receipt)
+                mutate(tampered)
+                with self.assertRaises(CONTRACT.ContractError):
+                    CONTRACT.verify_intake_receipt(tampered)
+
+        with self.assertRaisesRegex(CONTRACT.ContractError, "duplicate JSON key"):
+            CONTRACT.load_json_bytes(b'{"schemaVersion":2,"schemaVersion":2}', "receipt")
+        with self.assertRaisesRegex(CONTRACT.ContractError, "fields mismatch"):
+            request = copy.deepcopy(self.request)
+            request["unknown"] = True
+            CONTRACT.validate_request(request, CONTRACT.PRODUCER_REPOSITORY, NOW)
+        for field, invalid in (("schemaVersion", 2.0), ("humanActions", False)):
+            with self.subTest(result_field=field, invalid=invalid):
+                verified = copy.deepcopy(self.verified)
+                verified[field] = invalid
+                with self.assertRaises(CONTRACT.ContractError):
+                    CONTRACT.validate_intake_result(self.request, verified)
+        with self.assertRaisesRegex(CONTRACT.ContractError, "observed release automation"):
+            observed = dict(CONTRACT.RELEASE_APP_IDENTITY)
+            observed["installationId"] = "1"
+            CONTRACT.build_intake_receipt(
+                self.request,
+                self.verified,
+                workflow_run_id="123456",
+                workflow_attempt="1",
+                workflow_ref=(
+                    f"{CONTRACT.PRODUCER_REPOSITORY}/.github/workflows/security-release-intake.yml@refs/heads/main"
+                ),
+                workflow_event="repository_dispatch",
+                workflow_actor=CONTRACT.RELEASE_APP_LOGIN,
+                observed_automation=observed,
+            )
+
+    def test_security_fragment_and_consumer_are_exact(self) -> None:
+        valid = b'{"security_fixes":["Fixed exact vulnerability."]}\n'
+        self.assertEqual(
+            {"security_fixes": ["Fixed exact vulnerability."]},
+            CONTRACT.validate_security_fragment(valid, "fragment"),
+        )
+        for invalid in (
+            b"---\nsecurity_fixes:\n  - YAML is not canonical JSON.\n",
+            b'{"bugfixes":["not Security"]}',
+            b'{"security_fixes":[]}',
+            b'{"security_fixes":["one"],"security_fixes":["two"]}',
+        ):
+            with self.subTest(invalid=invalid), self.assertRaises(CONTRACT.ContractError):
+                CONTRACT.validate_security_fragment(invalid, "fragment")
+
+        CONTRACT.validate_metadata_payload(
+            self.metadata,
+            expected_evidence_id=EVIDENCE_ID,
+            expected_version=VERSION,
+            expected_profile=PROFILE,
+            checked_at=NOW,
+        )
+        metadata = copy.deepcopy(self.metadata)
+        metadata["consumers"] = [CONTRACT.CONSUMER_REPOSITORY, "example/other"]
+        with self.assertRaisesRegex(CONTRACT.ContractError, "exact MLX-90 consumer"):
+            CONTRACT.validate_metadata_payload(
+                metadata,
+                expected_evidence_id=EVIDENCE_ID,
+                expected_version=VERSION,
+                expected_profile=PROFILE,
+                checked_at=NOW,
+            )
+
+    def test_immutable_markers_reject_receipts_and_existing_metadata_in_candidate(self) -> None:
+        metadata_path = f".lit/security-releases/{VERSION}.json"
+        valid = [
+            ("A", metadata_path),
+            ("A", "changelogs/fragments/keycloak-security.yml"),
+            ("M", "roles/keycloak_deploy/defaults/main.yml"),
+        ]
+        CONTRACT.validate_immutable_marker_changes(valid, VERSION)
+        invalid = (
+            valid + [("M", ".lit/security-releases/3.2.2.json")],
+            [("M", metadata_path)],
+            valid + [("A", f".lit/security-release-intakes/{VERSION}.json")],
+            valid + [("M", ".lit/security-release-profiles.json")],
+        )
+        for changes in invalid:
+            with self.subTest(changes=changes), self.assertRaises(CONTRACT.ContractError):
+                CONTRACT.validate_immutable_marker_changes(changes, VERSION)
+
+    def test_binding_fails_closed_for_partial_or_tampered_markers(self) -> None:
+        metadata_path = self.root / f".lit/security-releases/{VERSION}.json"
+        metadata_path.parent.mkdir(parents=True)
+        metadata_path.write_bytes(self.metadata_raw)
+        with self.assertRaisesRegex(CONTRACT.ContractError, "partial Security marker"):
+            CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
+
+        receipt = self._receipt()
+        receipt_path = self.root / f".lit/security-release-intakes/{VERSION}.json"
+        receipt_path.parent.mkdir(parents=True)
+        receipt_path.write_bytes(CONTRACT.canonical_document_bytes(receipt))
+        fragment_path = self.root / self.verified["changelogFragmentPath"]
+        with self.assertRaisesRegex(CONTRACT.ContractError, "changelog fragment must be"):
+            CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
+        fragment_path.parent.mkdir(parents=True)
+        fragment_path.write_bytes(self.fragment_raw)
+        binding = CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
+        assert binding is not None
+        self.assertEqual(self.request["chainId"], binding["chain_id"])
+        self.assertEqual(CONTRACT.sha256_bytes(receipt_path.read_bytes()), binding["intake_receipt_sha256"])
+
+        receipt_path.write_text(
+            json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(CONTRACT.ContractError, "not canonical JSON"):
+            CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
+        receipt_path.write_bytes(CONTRACT.canonical_document_bytes(receipt))
+
+        fragment_path.write_bytes(b'{"security_fixes":["Changed fix."]}\n')
+        with self.assertRaisesRegex(CONTRACT.ContractError, "fragment digest differs"):
+            CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
+        fragment_path.write_bytes(self.fragment_raw)
+
+        receipt_path.unlink()
+        receipt_path.symlink_to(fragment_path)
+        with self.assertRaisesRegex(CONTRACT.ContractError, "receipt must be a regular non-symlink"):
+            CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
+        receipt_path.unlink()
+        receipt_path.write_bytes(CONTRACT.canonical_document_bytes(receipt))
+
+        metadata = copy.deepcopy(self.metadata)
+        metadata["fixedVersion"] = "3.2.5"
+        metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+        with self.assertRaisesRegex(CONTRACT.ContractError, "digest differs"):
+            CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
+
+    def test_request_metadata_profile_and_pending_marker_contracts_are_exact(self) -> None:
+        metadata = copy.deepcopy(self.metadata)
+        for field, value, message in (
+            ("issuedAt", "2026-08-08T22:31:00Z", "issuedAt differs"),
+            ("expiresAt", "2026-09-09T22:30:00Z", "expiresAt differs"),
+        ):
+            with self.subTest(field=field):
+                request = copy.deepcopy(self.request)
+                request[field] = value
+                with self.assertRaisesRegex(CONTRACT.ContractError, message):
+                    CONTRACT.validate_request_metadata_binding(request, metadata)
+
+        profiles = CONTRACT.load_json_file(
+            self.root / ".lit/security-release-profiles.json",
+            "profile registry",
+        )
+        CONTRACT.validate_profile_registry(profiles, PROFILE)
+        profiles["profiles"][PROFILE]["unknown"] = True
+        with self.assertRaisesRegex(CONTRACT.ContractError, "fields mismatch"):
+            CONTRACT.validate_profile_registry(profiles, PROFILE)
+
+        self._write_binding()
+        self.assertIsNotNone(
+            CONTRACT.load_release_security_binding(
+                self.root,
+                "3.2.3",
+                VERSION,
+                checked_at=NOW,
+            )
+        )
+        self.assertIsNone(
+            CONTRACT.load_release_security_binding(
+                self.root,
+                VERSION,
+                "3.2.5",
+                checked_at=NOW,
+            )
+        )
+        future = self.root / ".lit/security-releases/3.2.6.json"
+        future.write_text("{}\n", encoding="utf-8")
+        with self.assertRaisesRegex(CONTRACT.ContractError, "does not match"):
+            CONTRACT.load_release_security_binding(
+                self.root,
+                VERSION,
+                "3.2.5",
+                checked_at=NOW,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_security_release_contract.py
+++ b/tests/unit/test_security_release_contract.py
@@ -255,7 +255,9 @@ class SecurityReleaseContractTests(unittest.TestCase):
                 checked_at=NOW,
             )
 
-    def test_immutable_markers_reject_receipts_and_existing_metadata_in_candidate(self) -> None:
+    def test_immutable_markers_reject_receipts_and_existing_metadata_in_candidate(
+        self,
+    ) -> None:
         metadata_path = f".lit/security-releases/{VERSION}.json"
         valid = [
             ("A", metadata_path),
@@ -292,7 +294,10 @@ class SecurityReleaseContractTests(unittest.TestCase):
         binding = CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
         assert binding is not None
         self.assertEqual(self.request["chainId"], binding["chain_id"])
-        self.assertEqual(CONTRACT.sha256_bytes(receipt_path.read_bytes()), binding["intake_receipt_sha256"])
+        self.assertEqual(
+            CONTRACT.sha256_bytes(receipt_path.read_bytes()),
+            binding["intake_receipt_sha256"],
+        )
 
         receipt_path.write_text(
             json.dumps(receipt, indent=2, sort_keys=True) + "\n",
@@ -320,7 +325,36 @@ class SecurityReleaseContractTests(unittest.TestCase):
         with self.assertRaisesRegex(CONTRACT.ContractError, "digest differs"):
             CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
 
-    def test_request_metadata_profile_and_pending_marker_contracts_are_exact(self) -> None:
+    def test_binding_rejects_oversized_files_before_parsing(self) -> None:
+        self._write_binding()
+        metadata_path = self.root / f".lit/security-releases/{VERSION}.json"
+        receipt_path = self.root / f".lit/security-release-intakes/{VERSION}.json"
+        fragment_path = self.root / self.verified["changelogFragmentPath"]
+        profiles_path = self.root / ".lit/security-release-profiles.json"
+
+        for path, limit, label in (
+            (metadata_path, CONTRACT.MAX_JSON_BYTES, "Security metadata exceeds"),
+            (receipt_path, CONTRACT.MAX_JSON_BYTES, "Security intake receipt exceeds"),
+            (
+                fragment_path,
+                CONTRACT.MAX_SECURITY_FRAGMENT_BYTES,
+                "Security changelog fragment exceeds",
+            ),
+        ):
+            original = path.read_bytes()
+            with self.subTest(path=path):
+                path.write_bytes(b"x" * (limit + 1))
+                with self.assertRaisesRegex(CONTRACT.ContractError, label):
+                    CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
+                path.write_bytes(original)
+
+        profiles_path.write_bytes(b"x" * (CONTRACT.MAX_JSON_BYTES + 1))
+        with self.assertRaisesRegex(CONTRACT.ContractError, "profile registry exceeds"):
+            CONTRACT.load_json_file(profiles_path, "profile registry")
+
+    def test_request_metadata_profile_and_pending_marker_contracts_are_exact(
+        self,
+    ) -> None:
         metadata = copy.deepcopy(self.metadata)
         for field, value, message in (
             ("issuedAt", "2026-08-08T22:31:00Z", "issuedAt differs"),

--- a/tests/unit/test_security_release_contract.py
+++ b/tests/unit/test_security_release_contract.py
@@ -351,13 +351,36 @@ class SecurityReleaseContractTests(unittest.TestCase):
 
         profiles_path.write_bytes(b"x" * (CONTRACT.MAX_JSON_BYTES + 1))
         with self.assertRaisesRegex(CONTRACT.ContractError, "profile registry exceeds"):
-            CONTRACT.load_json_file(profiles_path, "profile registry")
+            CONTRACT.load_json_file(
+                self.root,
+                Path(".lit/security-release-profiles.json"),
+                "profile registry",
+            )
 
     def test_bounded_read_fails_closed_without_nofollow_support(self) -> None:
-        profiles_path = self.root / ".lit/security-release-profiles.json"
         with patch.object(CONTRACT.os, "O_NOFOLLOW", None):
             with self.assertRaisesRegex(CONTRACT.ContractError, "cannot prove non-symlink reads"):
-                CONTRACT.load_json_file(profiles_path, "profile registry")
+                CONTRACT.load_json_file(
+                    self.root,
+                    Path(".lit/security-release-profiles.json"),
+                    "profile registry",
+                )
+
+    def test_binding_rejects_symlinked_ancestor_directories(self) -> None:
+        self._write_binding()
+        metadata_path = self.root / f".lit/security-releases/{VERSION}.json"
+        fragment_path = self.root / self.verified["changelogFragmentPath"]
+        for parent in (self.root / ".lit", metadata_path.parent, fragment_path.parent):
+            backup = parent.with_name(parent.name + "-real")
+            with self.subTest(parent=parent):
+                parent.rename(backup)
+                parent.symlink_to(backup, target_is_directory=True)
+                try:
+                    with self.assertRaisesRegex(CONTRACT.ContractError, "regular non-symlink"):
+                        CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
+                finally:
+                    parent.unlink()
+                    backup.rename(parent)
 
     def test_request_metadata_profile_and_pending_marker_contracts_are_exact(
         self,
@@ -374,7 +397,8 @@ class SecurityReleaseContractTests(unittest.TestCase):
                     CONTRACT.validate_request_metadata_binding(request, metadata)
 
         profiles = CONTRACT.load_json_file(
-            self.root / ".lit/security-release-profiles.json",
+            self.root,
+            Path(".lit/security-release-profiles.json"),
             "profile registry",
         )
         CONTRACT.validate_profile_registry(profiles, PROFILE)

--- a/tests/unit/test_security_release_contract.py
+++ b/tests/unit/test_security_release_contract.py
@@ -12,9 +12,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-sys.path.insert(0, str(ROOT / "scripts"))
-
-import security_release_contract as CONTRACT  # noqa: E402
+SCRIPTS = str(ROOT / "scripts")
+sys.path.insert(0, SCRIPTS)
+try:
+    import security_release_contract as CONTRACT  # noqa: E402
+finally:
+    sys.path.remove(SCRIPTS)
 
 VERSION = "3.2.4"
 EVIDENCE_ID = "MLX90-KEYCLOAK-26.7.1-3.2.4"
@@ -116,10 +119,11 @@ class SecurityReleaseContractTests(unittest.TestCase):
         }
         self.fragment_raw = fragment
 
-    def _receipt(self) -> dict[str, object]:
+    def _receipt(self, *, checked_at: datetime = NOW) -> dict[str, object]:
         return CONTRACT.build_intake_receipt(
             self.request,
             self.verified,
+            checked_at=checked_at,
             workflow_run_id="123456",
             workflow_attempt="1",
             workflow_ref=(
@@ -164,7 +168,7 @@ class SecurityReleaseContractTests(unittest.TestCase):
     def test_request_and_receipt_are_exact_duplicate_safe_and_app_bound(self) -> None:
         CONTRACT.validate_request(self.request, CONTRACT.PRODUCER_REPOSITORY, NOW)
         receipt = self._receipt()
-        CONTRACT.verify_intake_receipt(receipt)
+        CONTRACT.verify_intake_receipt(receipt, checked_at=NOW)
         self.assertEqual(CONTRACT.RELEASE_APP_IDENTITY, receipt["automation"])
 
         mutations = (
@@ -181,7 +185,13 @@ class SecurityReleaseContractTests(unittest.TestCase):
                 tampered = copy.deepcopy(receipt)
                 mutate(tampered)
                 with self.assertRaises(CONTRACT.ContractError):
-                    CONTRACT.verify_intake_receipt(tampered)
+                    CONTRACT.verify_intake_receipt(tampered, checked_at=NOW)
+
+        after_expiry = datetime(2026, 9, 8, 22, 30, tzinfo=UTC)
+        with self.assertRaisesRegex(CONTRACT.ContractError, "not currently valid"):
+            CONTRACT.verify_intake_receipt(receipt, checked_at=after_expiry)
+        with self.assertRaisesRegex(CONTRACT.ContractError, "not currently valid"):
+            self._receipt(checked_at=after_expiry)
 
         with self.assertRaisesRegex(CONTRACT.ContractError, "duplicate JSON key"):
             CONTRACT.load_json_bytes(b'{"schemaVersion":2,"schemaVersion":2}', "receipt")
@@ -201,6 +211,7 @@ class SecurityReleaseContractTests(unittest.TestCase):
             CONTRACT.build_intake_receipt(
                 self.request,
                 self.verified,
+                checked_at=NOW,
                 workflow_run_id="123456",
                 workflow_attempt="1",
                 workflow_ref=(

--- a/tests/unit/test_security_release_contract.py
+++ b/tests/unit/test_security_release_contract.py
@@ -12,6 +12,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = str(ROOT / "scripts")
 sys.path.insert(0, SCRIPTS)
@@ -95,7 +97,7 @@ class SecurityReleaseContractTests(unittest.TestCase):
             "expiresAt": "2026-09-08T22:30:00Z",
             "humanActions": 0,
         }
-        fragment = b'{"security_fixes":["Keycloak fix."]}\n'
+        fragment = CONTRACT.canonical_security_fragment_bytes(["Keycloak fix."])
         self.verified = {
             "schemaVersion": 2,
             "chainId": chain_id,
@@ -224,16 +226,19 @@ class SecurityReleaseContractTests(unittest.TestCase):
             )
 
     def test_security_fragment_and_consumer_are_exact(self) -> None:
-        valid = b'{"security_fixes":["Fixed exact vulnerability."]}\n'
+        entries = ['Fixed: "quoted" vulnerability.', "Unicode \u00e4 remains deterministic."]
+        valid = CONTRACT.canonical_security_fragment_bytes(entries)
         self.assertEqual(
-            {"security_fixes": ["Fixed exact vulnerability."]},
+            {"security_fixes": entries},
             CONTRACT.validate_security_fragment(valid, "fragment"),
         )
+        self.assertEqual({"security_fixes": entries}, yaml.safe_load(valid))
         for invalid in (
-            b"---\nsecurity_fixes:\n  - YAML is not canonical JSON.\n",
-            b'{"bugfixes":["not Security"]}',
-            b'{"security_fixes":[]}',
-            b'{"security_fixes":["one"],"security_fixes":["two"]}',
+            b"---\nsecurity_fixes:\n  - YAML scalar is not canonically quoted.\n",
+            b'---\nbugfixes:\n  - "not Security"\n',
+            b"---\nsecurity_fixes: []\n",
+            b'---\nsecurity_fixes:\n  - "one"\nsecurity_fixes:\n  - "two"\n',
+            b'---\nsecurity_fixes:\n  - "missing final newline"',
         ):
             with self.subTest(invalid=invalid), self.assertRaises(CONTRACT.ContractError):
                 CONTRACT.validate_security_fragment(invalid, "fragment")
@@ -308,7 +313,7 @@ class SecurityReleaseContractTests(unittest.TestCase):
             CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
         receipt_path.write_bytes(CONTRACT.canonical_document_bytes(receipt))
 
-        fragment_path.write_bytes(b'{"security_fixes":["Changed fix."]}\n')
+        fragment_path.write_bytes(CONTRACT.canonical_security_fragment_bytes(["Changed fix."]))
         with self.assertRaisesRegex(CONTRACT.ContractError, "fragment digest differs"):
             CONTRACT.load_security_binding(self.root, VERSION, checked_at=NOW)
         fragment_path.write_bytes(self.fragment_raw)

--- a/tests/unit/test_security_release_contract.py
+++ b/tests/unit/test_security_release_contract.py
@@ -243,6 +243,17 @@ class SecurityReleaseContractTests(unittest.TestCase):
             with self.subTest(invalid=invalid), self.assertRaises(CONTRACT.ContractError):
                 CONTRACT.validate_security_fragment(invalid, "fragment")
 
+        for invalid_entries in (
+            [],
+            ["entry"] * 65,
+            [""],
+            [" not trimmed"],
+            ["two\nlines"],
+            [1],
+        ):
+            with self.subTest(invalid_entries=invalid_entries), self.assertRaises(CONTRACT.ContractError):
+                CONTRACT.canonical_security_fragment_bytes(invalid_entries)
+
         CONTRACT.validate_metadata_payload(
             self.metadata,
             expected_evidence_id=EVIDENCE_ID,

--- a/tests/unit/test_security_release_contract.py
+++ b/tests/unit/test_security_release_contract.py
@@ -10,6 +10,7 @@ import tempfile
 import unittest
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = str(ROOT / "scripts")
@@ -351,6 +352,12 @@ class SecurityReleaseContractTests(unittest.TestCase):
         profiles_path.write_bytes(b"x" * (CONTRACT.MAX_JSON_BYTES + 1))
         with self.assertRaisesRegex(CONTRACT.ContractError, "profile registry exceeds"):
             CONTRACT.load_json_file(profiles_path, "profile registry")
+
+    def test_bounded_read_fails_closed_without_nofollow_support(self) -> None:
+        profiles_path = self.root / ".lit/security-release-profiles.json"
+        with patch.object(CONTRACT.os, "O_NOFOLLOW", None):
+            with self.assertRaisesRegex(CONTRACT.ContractError, "cannot prove non-symlink reads"):
+                CONTRACT.load_json_file(profiles_path, "profile registry")
 
     def test_request_metadata_profile_and_pending_marker_contracts_are_exact(
         self,

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -52,6 +53,17 @@ def docker_action_image(path: Path) -> str | None:
 
 
 class WorkflowSecurityTests(unittest.TestCase):
+    def test_copilot_instructions_bind_the_exact_agent_contract(self) -> None:
+        agents_digest = hashlib.sha256((ROOT / "AGENTS.md").read_bytes()).hexdigest()
+        instructions = (ROOT / ".github" / "copilot-instructions.md").read_text(encoding="utf-8").splitlines()
+        self.assertEqual(
+            [
+                "<!-- Managed contract: Codex and Copilot must apply AGENTS.md. -->",
+                f"<!-- AGENTS_SHA256: {agents_digest} -->",
+            ],
+            instructions[-2:],
+        )
+
     def test_quality_cells_install_only_the_prebuilt_exact_candidate(self) -> None:
         action = ACTION.read_text(encoding="utf-8")
         install = re.search(

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -56,6 +56,8 @@ class WorkflowSecurityTests(unittest.TestCase):
     def test_copilot_instructions_bind_the_exact_agent_contract(self) -> None:
         agents_digest = hashlib.sha256((ROOT / "AGENTS.md").read_bytes()).hexdigest()
         instructions = (ROOT / ".github" / "copilot-instructions.md").read_text(encoding="utf-8").splitlines()
+        while instructions and not instructions[-1].strip():
+            instructions.pop()
         self.assertEqual(
             [
                 "<!-- Managed contract: Codex and Copilot must apply AGENTS.md. -->",


### PR DESCRIPTION
## Summary

- bind the history-free review instructions and regression contract
- bind the Chrome Linux SBOM CPE mapping
- add the inert MLX-90 receipt/contract validation library and tests
- bind the downstream regression test to the canonical protected main-promotion merge gate

This is stage 1 of the Supplementary Golden Path. Runtime activation remains inert until the subsequent separately reviewed stage.

## Exact revision

- base: `8c49bec2ac5fdcc0004153729815674768a3ef53`
- head: `612de468d8b3bd931cf5a8c4bc5be903b790684e`
- history-free review bytes: `65465 < 200000`

## Verification

- history-free Codex review: PASS
- history-free GitHub Copilot review: PASS
- 229 stage-available unit tests: PASS
- 47 directly affected contract tests: PASS
- `git diff --check`: PASS

Server-side Current-Head Copilot review and all protected required checks remain mandatory. Normal merge commit only; no bypass.