### PR TITLE
feat(security): activate App-authored intake receipts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,4 +9,4 @@
 - Prefer a regression test for bugs and security issues.
 
 <!-- Managed contract: Codex and Copilot must apply AGENTS.md. -->
-<!-- AGENTS_SHA256: a0162704193f51350d43ad4873462490f6ead53919ebb37e07c15ef72dacbf04 -->
+<!-- AGENTS_SHA256: 14756dae73fbbae40e3fe06c8f00eaf61412d1f85512d0aed2e1bcfd3b5ea843 -->

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -420,24 +420,26 @@ jobs:
           PY
           )"
           test "$released_version" = "$expected_version"
+
+          base_tree="$RUNNER_TEMP/release-preparation-base"
+          test ! -e "$base_tree"
+          git worktree add --detach --quiet "$base_tree" "$REVIEWED_BASE_SHA"
+          test "$(git -C "$base_tree" rev-parse HEAD)" = "$REVIEWED_BASE_SHA"
           python scripts/release-version.py \
             --verify-preparation-receipt "$receipt" \
             --repository "$GITHUB_REPOSITORY" \
             --repository-id "$REPOSITORY_ID" \
             --base-sha "$REVIEWED_BASE_SHA" \
-            --expected-version "$expected_version" >/dev/null
+            --expected-version "$expected_version" \
+            --root "$base_tree" >/dev/null
 
-          base_tree="$RUNNER_TEMP/release-preparation-base"
-          rm -rf "$base_tree"
-          mkdir -p "$base_tree/fragments"
-          git show "$REVIEWED_BASE_SHA:galaxy.yml" > "$base_tree/galaxy.yml"
           while IFS= read -r fragment; do
             name="$(jq -er '.path' <<< "$fragment")"
             expected_digest="$(jq -er '.sha256' <<< "$fragment")"
-            git show \
-              "$REVIEWED_BASE_SHA:changelogs/fragments/$name" \
-              > "$base_tree/fragments/$name"
-            test "$(sha256sum "$base_tree/fragments/$name" | awk '{print $1}')" = \
+            fragment_path="$base_tree/changelogs/fragments/$name"
+            test -f "$fragment_path"
+            test ! -L "$fragment_path"
+            test "$(sha256sum "$fragment_path" | awk '{print $1}')" = \
               "$expected_digest"
             if git cat-file -e \
                 "$REVIEWED_HEAD_SHA:changelogs/fragments/$name" 2>/dev/null
@@ -450,7 +452,7 @@ jobs:
           recomputed="$(
             python scripts/release-version.py \
               --galaxy "$base_tree/galaxy.yml" \
-              --fragments "$base_tree/fragments" \
+              --fragments "$base_tree/changelogs/fragments" \
               --requested-version "$expected_version"
           )"
           jq -e --argjson recomputed "$recomputed" '

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -425,7 +425,7 @@ jobs:
           test ! -e "$base_tree"
           git worktree add --detach --quiet "$base_tree" "$REVIEWED_BASE_SHA"
           test "$(git -C "$base_tree" rev-parse HEAD)" = "$REVIEWED_BASE_SHA"
-          python scripts/release-version.py \
+          python "$base_tree/scripts/release-version.py" \
             --verify-preparation-receipt "$receipt" \
             --repository "$GITHUB_REPOSITORY" \
             --repository-id "$REPOSITORY_ID" \
@@ -450,7 +450,7 @@ jobs:
           done < <(jq -c '.fragments[]' "$receipt")
 
           recomputed="$(
-            python scripts/release-version.py \
+            python "$base_tree/scripts/release-version.py" \
               --galaxy "$base_tree/galaxy.yml" \
               --fragments "$base_tree/changelogs/fragments" \
               --requested-version "$expected_version"

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,5 +1,4 @@
-# Managed by lightning-it/shared-assets-lit.
-# Do not edit downstream copies directly.
+# Repository-owned MLX-90 golden-path incubation asset; canonicalize after real humanActions=0 acceptance.
 # yamllint disable rule:truthy rule:line-length
 ---
 name: Copilot review gate

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -274,6 +274,19 @@ jobs:
           git merge-base --is-ancestor "origin/main" "${HEAD_SHA}"
           echo "Verified current protected develop head and main ancestry."
 
+      - name: Setup Python for trusted release receipt verification
+        if: steps.trusted-automation.outputs.kind == 'release-preparation'
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: "3.14"
+          cache: pip
+
+      - name: Install exact trusted release receipt dependency
+        if: steps.trusted-automation.outputs.kind == 'release-preparation'
+        run: >-
+          python -m pip install --disable-pip-version-check
+          PyYAML==6.0.3
+
       - name: Verify release preparation commit and bounded files
         if: steps.trusted-automation.outputs.kind == 'release-preparation'
         env:
@@ -281,6 +294,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           RELEASE_TAG: ${{ steps.trusted-automation.outputs.release_tag }}
+          REPOSITORY_ID: ${{ github.repository_id }}
         run: |
           set -euo pipefail
           gh auth setup-git
@@ -308,19 +322,21 @@ jobs:
           }
           version="${RELEASE_TAG#v}"
           [ "$(git show "${HEAD_SHA}:galaxy.yml" | awk '$1 == "version:" {print $2; exit}')" = "${version}" ]
-          preparation="$(git show "${HEAD_SHA}:changelogs/release-preparation.json")"
-          jq -e \
-            --arg base "${BASE_SHA}" \
-            --arg repository "${GITHUB_REPOSITORY}" \
-            --arg version "${version}" \
-            '.schema_version == 1
-             and .base_sha == $base
-             and .next_version == $version
-             and .repository == $repository
-             and .preparer.login == "lightning-it-release-automation[bot]"
-             and .workflow.source_sha == $base' \
-            <<<"${preparation}" >/dev/null
-          echo "Verified single-parent release preparation and bounded generated files."
+          receipt="$RUNNER_TEMP/release-preparation-receipt.json"
+          base_tree="$RUNNER_TEMP/release-preparation-base"
+          test ! -e "$receipt"
+          test ! -e "$base_tree"
+          git show "${HEAD_SHA}:changelogs/release-preparation.json" > "$receipt"
+          git worktree add --detach --quiet "$base_tree" "$BASE_SHA"
+          test "$(git -C "$base_tree" rev-parse HEAD)" = "$BASE_SHA"
+          python "$base_tree/scripts/release-version.py" \
+            --verify-preparation-receipt "$receipt" \
+            --repository "$GITHUB_REPOSITORY" \
+            --repository-id "$REPOSITORY_ID" \
+            --base-sha "$BASE_SHA" \
+            --expected-version "$version" \
+            --root "$base_tree" >/dev/null
+          echo "Verified schema-v2 preparation against the immutable base tree and bounded generated files."
 
       - name: Verify release back-sync merge and bounded files
         if: steps.trusted-automation.outputs.kind == 'release-backsync'

--- a/.github/workflows/security-release-dispatch.yml
+++ b/.github/workflows/security-release-dispatch.yml
@@ -1,4 +1,4 @@
-# Managed by lightning-it/shared-assets-lit. MLX-90 Security-only dispatch.
+# Repository-owned MLX-90 golden-path incubation asset; canonicalize after real humanActions=0 acceptance.
 # yamllint disable rule:truthy
 ---
 name: Security release dispatch

--- a/.github/workflows/security-release-dispatch.yml
+++ b/.github/workflows/security-release-dispatch.yml
@@ -81,6 +81,11 @@ jobs:
         run: |
           set -euo pipefail
 
+          authenticated_fetch() {
+            git -c credential.helper= \
+              -c 'credential.helper=!gh auth git-credential' fetch "$@"
+          }
+
           [[ "$SOURCE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
           [[ "$CONTROLLER_SHA" =~ ^[0-9a-f]{40}$ ]]
           source_run="$RUNNER_TEMP/security-source-run.json"
@@ -103,7 +108,7 @@ jobs:
           SOURCE_SHA="$(jq -er .head_sha "$source_run")"
           [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
           test "$(git rev-parse HEAD)" = "$CONTROLLER_SHA"
-          git fetch --no-tags origin main develop
+          authenticated_fetch --no-tags origin main develop
           test "$(git rev-parse origin/main)" = "$CONTROLLER_SHA"
           test "$(git rev-parse origin/develop)" = "$SOURCE_SHA"
 
@@ -144,14 +149,20 @@ jobs:
         id: request
         env:
           CONTROLLER_SHA: ${{ github.sha }}
+          RUN_TOKEN: ${{ github.token }}
           SOURCE_SHA: ${{ needs.classify.outputs['source-sha'] }}
         run: |
           set -euo pipefail
 
+          authenticated_fetch() {
+            GH_TOKEN="$RUN_TOKEN" git -c credential.helper= \
+              -c 'credential.helper=!gh auth git-credential' fetch "$@"
+          }
+
           [[ "$CONTROLLER_SHA" =~ ^[0-9a-f]{40}$ ]]
           [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
           test "$(git rev-parse HEAD)" = "$CONTROLLER_SHA"
-          git fetch --no-tags origin main develop
+          authenticated_fetch --no-tags origin main develop
           test "$(git rev-parse origin/main)" = "$CONTROLLER_SHA"
           test "$(git rev-parse origin/develop)" = "$SOURCE_SHA"
           result="$RUNNER_TEMP/security-dispatch-envelope.json"
@@ -165,6 +176,58 @@ jobs:
           jq -e '.dispatch == true and (.request.humanActions == 0)' "$result" >/dev/null
           echo "envelope=$result" >>"$GITHUB_OUTPUT"
 
+      - name: Mint installation-wide metadata-only App attestation token
+        id: release-app-metadata
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-metadata: read
+
+      - name: Verify exact App installation and repository scope
+        env:
+          APP_INSTALLATION_ID: ${{ steps.release-app-metadata.outputs.installation-id }}
+          APP_SLUG: ${{ steps.release-app-metadata.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.release-app-metadata.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          test "$APP_SLUG" = lightning-it-release-automation
+          test "$APP_INSTALLATION_ID" = 148019054
+          bot="$RUNNER_TEMP/security-dispatch-app-bot.json"
+          gh api "users/${APP_SLUG}%5Bbot%5D" >"$bot"
+          jq -e '
+            .login == "lightning-it-release-automation[bot]"
+            and .id == 307565056
+            and .type == "Bot"
+          ' "$bot" >/dev/null
+          app="$RUNNER_TEMP/security-dispatch-app.json"
+          gh api "apps/${APP_SLUG}" >"$app"
+          jq -e '
+            .slug == "lightning-it-release-automation"
+            and .owner.login == "lightning-it"
+            and .permissions == {
+              "actions": "write",
+              "checks": "read",
+              "contents": "write",
+              "metadata": "read",
+              "pull_requests": "write"
+            }
+          ' "$app" >/dev/null
+          repositories="$RUNNER_TEMP/security-dispatch-installation-repositories.json"
+          gh api --paginate --slurp \
+            'installation/repositories?per_page=100' >"$repositories"
+          jq -e '
+            [.[].repositories[].full_name] | sort == [
+              "lightning-it/ansible-collection-supplementary",
+              "lightning-it/container-ee-wunder-ansible-ubi9",
+              "lightning-it/github-management-lit",
+              "lightning-it/modulix-validation",
+              "lightning-it/shared-assets-lit"
+            ]
+          ' "$repositories" >/dev/null
+
       - name: Mint repository-scoped release automation App token
         id: release-app
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
@@ -173,35 +236,55 @@ jobs:
           private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
-          permission-contents: write
+          permission-actions: write
 
-      - name: Verify exact App installation and repository scope
+      - name: Revalidate and dispatch exact request to immutable main intake
         env:
           APP_INSTALLATION_ID: ${{ steps.release-app.outputs.installation-id }}
           APP_SLUG: ${{ steps.release-app.outputs.app-slug }}
+          CONTROLLER_SHA: ${{ github.sha }}
+          EXPECTED_ENVELOPE: ${{ steps.request.outputs.envelope }}
           GH_TOKEN: ${{ steps.release-app.outputs.token }}
+          READ_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ needs.classify.outputs['source-sha'] }}
         run: |
           set -euo pipefail
 
           test "$APP_SLUG" = lightning-it-release-automation
           test "$APP_INSTALLATION_ID" = 148019054
-          test "$(gh api "users/${APP_SLUG}%5Bbot%5D" --jq .login)" = \
-            'lightning-it-release-automation[bot]'
-          repositories="$(gh api --paginate 'installation/repositories?per_page=100')"
-          jq -se --arg repository "$GITHUB_REPOSITORY" \
-            '[.[].repositories[].full_name] | sort | unique == [$repository]' \
-            <<<"$repositories" >/dev/null
 
-      - name: Dispatch exact humanActions=0 Security intake
-        env:
-          ENVELOPE: ${{ steps.request.outputs.envelope }}
-          GH_TOKEN: ${{ steps.release-app.outputs.token }}
-        run: |
-          set -euo pipefail
+          authenticated_fetch() {
+            GH_TOKEN="$READ_TOKEN" git -c credential.helper= \
+              -c 'credential.helper=!gh auth git-credential' fetch "$@"
+          }
 
-          payload="$RUNNER_TEMP/security-repository-dispatch.json"
-          jq -ce '{event_type:"mlx90-security-release",client_payload:.request}' \
-            "$ENVELOPE" >"$payload"
-          jq -e '.client_payload.humanActions == 0' "$payload" >/dev/null
-          gh api --method POST "repos/${GITHUB_REPOSITORY}/dispatches" \
+          [[ "$CONTROLLER_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          authenticated_fetch --no-tags origin main develop
+          test "$(git rev-parse HEAD)" = "$CONTROLLER_SHA"
+          test "$(git rev-parse origin/main)" = "$CONTROLLER_SHA"
+          test "$(git rev-parse origin/develop)" = "$SOURCE_SHA"
+
+          fresh_envelope="$RUNNER_TEMP/security-dispatch-envelope-final.json"
+          request="$RUNNER_TEMP/security-intake-request.json"
+          umask 077
+          python3 scripts/security-release-dispatch.py \
+            --repository "$GITHUB_REPOSITORY" \
+            --base-sha "$CONTROLLER_SHA" \
+            --head-sha "$SOURCE_SHA" \
+            --root . \
+            --output-json "$fresh_envelope" \
+            --output-request-json "$request" >/dev/null
+          cmp "$EXPECTED_ENVELOPE" "$fresh_envelope"
+          jq -e '.dispatch == true and (.request.humanActions == 0)' \
+            "$fresh_envelope" >/dev/null
+
+          request_json="$(<"$request")"
+          payload="$RUNNER_TEMP/security-workflow-dispatch.json"
+          jq -n --arg request_json "$request_json" \
+            '{ref:"main",inputs:{request_json:$request_json}}' >"$payload"
+          test "$(jq -er .ref "$payload")" = main
+          test "$(jq -er '.inputs.request_json' "$payload")" = "$request_json"
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/security-release-intake.yml/dispatches" \
             --input "$payload"

--- a/.github/workflows/security-release-intake.yml
+++ b/.github/workflows/security-release-intake.yml
@@ -1,4 +1,4 @@
-# Managed by lightning-it/shared-assets-lit. MLX-90 Security-only intake.
+# Repository-owned MLX-90 golden-path incubation asset; canonicalize after real humanActions=0 acceptance.
 # yamllint disable rule:truthy
 ---
 name: Security release intake

--- a/.github/workflows/security-release-intake.yml
+++ b/.github/workflows/security-release-intake.yml
@@ -4,8 +4,12 @@
 name: Security release intake
 
 on:
-  repository_dispatch:
-    types: [mlx90-security-release]
+  workflow_dispatch:
+    inputs:
+      request_json:
+        description: Canonical compact MLX-90 Security intake request v2
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -16,12 +20,17 @@ concurrency:
 
 jobs:
   classify:
-    name: Validate confirmed Security evidence before environment access
+    name: Validate App-dispatched Security evidence before environment access
     if: >-
+      github.event_name == 'workflow_dispatch' &&
       github.ref == 'refs/heads/main' &&
-      github.actor == 'lightning-it-release-automation[bot]'
+      github.actor == 'lightning-it-release-automation[bot]' &&
+      github.triggering_actor == 'lightning-it-release-automation[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
     outputs:
       base-sha: ${{ steps.request.outputs.base_sha }}
       candidate-head-sha: ${{ steps.request.outputs.candidate_head_sha }}
@@ -35,22 +44,69 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Validate exact evidence-bound source range
+      - name: Validate canonical request and exact App-authored controller run
         id: request
         env:
-          EVENT_PATH: ${{ github.event_path }}
+          CONTROLLER_SHA: ${{ github.sha }}
+          REQUEST_JSON: ${{ inputs.request_json }}
+          RUN_TOKEN: ${{ github.token }}
+          WORKFLOW_ACTOR: ${{ github.actor }}
+          WORKFLOW_ATTEMPT: ${{ github.run_attempt }}
+          WORKFLOW_EVENT: ${{ github.event_name }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          WORKFLOW_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
           set -euo pipefail
 
-          test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
-          git fetch --no-tags origin main develop
-          test "$(git rev-parse origin/main)" = "$GITHUB_SHA"
+          authenticated_fetch() {
+            GH_TOKEN="$RUN_TOKEN" git -c credential.helper= \
+              -c 'credential.helper=!gh auth git-credential' fetch "$@"
+          }
+
+          [[ "$CONTROLLER_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$WORKFLOW_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$WORKFLOW_ATTEMPT" =~ ^[1-9][0-9]*$ ]]
+          test "$WORKFLOW_EVENT" = workflow_dispatch
+          test "$WORKFLOW_ACTOR" = 'lightning-it-release-automation[bot]'
+          test "$WORKFLOW_TRIGGERING_ACTOR" = \
+            'lightning-it-release-automation[bot]'
+          test "$WORKFLOW_REF" = \
+            "${GITHUB_REPOSITORY}/.github/workflows/security-release-intake.yml@refs/heads/main"
+          test "$(git rev-parse HEAD)" = "$CONTROLLER_SHA"
+          authenticated_fetch --no-tags origin main develop
+          test "$(git rev-parse origin/main)" = "$CONTROLLER_SHA"
+
+          current_run="$RUNNER_TEMP/security-intake-controller-run.json"
+          GH_TOKEN="$RUN_TOKEN" gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}" \
+            >"$current_run"
+          jq -e \
+            --arg actor "$WORKFLOW_ACTOR" \
+            --arg attempt "$WORKFLOW_ATTEMPT" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg run_id "$WORKFLOW_RUN_ID" \
+            --arg sha "$CONTROLLER_SHA" '
+              (.id | tostring) == $run_id
+              and (.run_attempt | tostring) == $attempt
+              and .name == "Security release intake"
+              and .path == ".github/workflows/security-release-intake.yml"
+              and .event == "workflow_dispatch"
+              and .head_branch == "main"
+              and .head_sha == $sha
+              and .repository.full_name == $repository
+              and .head_repository.full_name == $repository
+              and .actor.login == $actor
+              and .triggering_actor.login == $actor
+              and .status == "in_progress"
+              and .conclusion == null
+            ' "$current_run" >/dev/null
 
           request="$RUNNER_TEMP/security-intake-request.json"
           patch="$RUNNER_TEMP/security-intake.patch"
           result="$RUNNER_TEMP/security-intake-result.json"
           umask 077
-          jq -ce '.client_payload' "$EVENT_PATH" >"$request"
+          printf '%s\n' "$REQUEST_JSON" >"$request"
           python3 scripts/security-release-intake.py \
             --request "$request" \
             --repository "$GITHUB_REPOSITORY" \
@@ -59,7 +115,10 @@ jobs:
             --output-json "$result" >/dev/null
 
           test -s "$patch"
-          jq -e '.humanActions == 0' "$result" >/dev/null
+          test "$(jq -er '.baseSha' "$result")" = "$CONTROLLER_SHA"
+          test "$(git rev-parse origin/develop)" = \
+            "$(jq -er '.candidateHeadSha' "$result")"
+          jq -e '.schemaVersion == 2 and .humanActions == 0' "$result" >/dev/null
           {
             echo "base_sha=$(jq -er '.baseSha' "$result")"
             echo "candidate_head_sha=$(jq -er '.candidateHeadSha' "$result")"
@@ -72,11 +131,15 @@ jobs:
     needs: classify
     if: >-
       needs.classify.result == 'success' &&
-      github.actor == 'lightning-it-release-automation[bot]'
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.actor == 'lightning-it-release-automation[bot]' &&
+      github.triggering_actor == 'lightning-it-release-automation[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment: mlx90-security-release-evidence
     permissions:
+      actions: read
       contents: read
       pull-requests: read
     steps:
@@ -87,26 +150,59 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Revalidate live source and reconstruct exact approved patch
+      - name: Revalidate live request and run before App token access
         id: request
         env:
-          EVENT_PATH: ${{ github.event_path }}
           EXPECTED_BASE_SHA: ${{ needs.classify.outputs.base-sha }}
           EXPECTED_CANDIDATE_HEAD_SHA: ${{ needs.classify.outputs.candidate-head-sha }}
           EXPECTED_EVIDENCE_ID: ${{ needs.classify.outputs.evidence-id }}
           EXPECTED_FIXED_VERSION: ${{ needs.classify.outputs.fixed-version }}
+          REQUEST_JSON: ${{ inputs.request_json }}
+          RUN_TOKEN: ${{ github.token }}
+          WORKFLOW_ATTEMPT: ${{ github.run_attempt }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
 
-          git fetch --no-tags origin main develop
+          authenticated_fetch() {
+            GH_TOKEN="$RUN_TOKEN" git -c credential.helper= \
+              -c 'credential.helper=!gh auth git-credential' fetch "$@"
+          }
+
+          authenticated_fetch --no-tags origin main develop
           test "$(git rev-parse HEAD)" = "$EXPECTED_BASE_SHA"
           test "$(git rev-parse origin/main)" = "$EXPECTED_BASE_SHA"
+          test "$(git rev-parse origin/develop)" = "$EXPECTED_CANDIDATE_HEAD_SHA"
 
-          request="$RUNNER_TEMP/security-intake-request.json"
-          patch="$RUNNER_TEMP/security-intake.patch"
-          result="$RUNNER_TEMP/security-intake-result.json"
+          current_run="$RUNNER_TEMP/security-intake-controller-run-pre-token.json"
+          GH_TOKEN="$RUN_TOKEN" gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}" \
+            >"$current_run"
+          jq -e \
+            --arg actor 'lightning-it-release-automation[bot]' \
+            --arg attempt "$WORKFLOW_ATTEMPT" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg run_id "$WORKFLOW_RUN_ID" \
+            --arg sha "$EXPECTED_BASE_SHA" '
+              (.id | tostring) == $run_id
+              and (.run_attempt | tostring) == $attempt
+              and .path == ".github/workflows/security-release-intake.yml"
+              and .event == "workflow_dispatch"
+              and .head_branch == "main"
+              and .head_sha == $sha
+              and .repository.full_name == $repository
+              and .head_repository.full_name == $repository
+              and .actor.login == $actor
+              and .triggering_actor.login == $actor
+              and .status == "in_progress"
+              and .conclusion == null
+            ' "$current_run" >/dev/null
+
+          request="$RUNNER_TEMP/security-intake-request-pre-token.json"
+          patch="$RUNNER_TEMP/security-intake-pre-token.patch"
+          result="$RUNNER_TEMP/security-intake-result-pre-token.json"
           umask 077
-          jq -ce '.client_payload' "$EVENT_PATH" >"$request"
+          printf '%s\n' "$REQUEST_JSON" >"$request"
           python3 scripts/security-release-intake.py \
             --request "$request" \
             --repository "$GITHUB_REPOSITORY" \
@@ -115,18 +211,81 @@ jobs:
             --output-json "$result" >/dev/null
 
           test "$(jq -er '.baseSha' "$result")" = "$EXPECTED_BASE_SHA"
-          test "$(jq -er '.candidateHeadSha' "$result")" = "$EXPECTED_CANDIDATE_HEAD_SHA"
+          test "$(jq -er '.candidateHeadSha' "$result")" = \
+            "$EXPECTED_CANDIDATE_HEAD_SHA"
           test "$(jq -er '.evidenceId' "$result")" = "$EXPECTED_EVIDENCE_ID"
           test "$(jq -er '.fixedVersion' "$result")" = "$EXPECTED_FIXED_VERSION"
           {
             echo "request=$request"
             echo "patch=$patch"
             echo "result=$result"
-            echo "branch=$(jq -er '.branch' "$result")"
-            echo "candidate_diff_sha256=$(jq -er '.candidateDiffSha256' "$result")"
           } >>"$GITHUB_OUTPUT"
 
-      - name: Mint least-privilege release automation App token
+      - name: Mint installation-wide metadata-only App attestation token
+        id: release-app-metadata
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_AUTOMATION_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-metadata: read
+
+      - name: Verify exact App installation identity and complete allowlist
+        id: release-bot
+        env:
+          APP_INSTALLATION_ID: ${{ steps.release-app-metadata.outputs.installation-id }}
+          APP_SLUG: ${{ steps.release-app-metadata.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.release-app-metadata.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          test "$APP_SLUG" = lightning-it-release-automation
+          test "$APP_INSTALLATION_ID" = 148019054
+          bot="$RUNNER_TEMP/security-intake-app-bot.json"
+          gh api "users/${APP_SLUG}%5Bbot%5D" >"$bot"
+          jq -e '
+            .login == "lightning-it-release-automation[bot]"
+            and .id == 307565056
+            and .type == "Bot"
+          ' "$bot" >/dev/null
+          app="$RUNNER_TEMP/security-intake-app.json"
+          permissions="$RUNNER_TEMP/security-intake-app-permissions.json"
+          gh api "apps/${APP_SLUG}" >"$app"
+          jq -e '
+            .slug == "lightning-it-release-automation"
+            and .owner.login == "lightning-it"
+            and .permissions == {
+              "actions": "write",
+              "checks": "read",
+              "contents": "write",
+              "metadata": "read",
+              "pull_requests": "write"
+            }
+          ' "$app" >/dev/null
+          jq -ceS '.permissions' "$app" >"$permissions"
+          repositories="$RUNNER_TEMP/security-intake-installation-repositories.json"
+          gh api --paginate --slurp \
+            'installation/repositories?per_page=100' >"$repositories"
+          jq -e '
+            [.[].repositories[].full_name] | sort == [
+              "lightning-it/ansible-collection-supplementary",
+              "lightning-it/container-ee-wunder-ansible-ubi9",
+              "lightning-it/github-management-lit",
+              "lightning-it/modulix-validation",
+              "lightning-it/shared-assets-lit"
+            ]
+          ' "$repositories" >/dev/null
+          {
+            echo "slug=$APP_SLUG"
+            echo "installation_id=$APP_INSTALLATION_ID"
+            echo "login=$(jq -er .login "$bot")"
+            echo "account_id=$(jq -er '.id | tostring' "$bot")"
+            echo "email=307565056+lightning-it-release-automation[bot]@users.noreply.github.com"
+            echo "permissions=$permissions"
+            echo "repositories=$repositories"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Mint repository-scoped release automation App token
         id: release-app
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         with:
@@ -137,95 +296,240 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - name: Resolve exact App bot identity
-        id: release-bot
+      - name: Revalidate exact request and mint canonical v2 receipt before mutation
+        id: final
         env:
-          APP_SLUG: ${{ steps.release-app.outputs.app-slug }}
-          GH_TOKEN: ${{ github.token }}
+          APP_ACCOUNT_ID: ${{ steps.release-bot.outputs.account_id }}
+          APP_INSTALLATION_ID: ${{ steps.release-bot.outputs.installation_id }}
+          APP_LOGIN: ${{ steps.release-bot.outputs.login }}
+          APP_PERMISSIONS: ${{ steps.release-bot.outputs.permissions }}
+          APP_REPOSITORIES: ${{ steps.release-bot.outputs.repositories }}
+          APP_SLUG: ${{ steps.release-bot.outputs.slug }}
+          MUTATION_APP_INSTALLATION_ID: ${{ steps.release-app.outputs.installation-id }}
+          MUTATION_APP_SLUG: ${{ steps.release-app.outputs.app-slug }}
+          EXPECTED_BASE_SHA: ${{ needs.classify.outputs.base-sha }}
+          EXPECTED_CANDIDATE_HEAD_SHA: ${{ needs.classify.outputs.candidate-head-sha }}
+          EXPECTED_EVIDENCE_ID: ${{ needs.classify.outputs.evidence-id }}
+          EXPECTED_FIXED_VERSION: ${{ needs.classify.outputs.fixed-version }}
+          EXPECTED_PATCH: ${{ steps.request.outputs.patch }}
+          EXPECTED_REQUEST: ${{ steps.request.outputs.request }}
+          EXPECTED_RESULT: ${{ steps.request.outputs.result }}
+          REQUEST_JSON: ${{ inputs.request_json }}
+          RUN_TOKEN: ${{ github.token }}
+          WORKFLOW_ACTOR: ${{ github.actor }}
+          WORKFLOW_ATTEMPT: ${{ github.run_attempt }}
+          WORKFLOW_EVENT: ${{ github.event_name }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          WORKFLOW_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
           set -euo pipefail
-          test "$APP_SLUG" = lightning-it-release-automation
-          bot_json="$(gh api "users/${APP_SLUG}%5Bbot%5D")"
-          login="$(jq -er '.login' <<<"$bot_json")"
-          bot_id="$(jq -er '.id' <<<"$bot_json")"
-          test "$login" = 'lightning-it-release-automation[bot]'
-          [[ "$bot_id" =~ ^[1-9][0-9]*$ ]]
-          echo "login=$login" >>"$GITHUB_OUTPUT"
-          echo "email=${bot_id}+${login}@users.noreply.github.com" >>"$GITHUB_OUTPUT"
 
-      - name: Create or prove deterministic isolated branch
+          test "$MUTATION_APP_SLUG" = "$APP_SLUG"
+          test "$MUTATION_APP_INSTALLATION_ID" = "$APP_INSTALLATION_ID"
+
+          authenticated_fetch() {
+            GH_TOKEN="$RUN_TOKEN" git -c credential.helper= \
+              -c 'credential.helper=!gh auth git-credential' fetch "$@"
+          }
+
+          authenticated_fetch --no-tags origin main develop
+          test "$(git rev-parse HEAD)" = "$EXPECTED_BASE_SHA"
+          test "$(git rev-parse origin/main)" = "$EXPECTED_BASE_SHA"
+          test "$(git rev-parse origin/develop)" = "$EXPECTED_CANDIDATE_HEAD_SHA"
+
+          current_run="$RUNNER_TEMP/security-intake-controller-run-final.json"
+          GH_TOKEN="$RUN_TOKEN" gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}" \
+            >"$current_run"
+          jq -e \
+            --arg actor "$WORKFLOW_ACTOR" \
+            --arg attempt "$WORKFLOW_ATTEMPT" \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg run_id "$WORKFLOW_RUN_ID" \
+            --arg sha "$EXPECTED_BASE_SHA" '
+              (.id | tostring) == $run_id
+              and (.run_attempt | tostring) == $attempt
+              and .path == ".github/workflows/security-release-intake.yml"
+              and .event == "workflow_dispatch"
+              and .head_branch == "main"
+              and .head_sha == $sha
+              and .repository.full_name == $repository
+              and .head_repository.full_name == $repository
+              and .actor.login == $actor
+              and .triggering_actor.login == $actor
+              and .status == "in_progress"
+              and .conclusion == null
+            ' "$current_run" >/dev/null
+
+          request="$RUNNER_TEMP/security-intake-request-final.json"
+          patch="$RUNNER_TEMP/security-intake-final.patch"
+          result="$RUNNER_TEMP/security-intake-result-final.json"
+          receipt="$RUNNER_TEMP/security-intake-receipt-v2.json"
+          umask 077
+          printf '%s\n' "$REQUEST_JSON" >"$request"
+          mapfile -t observed_repositories < <(
+            jq -r '[.[].repositories[].full_name] | sort | .[]' \
+              "$APP_REPOSITORIES"
+          )
+          test "${#observed_repositories[@]}" -eq 5
+          repository_arguments=()
+          for observed_repository in "${observed_repositories[@]}"; do
+            repository_arguments+=(
+              --observed-app-repository "$observed_repository"
+            )
+          done
+          python3 scripts/security-release-intake.py \
+            --request "$request" \
+            --repository "$GITHUB_REPOSITORY" \
+            --root . \
+            --output-patch "$patch" \
+            --output-json "$result" \
+            --output-intake-receipt "$receipt" \
+            --workflow-run-id "$WORKFLOW_RUN_ID" \
+            --workflow-attempt "$WORKFLOW_ATTEMPT" \
+            --workflow-ref "$WORKFLOW_REF" \
+            --workflow-event "$WORKFLOW_EVENT" \
+            --workflow-actor "$WORKFLOW_ACTOR" \
+            --workflow-triggering-actor "$WORKFLOW_TRIGGERING_ACTOR" \
+            --observed-app-slug "$APP_SLUG" \
+            --observed-app-installation-id "$APP_INSTALLATION_ID" \
+            --observed-app-login "$APP_LOGIN" \
+            --observed-app-account-id "$APP_ACCOUNT_ID" \
+            --observed-app-permissions "$APP_PERMISSIONS" \
+            "${repository_arguments[@]}" >/dev/null
+
+          cmp "$EXPECTED_REQUEST" "$request"
+          cmp "$EXPECTED_PATCH" "$patch"
+          cmp "$EXPECTED_RESULT" "$result"
+          jq -e '
+            .schemaVersion == 2
+            and .request.schemaVersion == 2
+            and .verified.schemaVersion == 2
+            and .request.humanActions == 0
+            and .verified.humanActions == 0
+            and .automation.slug == "lightning-it-release-automation"
+            and .automation.installationId == "148019054"
+            and .automation.login == "lightning-it-release-automation[bot]"
+            and .automation.accountId == "307565056"
+            and .automation.permissions == {
+              "actions": "write",
+              "checks": "read",
+              "contents": "write",
+              "metadata": "read",
+              "pull_requests": "write"
+            }
+            and .automation.selectedRepositories == [
+              "lightning-it/ansible-collection-supplementary",
+              "lightning-it/container-ee-wunder-ansible-ubi9",
+              "lightning-it/github-management-lit",
+              "lightning-it/modulix-validation",
+              "lightning-it/shared-assets-lit"
+            ]
+            and .controller.event == "workflow_dispatch"
+            and .controller.actor == "lightning-it-release-automation[bot]"
+            and .controller.triggeringActor == "lightning-it-release-automation[bot]"
+          ' "$receipt" >/dev/null
+          {
+            echo "request=$request"
+            echo "patch=$patch"
+            echo "result=$result"
+            echo "receipt=$receipt"
+            echo "branch=$(jq -er '.branch' "$result")"
+            echo "candidate_diff_sha256=$(jq -er '.candidateDiffSha256' "$result")"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Create or prove exact App-authored isolated commit
         id: branch
         env:
           APP_TOKEN: ${{ steps.release-app.outputs.token }}
           BASE_SHA: ${{ needs.classify.outputs.base-sha }}
           BOT_EMAIL: ${{ steps.release-bot.outputs.email }}
           BOT_LOGIN: ${{ steps.release-bot.outputs.login }}
-          BRANCH: ${{ steps.request.outputs.branch }}
+          BRANCH: ${{ steps.final.outputs.branch }}
+          CANDIDATE_HEAD_SHA: ${{ needs.classify.outputs.candidate-head-sha }}
           EVIDENCE_ID: ${{ needs.classify.outputs.evidence-id }}
           FIXED_VERSION: ${{ needs.classify.outputs.fixed-version }}
-          PATCH_FILE: ${{ steps.request.outputs.patch }}
-          REQUEST_FILE: ${{ steps.request.outputs.request }}
-          RESULT_FILE: ${{ steps.request.outputs.result }}
+          PATCH_FILE: ${{ steps.final.outputs.patch }}
+          RECEIPT_FILE: ${{ steps.final.outputs.receipt }}
         run: |
           set -euo pipefail
 
-          authenticated_push() {
+          authenticated_git() {
             GH_TOKEN="$APP_TOKEN" git -c credential.helper= \
-              -c 'credential.helper=!gh auth git-credential' push "$@"
+              -c 'credential.helper=!gh auth git-credential' "$@"
           }
 
           [[ "$BRANCH" == security-release/MLX90-* ]]
+          authenticated_git fetch --no-tags origin main develop
           test "$(git rev-parse origin/main)" = "$BASE_SHA"
+          test "$(git rev-parse origin/develop)" = "$CANDIDATE_HEAD_SHA"
           git switch --detach "$BASE_SHA"
           git switch -c "$BRANCH"
           git apply --binary --index "$PATCH_FILE"
 
           receipt=".lit/security-release-intakes/${FIXED_VERSION}.json"
           test ! -e "$receipt"
+          test ! -L "$receipt"
           mkdir -p "$(dirname "$receipt")"
-          jq -S -n \
-            --slurpfile request "$REQUEST_FILE" \
-            --slurpfile verified "$RESULT_FILE" \
-            '{schemaVersion:1,request:$request[0],verified:$verified[0]}' \
-            >"$receipt"
-          git add "$receipt"
+          cp "$RECEIPT_FILE" "$receipt"
+          chmod 0600 "$receipt"
+          cmp "$RECEIPT_FILE" "$receipt"
+          git add -- "$receipt"
+          git diff --cached --check
 
           git config user.name "$BOT_LOGIN"
           git config user.email "$BOT_EMAIL"
           tree_sha="$(git write-tree)"
-          remote_sha="$(git ls-remote --heads origin "refs/heads/${BRANCH}" | awk 'NR == 1 {print $1}')"
+          remote_sha="$(authenticated_git ls-remote --heads origin \
+            "refs/heads/${BRANCH}" | awk 'NR == 1 {print $1}')"
           if [ -n "$remote_sha" ]; then
             [[ "$remote_sha" =~ ^[0-9a-f]{40}$ ]]
-            git fetch --no-tags origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
-            test "$(git show -s --format=%T "$remote_sha")" = "$tree_sha"
-            test "$(git show -s --format=%P "$remote_sha")" = "$BASE_SHA"
-            test "$(git show -s --format='%an <%ae>' "$remote_sha")" = \
-              "$BOT_LOGIN <$BOT_EMAIL>"
-            test "$(git show -s --format='%cn <%ce>' "$remote_sha")" = \
-              "$BOT_LOGIN <$BOT_EMAIL>"
+            authenticated_git fetch --no-tags origin \
+              "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
             head_sha="$remote_sha"
           else
             git commit -m "fix(security): ${EVIDENCE_ID}"
             head_sha="$(git rev-parse HEAD)"
-            test "$(git show -s --format=%P HEAD)" = "$BASE_SHA"
-            authenticated_push origin "HEAD:refs/heads/${BRANCH}"
+            authenticated_git fetch --no-tags origin main develop
+            test "$(git rev-parse origin/main)" = "$BASE_SHA"
+            test "$(git rev-parse origin/develop)" = "$CANDIDATE_HEAD_SHA"
+            authenticated_git push origin "HEAD:refs/heads/${BRANCH}"
           fi
-          test "$(git ls-remote --heads origin "refs/heads/${BRANCH}" | awk 'NR == 1 {print $1}')" = "$head_sha"
+
+          test "$(git show -s --format=%T "$head_sha")" = "$tree_sha"
+          test "$(git show -s --format=%P "$head_sha")" = "$BASE_SHA"
+          test "$(git show -s --format='%an <%ae>' "$head_sha")" = \
+            "$BOT_LOGIN <$BOT_EMAIL>"
+          test "$(git show -s --format='%cn <%ce>' "$head_sha")" = \
+            "$BOT_LOGIN <$BOT_EMAIL>"
+          test "$(authenticated_git ls-remote --heads origin \
+            "refs/heads/${BRANCH}" | awk 'NR == 1 {print $1}')" = "$head_sha"
           echo "head_sha=$head_sha" >>"$GITHUB_OUTPUT"
 
       - name: Create or prove exact App-authored Security PR
         id: pull
         env:
+          APP_TOKEN: ${{ steps.release-app.outputs.token }}
           BASE_SHA: ${{ needs.classify.outputs.base-sha }}
-          GH_TOKEN: ${{ steps.release-app.outputs.token }}
-          BRANCH: ${{ steps.request.outputs.branch }}
+          BRANCH: ${{ steps.final.outputs.branch }}
           HEAD_SHA: ${{ steps.branch.outputs.head_sha }}
           EVIDENCE_ID: ${{ needs.classify.outputs.evidence-id }}
           FIXED_VERSION: ${{ needs.classify.outputs.fixed-version }}
-          DIFF_SHA256: ${{ steps.request.outputs.candidate_diff_sha256 }}
+          DIFF_SHA256: ${{ steps.final.outputs.candidate_diff_sha256 }}
+          GH_TOKEN: ${{ steps.release-app.outputs.token }}
         run: |
           set -euo pipefail
 
+          authenticated_git() {
+            GH_TOKEN="$APP_TOKEN" git -c credential.helper= \
+              -c 'credential.helper=!gh auth git-credential' "$@"
+          }
+
+          authenticated_git fetch --no-tags origin main \
+            "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"
+          test "$(git rev-parse origin/main)" = "$BASE_SHA"
+          test "$(git rev-parse "refs/remotes/origin/${BRANCH}")" = "$HEAD_SHA"
           pulls="$(gh api --method GET "repos/${GITHUB_REPOSITORY}/pulls" \
             -f state=open -f base=main \
             -f "head=${GITHUB_REPOSITORY_OWNER}:${BRANCH}" -f per_page=100)"
@@ -249,27 +553,114 @@ jobs:
               --base main --head "$BRANCH" \
               --title "fix(security): ${EVIDENCE_ID}" --body-file "$body")"
           fi
-          live="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/$(gh pr view "$pr_url" --json number --jq .number)")"
-          # shellcheck disable=SC2016  # jq variables are expanded by jq, not the shell.
-          jq -e --arg repo "$GITHUB_REPOSITORY" --arg branch "$BRANCH" --arg head "$HEAD_SHA" '
-            .user.login == "lightning-it-release-automation[bot]"
-            and .head.repo.full_name == $repo
-            and .head.ref == $branch
-            and .head.sha == $head
-            and .base.ref == "main"
-            and .state == "open"
-          ' <<<"$live" >/dev/null
-          gh pr edit "$pr_url" --repo "$GITHUB_REPOSITORY" \
-            --title "fix(security): ${EVIDENCE_ID}" --body-file "$body"
+          number="$(gh pr view "$pr_url" --repo "$GITHUB_REPOSITORY" \
+            --json number --jq .number)"
+          live="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}")"
+          # shellcheck disable=SC2016  # jq variables are expanded by jq.
+          jq -e \
+            --arg base "$BASE_SHA" \
+            --arg branch "$BRANCH" \
+            --arg head "$HEAD_SHA" \
+            --arg repo "$GITHUB_REPOSITORY" '
+              .user.login == "lightning-it-release-automation[bot]"
+              and .user.id == 307565056
+              and .user.type == "Bot"
+              and .head.repo.full_name == $repo
+              and .head.ref == $branch
+              and .head.sha == $head
+              and .base.ref == "main"
+              and .base.sha == $base
+              and .draft == false
+              and .state == "open"
+            ' <<<"$live" >/dev/null
+          update="$RUNNER_TEMP/security-pr-update.json"
+          jq -n \
+            --arg title "fix(security): ${EVIDENCE_ID}" \
+            --rawfile body "$body" \
+            '{title:$title,body:$body}' >"$update"
+          gh api --method PATCH \
+            "repos/${GITHUB_REPOSITORY}/pulls/${number}" --input "$update" >/dev/null
+          live="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}")"
+          # shellcheck disable=SC2016  # jq variables are expanded by jq.
+          jq -e \
+            --arg base "$BASE_SHA" \
+            --arg branch "$BRANCH" \
+            --arg head "$HEAD_SHA" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg title "fix(security): ${EVIDENCE_ID}" '
+              .user.login == "lightning-it-release-automation[bot]"
+              and .user.id == 307565056
+              and .user.type == "Bot"
+              and .head.repo.full_name == $repo
+              and .head.ref == $branch
+              and .head.sha == $head
+              and .base.ref == "main"
+              and .base.sha == $base
+              and .title == $title
+              and .draft == false
+              and .state == "open"
+            ' <<<"$live" >/dev/null
+          echo "number=$number" >>"$GITHUB_OUTPUT"
           echo "url=$pr_url" >>"$GITHUB_OUTPUT"
 
-      - name: Enable protected native auto-merge for the exact current head
+      - name: Enable and prove native MERGE auto-merge for exact current head
         env:
+          APP_TOKEN: ${{ steps.release-app.outputs.token }}
+          BASE_SHA: ${{ needs.classify.outputs.base-sha }}
           GH_TOKEN: ${{ steps.release-app.outputs.token }}
-          PR_URL: ${{ steps.pull.outputs.url }}
           HEAD_SHA: ${{ steps.branch.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.pull.outputs.number }}
+          PR_URL: ${{ steps.pull.outputs.url }}
         run: |
           set -euo pipefail
-          test "$(gh pr view "$PR_URL" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)" = "$HEAD_SHA"
+
+          authenticated_git() {
+            GH_TOKEN="$APP_TOKEN" git -c credential.helper= \
+              -c 'credential.helper=!gh auth git-credential' "$@"
+          }
+
+          live="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          test "$(jq -er .head.sha <<<"$live")" = "$HEAD_SHA"
+          test "$(jq -er .base.sha <<<"$live")" = "$BASE_SHA"
+          test "$(jq -er .state <<<"$live")" = open
           gh pr merge "$PR_URL" --repo "$GITHUB_REPOSITORY" \
             --auto --merge --match-head-commit "$HEAD_SHA"
+          for attempt in 1 2 3 4 5; do
+            live="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+            if jq -e --arg base "$BASE_SHA" --arg head "$HEAD_SHA" '
+              .state == "open"
+              and .base.sha == $base
+              and .head.sha == $head
+              and .auto_merge.merge_method == "merge"
+              and .auto_merge.enabled_by.login ==
+                "lightning-it-release-automation[bot]"
+              and .auto_merge.enabled_by.id == 307565056
+              and .auto_merge.enabled_by.type == "Bot"
+            ' <<<"$live" >/dev/null; then
+              exit 0
+            fi
+            if jq -e --arg head "$HEAD_SHA" '
+              .state == "closed"
+              and .merged == true
+              and .head.sha == $head
+              and .merged_by.login == "lightning-it-release-automation[bot]"
+              and .merged_by.id == 307565056
+              and .merged_by.type == "Bot"
+              and (.merge_commit_sha | test("^[0-9a-f]{40}$"))
+            ' <<<"$live" >/dev/null; then
+              merge_sha="$(jq -er .merge_commit_sha <<<"$live")"
+              authenticated_git fetch --no-tags origin main
+              test "$(git rev-parse origin/main)" = "$merge_sha"
+              read -r first_parent second_parent extra_parent <<<"$(
+                git show -s --format=%P "$merge_sha"
+              )"
+              test "$first_parent" = "$BASE_SHA"
+              test "$second_parent" = "$HEAD_SHA"
+              test -z "${extra_parent:-}"
+              test "$(git show -s --format=%T "$merge_sha")" = \
+                "$(git show -s --format=%T "$HEAD_SHA")"
+              exit 0
+            fi
+            test "$attempt" -lt 5
+            sleep 2
+          done

--- a/.lit/repository.yml
+++ b/.lit/repository.yml
@@ -56,6 +56,24 @@ enterprise_role_quality:
   long_term_archive_required: false
   release_eligibility: fail-closed
 local_managed_file_exceptions:
+  - path: .github/workflows/copilot-review.yml
+    owner: ansible-collection-supplementary
+    reason: MLX-90 golden-path incubation until real humanActions=0 acceptance.
+  - path: scripts/security-release-intake.py
+    owner: ansible-collection-supplementary
+    reason: MLX-90 golden-path incubation until real humanActions=0 acceptance.
+  - path: .github/workflows/security-release-intake.yml
+    owner: ansible-collection-supplementary
+    reason: MLX-90 golden-path incubation until real humanActions=0 acceptance.
+  - path: scripts/security-release-dispatch.py
+    owner: ansible-collection-supplementary
+    reason: MLX-90 golden-path incubation until real humanActions=0 acceptance.
+  - path: .github/workflows/security-release-dispatch.yml
+    owner: ansible-collection-supplementary
+    reason: MLX-90 golden-path incubation until real humanActions=0 acceptance.
+  - path: tests/unit/test_security_release_request_dispatch.py
+    owner: ansible-collection-supplementary
+    reason: MLX-90 golden-path incubation until real humanActions=0 acceptance.
   - path: AGENTS.md
     owner: ansible-collection-supplementary
     reason: >-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,12 @@ If generic guidance conflicts with repository behavior, you MUST prefer reposito
    tests in `shared-assets-lit`.
 7. The role-quality governance block in this file is enforced by `scripts/validate-role-coverage.py` and recorded in
    `.lit/repository.yml`; a shared-assets sync MUST preserve it.
+8. Until a fresh real Security release proves `humanActions=0`, this repository owns exactly
+   `.github/workflows/copilot-review.yml`, `scripts/security-release-intake.py`,
+   `.github/workflows/security-release-intake.yml`, `scripts/security-release-dispatch.py`,
+   `.github/workflows/security-release-dispatch.yml`, and
+   `tests/unit/test_security_release_request_dispatch.py`. Sync MUST preserve them byte-for-byte; after acceptance,
+   their proven versions are canonicalized once in `shared-assets-lit`.
 
 ## 2. Repository Baseline (This Repo)
 

--- a/changelogs/fragments/mlx90-golden-security-contract.yml
+++ b/changelogs/fragments/mlx90-golden-security-contract.yml
@@ -1,0 +1,9 @@
+---
+security_fixes:
+  - >-
+    Bind MLX-90 Security intake and release preparation to duplicate-safe canonical
+    chain identifiers, immutable receipts, and exact automation identities.
+  - >-
+    Route the protected-main Security controller to the intake through an exact
+    App-authenticated workflow dispatch with live installation, allowlist, permission,
+    commit, pull-request, and native merge proof.

--- a/scripts/release-version.py
+++ b/scripts/release-version.py
@@ -6,10 +6,16 @@ import argparse
 import hashlib
 import json
 import re
+import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import security_release_contract as CONTRACT  # noqa: E402
 
 SEMVER_RE = re.compile(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)")
 IMPACT_CATEGORIES = {
@@ -20,11 +26,20 @@ IMPACT_CATEGORIES = {
 NEUTRAL_CATEGORIES = {"known_issues", "release_summary", "trivial"}
 KNOWN_CATEGORIES = set().union(*IMPACT_CATEGORIES.values(), NEUTRAL_CATEGORIES)
 MAX_FRAGMENT_BYTES = 1024 * 1024
-RELEASE_PREPARATION_SCHEMA_VERSION = 1
+RELEASE_PREPARATION_SCHEMA_VERSION = 2
 RELEASE_PREPARER = {
-    "login": "lightning-it-release-automation[bot]",
-    "account_id": "307565056",
-    "email": "307565056+lightning-it-release-automation[bot]@users.noreply.github.com",
+    "login": CONTRACT.RELEASE_APP_LOGIN,
+    "account_id": CONTRACT.RELEASE_APP_ACCOUNT_ID,
+    "email": CONTRACT.RELEASE_APP_EMAIL,
+}
+SECURITY_RECEIPT_KEYS = {
+    "evidence_id",
+    "metadata_path",
+    "metadata_sha256",
+    "intake_receipt_path",
+    "intake_receipt_sha256",
+    "candidate_diff_sha256",
+    "human_actions",
 }
 
 
@@ -53,21 +68,33 @@ UniqueKeyLoader.add_constructor(
 
 
 def _load_unique_json(path: Path) -> dict[str, Any]:
-    def unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-        payload: dict[str, Any] = {}
-        for key, value in pairs:
-            if key in payload:
-                raise VersionError(f"duplicate JSON key in release preparation receipt: {key}")
-            payload[key] = value
-        return payload
-
     try:
-        payload = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=unique_object)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        if path.is_symlink() or not path.is_file():
+            raise VersionError("release preparation receipt must be a regular non-symlink file")
+        raw = path.read_bytes()
+        payload = CONTRACT.load_json_bytes(raw, "release preparation receipt")
+        if raw != CONTRACT.canonical_document_bytes(payload):
+            raise VersionError("release preparation receipt is not canonical JSON")
+    except (OSError, CONTRACT.ContractError) as error:
         raise VersionError(f"cannot parse release preparation receipt: {error}") from error
-    if not isinstance(payload, dict):
-        raise VersionError("release preparation receipt must be an object")
     return payload
+
+
+def _security_binding(
+    root: Path,
+    current_version: str,
+    target_version: str,
+    checked_at: datetime,
+) -> dict[str, Any] | None:
+    try:
+        return CONTRACT.load_release_security_binding(
+            root,
+            current_version,
+            target_version,
+            checked_at=checked_at,
+        )
+    except (OSError, CONTRACT.ContractError) as error:
+        raise VersionError(str(error)) from error
 
 
 def parse_stable_version(value: object, *, label: str) -> tuple[int, int, int]:
@@ -84,7 +111,13 @@ def _load_yaml(path: Path) -> dict[str, Any]:
     if path.stat().st_size > MAX_FRAGMENT_BYTES:
         raise VersionError(f"oversized changelog fragment: {path}")
     try:
-        payload = yaml.load(path.read_text(encoding="utf-8"), Loader=UniqueKeyLoader) or {}
+        payload = (
+            yaml.load(
+                path.read_text(encoding="utf-8"),
+                Loader=UniqueKeyLoader,  # noqa: S506 -- subclasses yaml.SafeLoader.
+            )
+            or {}
+        )
     except (OSError, UnicodeDecodeError, yaml.YAMLError) as error:
         raise VersionError(f"cannot parse changelog fragment {path}: {error}") from error
     if not isinstance(payload, dict):
@@ -113,8 +146,10 @@ def derive_impact(fragments_root: Path) -> tuple[str, list[str]]:
         if not payload:
             raise VersionError(f"empty changelog fragment: {path}")
         for category, entries in payload.items():
-            if not isinstance(entries, list) or not entries or any(
-                not isinstance(entry, str) or not entry.strip() for entry in entries
+            if (
+                not isinstance(entries, list)
+                or not entries
+                or any(not isinstance(entry, str) or not entry.strip() for entry in entries)
             ):
                 raise VersionError(f"changelog category {category} must contain nonempty text entries: {path}")
             if category not in NEUTRAL_CATEGORIES:
@@ -150,7 +185,13 @@ def resolve_version(galaxy_path: Path, fragments_root: Path, requested: str = ""
     if galaxy_path.is_symlink() or not galaxy_path.is_file() or galaxy_path.stat().st_size > MAX_FRAGMENT_BYTES:
         raise VersionError(f"unsafe collection metadata: {galaxy_path}")
     try:
-        galaxy = yaml.load(galaxy_path.read_text(encoding="utf-8"), Loader=UniqueKeyLoader) or {}
+        galaxy = (
+            yaml.load(
+                galaxy_path.read_text(encoding="utf-8"),
+                Loader=UniqueKeyLoader,  # noqa: S506 -- subclasses yaml.SafeLoader.
+            )
+            or {}
+        )
     except (OSError, UnicodeDecodeError, yaml.YAMLError) as error:
         raise VersionError(f"cannot parse collection metadata: {error}") from error
     if not isinstance(galaxy, dict):
@@ -188,14 +229,37 @@ def build_preparation_receipt(
     workflow_ref: str,
     workflow_event: str,
     workflow_actor: str,
+    root: Path | None = None,
+    checked_at: datetime | None = None,
 ) -> dict[str, Any]:
     """Bind reviewed fragment inputs to the protected release-preparation run."""
 
+    root = (root or Path.cwd()).resolve()
+    checked_at = checked_at or datetime.now(UTC)
+    version = str(resolution.get("version", ""))
+    current_version = str(resolution.get("current_version", ""))
+    security_binding = _security_binding(root, current_version, version, checked_at)
+    release_mode = "security" if security_binding is not None else "normal"
+    chain_id = security_binding["chain_id"] if security_binding is not None else None
+    security = None
+    if security_binding is not None:
+        security = {
+            "evidence_id": security_binding["evidence_id"],
+            "metadata_path": security_binding["metadata_path"],
+            "metadata_sha256": security_binding["metadata_sha256"],
+            "intake_receipt_path": security_binding["intake_receipt_path"],
+            "intake_receipt_sha256": security_binding["intake_receipt_sha256"],
+            "candidate_diff_sha256": security_binding["candidate_diff_sha256"],
+            "human_actions": security_binding["human_actions"],
+        }
     payload: dict[str, Any] = {
         "schema_version": RELEASE_PREPARATION_SCHEMA_VERSION,
         "repository": repository,
         "repository_id": repository_id,
         "base_sha": base_sha,
+        "release_mode": release_mode,
+        "chain_id": chain_id,
+        "security": security,
         "current_version": resolution.get("current_version"),
         "impact": resolution.get("impact"),
         "next_version": resolution.get("version"),
@@ -217,7 +281,9 @@ def build_preparation_receipt(
         expected_repository=repository,
         expected_repository_id=repository_id,
         expected_base_sha=base_sha,
-        expected_version=str(resolution.get("version", "")),
+        expected_version=version,
+        root=root,
+        checked_at=checked_at,
     )
     return payload
 
@@ -229,6 +295,8 @@ def verify_preparation_receipt(
     expected_repository_id: str,
     expected_base_sha: str,
     expected_version: str,
+    root: Path | None = None,
+    checked_at: datetime | None = None,
 ) -> None:
     """Fail closed unless a preparation receipt is structurally and semantically exact."""
 
@@ -237,6 +305,9 @@ def verify_preparation_receipt(
         "repository",
         "repository_id",
         "base_sha",
+        "release_mode",
+        "chain_id",
+        "security",
         "current_version",
         "impact",
         "next_version",
@@ -246,7 +317,12 @@ def verify_preparation_receipt(
     }
     if set(receipt) != required:
         raise VersionError("release preparation receipt has missing or unknown fields")
-    if receipt.get("schema_version") != RELEASE_PREPARATION_SCHEMA_VERSION:
+    schema_version = receipt.get("schema_version")
+    if (
+        not isinstance(schema_version, int)
+        or isinstance(schema_version, bool)
+        or schema_version != RELEASE_PREPARATION_SCHEMA_VERSION
+    ):
         raise VersionError("release preparation receipt schema is unsupported")
     if receipt.get("repository") != expected_repository or not re.fullmatch(
         r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", expected_repository
@@ -264,6 +340,39 @@ def verify_preparation_receipt(
     parse_stable_version(next_value, label="receipt next version")
     if next_value != calculated or next_value != expected_version:
         raise VersionError("release preparation receipt next version is not fragment-derived")
+
+    root = (root or Path.cwd()).resolve()
+    checked_at = checked_at or datetime.now(UTC)
+    security_binding = _security_binding(root, receipt["current_version"], expected_version, checked_at)
+    expected_mode = "security" if security_binding is not None else "normal"
+    if receipt.get("release_mode") != expected_mode:
+        raise VersionError("release preparation receipt mode differs from immutable Security markers")
+    if security_binding is None:
+        if receipt.get("chain_id") is not None or receipt.get("security") is not None:
+            raise VersionError("normal release preparation receipt contains partial Security markers")
+    else:
+        expected_security = {
+            "evidence_id": security_binding["evidence_id"],
+            "metadata_path": security_binding["metadata_path"],
+            "metadata_sha256": security_binding["metadata_sha256"],
+            "intake_receipt_path": security_binding["intake_receipt_path"],
+            "intake_receipt_sha256": security_binding["intake_receipt_sha256"],
+            "candidate_diff_sha256": security_binding["candidate_diff_sha256"],
+            "human_actions": 0,
+        }
+        security = receipt.get("security")
+        if not isinstance(security, dict) or set(security) != SECURITY_RECEIPT_KEYS:
+            raise VersionError("Security release preparation receipt binding is malformed")
+        human_actions = security.get("human_actions")
+        if not isinstance(human_actions, int) or isinstance(human_actions, bool):
+            raise VersionError("Security release preparation human_actions must be an integer")
+        if security != expected_security or receipt.get("chain_id") != security_binding["chain_id"]:
+            raise VersionError("Security release preparation receipt differs from the immutable intake binding")
+        if (
+            expected_repository != CONTRACT.PRODUCER_REPOSITORY
+            or expected_repository_id != CONTRACT.PRODUCER_REPOSITORY_ID
+        ):
+            raise VersionError("Security release preparation repository identity is unauthorized")
 
     fragments = receipt.get("fragments")
     if not isinstance(fragments, list) or not fragments or len(fragments) > 256:
@@ -285,6 +394,14 @@ def verify_preparation_receipt(
         names.append(name)
     if names != sorted(set(names)):
         raise VersionError("release preparation receipt fragment digests are duplicate or unsorted")
+    if security_binding is not None:
+        expected_fragment = Path(security_binding["changelog_fragment_path"]).name
+        expected_digest = security_binding["changelog_fragment_sha256"].removeprefix("sha256:")
+        bound_fragments = {fragment["path"]: fragment["sha256"] for fragment in fragments}
+        if bound_fragments.get(expected_fragment) != expected_digest:
+            raise VersionError(
+                "Security release preparation fragments do not contain the immutable intake fragment digest"
+            )
     if receipt.get("preparer") != RELEASE_PREPARER:
         raise VersionError("release preparation receipt preparer is unauthorized")
 
@@ -301,9 +418,7 @@ def verify_preparation_receipt(
     }
     if not isinstance(workflow, dict) or set(workflow) != workflow_keys:
         raise VersionError("release preparation receipt workflow identity is malformed")
-    expected_workflow_ref = (
-        f"{expected_repository}/.github/workflows/release-prepare.yml@refs/heads/main"
-    )
+    expected_workflow_ref = f"{expected_repository}/.github/workflows/release-prepare.yml@refs/heads/main"
     if (
         workflow.get("path") != ".github/workflows/release-prepare.yml"
         or workflow.get("ref") != expected_workflow_ref
@@ -312,10 +427,16 @@ def verify_preparation_receipt(
         or workflow.get("event") not in {"push", "workflow_dispatch"}
         or not isinstance(workflow.get("actor"), str)
         or not workflow.get("actor")
-        or re.fullmatch(r"[1-9][0-9]*", str(workflow.get("run_id", ""))) is None
-        or re.fullmatch(r"[1-9][0-9]*", str(workflow.get("run_attempt", ""))) is None
+        or not isinstance(workflow.get("run_id"), str)
+        or re.fullmatch(r"[1-9][0-9]*", workflow["run_id"]) is None
+        or not isinstance(workflow.get("run_attempt"), str)
+        or re.fullmatch(r"[1-9][0-9]*", workflow["run_attempt"]) is None
     ):
         raise VersionError("release preparation receipt does not identify an authorized workflow run")
+    if expected_mode == "security" and (
+        workflow.get("event") != "push" or workflow.get("actor") != CONTRACT.RELEASE_APP_LOGIN
+    ):
+        raise VersionError("Security release preparation must be an App-authored protected-main push")
 
 
 def main() -> int:
@@ -334,8 +455,11 @@ def main() -> int:
     parser.add_argument("--workflow-event", default="")
     parser.add_argument("--workflow-actor", default="")
     parser.add_argument("--expected-version", default="")
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--checked-at", default="")
     args = parser.parse_args()
     try:
+        checked_at = CONTRACT.timestamp(args.checked_at, "--checked-at") if args.checked_at else datetime.now(UTC)
         if args.verify_preparation_receipt:
             if args.write_preparation_receipt:
                 raise VersionError("receipt creation and verification are mutually exclusive")
@@ -346,6 +470,8 @@ def main() -> int:
                 expected_repository_id=args.repository_id,
                 expected_base_sha=args.base_sha,
                 expected_version=args.expected_version,
+                root=args.root,
+                checked_at=checked_at,
             )
             print(json.dumps(receipt, sort_keys=True, separators=(",", ":")))
             return 0
@@ -361,13 +487,12 @@ def main() -> int:
                 workflow_ref=args.workflow_ref,
                 workflow_event=args.workflow_event,
                 workflow_actor=args.workflow_actor,
+                root=args.root,
+                checked_at=checked_at,
             )
             args.write_preparation_receipt.parent.mkdir(parents=True, exist_ok=True)
-            args.write_preparation_receipt.write_text(
-                json.dumps(receipt, indent=2, sort_keys=True) + "\n",
-                encoding="utf-8",
-            )
-    except VersionError as error:
+            args.write_preparation_receipt.write_bytes(CONTRACT.canonical_document_bytes(receipt))
+    except (VersionError, CONTRACT.ContractError) as error:
         parser.error(str(error))
     print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
     return 0

--- a/scripts/security-release-dispatch.py
+++ b/scripts/security-release-dispatch.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
-import json
 import re
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from types import ModuleType
 from typing import Any
-
 
 METADATA_PATH = re.compile(r"^\.lit/security-releases/([^/]+)\.json$")
 
@@ -43,51 +41,62 @@ def build_envelope(
             INTAKE.fail(f"{label} must be a full lowercase commit SHA")
 
     live_main = INTAKE.git_text(root, "rev-parse", "refs/remotes/origin/main").strip()
-    live_develop = INTAKE.git_text(
-        root, "rev-parse", "refs/remotes/origin/develop"
-    ).strip()
+    live_develop = INTAKE.git_text(root, "rev-parse", "refs/remotes/origin/develop").strip()
     if live_main != base_sha or live_develop != head_sha:
         INTAKE.fail("dispatch source refs changed after protected CI")
 
     paths = INTAKE.changed_paths(root, base_sha, head_sha)
-    security_metadata = [
-        (status, path)
-        for status, path in paths
-        if path.startswith(".lit/security-releases/")
-    ]
+    security_metadata = [(status, path) for status, path in paths if path.startswith(".lit/security-releases/")]
     if not security_metadata:
+        if any(path.startswith(".lit/security-release-intakes/") for _status, path in paths):
+            INTAKE.fail("partial Security marker: candidate changes an App-owned intake receipt without metadata")
         return {"dispatch": False}
     if len(security_metadata) != 1 or security_metadata[0][0] != "A":
         INTAKE.fail("dispatch range must add exactly one immutable Security metadata file")
     match = METADATA_PATH.fullmatch(security_metadata[0][1])
     if match is None or INTAKE.SEMVER.fullmatch(match.group(1)) is None:
         INTAKE.fail("dispatch Security metadata path is invalid")
+    assert match is not None
     fixed_version = match.group(1)
-    metadata = INTAKE.show_json(
-        root,
-        head_sha,
-        security_metadata[0][1],
-        "Security release metadata",
-    )
+    metadata_raw = INTAKE.git_bytes(root, "show", f"{head_sha}:{security_metadata[0][1]}")
+    metadata = INTAKE.load_json_bytes(metadata_raw, "Security release metadata")
     issued_at = metadata.get("createdAt")
     validity = metadata.get("validity")
     expires_at = validity.get("expiresAt") if isinstance(validity, dict) else None
+    acceptance_profile = metadata.get("acceptanceProfile")
     if not isinstance(issued_at, str) or not isinstance(expires_at, str):
         INTAKE.fail("Security metadata cannot bind the dispatch validity interval")
+    if not isinstance(acceptance_profile, str):
+        INTAKE.fail("Security metadata cannot bind the acceptance profile")
+
+    candidate_diff_sha256 = INTAKE.sha256(INTAKE.canonical_diff(root, base_sha, head_sha))
+    metadata_sha256 = INTAKE.sha256(metadata_raw)
+    chain_id = INTAKE.CONTRACT.compute_chain_id(
+        repository=repository,
+        repository_id=INTAKE.CONTRACT.PRODUCER_REPOSITORY_ID,
+        base_sha=base_sha,
+        candidate_head_sha=head_sha,
+        candidate_diff_sha256=candidate_diff_sha256,
+        evidence_id=str(metadata.get("evidenceId", "")),
+        fixed_version=fixed_version,
+        acceptance_profile=acceptance_profile,
+    )
 
     request = {
-        "schemaVersion": 1,
+        "schemaVersion": INTAKE.CONTRACT.INTAKE_REQUEST_SCHEMA_VERSION,
         "event": "mlx90-security-release",
         "repository": repository,
+        "repositoryId": INTAKE.CONTRACT.PRODUCER_REPOSITORY_ID,
         "baseSha": base_sha,
         "candidateRef": "develop",
         "candidateBaseSha": base_sha,
         "candidateHeadSha": head_sha,
-        "candidateDiffSha256": INTAKE.sha256(
-            INTAKE.canonical_diff(root, base_sha, head_sha)
-        ),
+        "candidateDiffSha256": candidate_diff_sha256,
         "evidenceId": metadata.get("evidenceId"),
         "fixedVersion": fixed_version,
+        "acceptanceProfile": acceptance_profile,
+        "metadataSha256": metadata_sha256,
+        "chainId": chain_id,
         "issuedAt": issued_at,
         "expiresAt": expires_at,
         "humanActions": 0,
@@ -98,6 +107,8 @@ def build_envelope(
         result["evidenceId"] != request["evidenceId"]
         or result["fixedVersion"] != fixed_version
         or result["candidateHeadSha"] != head_sha
+        or result["chainId"] != chain_id
+        or result["metadataSha256"] != metadata_sha256
         or result["humanActions"] != 0
     ):
         INTAKE.fail("verified Security intake differs from the dispatch request")
@@ -112,13 +123,10 @@ def main() -> int:
     parser.add_argument("--root", type=Path, default=Path.cwd())
     parser.add_argument("--now", default="")
     parser.add_argument("--output-json", required=True, type=Path)
+    parser.add_argument("--output-request-json", type=Path)
     args = parser.parse_args()
     try:
-        now = (
-            INTAKE.timestamp(args.now, "--now")
-            if args.now
-            else datetime.now(UTC)
-        )
+        now = INTAKE.timestamp(args.now, "--now") if args.now else datetime.now(UTC)
         envelope = build_envelope(
             args.root.resolve(),
             INTAKE.require_string(args.repository, "--repository"),
@@ -126,9 +134,17 @@ def main() -> int:
             INTAKE.require_string(args.head_sha, "--head-sha"),
             now,
         )
-        serialized = json.dumps(envelope, sort_keys=True, separators=(",", ":")) + "\n"
-        INTAKE.write_exclusive(args.output_json, serialized.encode("utf-8"))
-        print(serialized, end="")
+        serialized = INTAKE.CONTRACT.canonical_document_bytes(envelope)
+        INTAKE.write_exclusive(args.output_json, serialized)
+        if args.output_request_json:
+            request = envelope.get("request")
+            if envelope.get("dispatch") is not True or not isinstance(request, dict):
+                INTAKE.fail("canonical Security request output requires dispatch=true")
+            INTAKE.write_exclusive(
+                args.output_request_json,
+                INTAKE.CONTRACT.canonical_document_bytes(request),
+            )
+        print(serialized.decode("utf-8"), end="")
     except (INTAKE.IntakeError, OSError, RuntimeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2

--- a/scripts/security-release-intake.py
+++ b/scripts/security-release-intake.py
@@ -9,60 +9,37 @@ Git diff to reviewed metadata already present in that range.
 from __future__ import annotations
 
 import argparse
-import hashlib
-import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-SHA = re.compile(r"^[0-9a-f]{40}$")
-DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
-EVIDENCE_ID = re.compile(r"^MLX90-[A-Z0-9][A-Z0-9._-]{2,127}$")
-SEMVER = re.compile(r"^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$")
-REF = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,199}$")
-PROFILE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{2,127}$")
-SECURITY_ID = re.compile(
-    r"^(?:CVE-[0-9]{4}-[0-9]{4,}|"
-    r"GHSA-[23456789cfghjmpqrvwx]{4}(?:-[23456789cfghjmpqrvwx]{4}){2}|"
-    r"LIT-SEC-[A-Z0-9._-]+)$"
-)
+import security_release_contract as CONTRACT  # noqa: E402
+
+SHA = CONTRACT.SHA
+DIGEST = CONTRACT.DIGEST
+EVIDENCE_ID = CONTRACT.EVIDENCE_ID
+SEMVER = CONTRACT.SEMVER
+REF = CONTRACT.REF
+PROFILE = CONTRACT.PROFILE
+SECURITY_ID = CONTRACT.SECURITY_ID
 REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
-CANONICAL_TIME = re.compile(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")
-REQUEST_KEYS = {
-    "schemaVersion",
-    "event",
-    "repository",
-    "baseSha",
-    "candidateRef",
-    "candidateBaseSha",
-    "candidateHeadSha",
-    "candidateDiffSha256",
-    "evidenceId",
-    "fixedVersion",
-    "issuedAt",
-    "expiresAt",
-    "humanActions",
-}
-METADATA_KEYS = {
-    "schemaVersion",
-    "evidenceId",
-    "createdAt",
-    "securityIdentifiers",
-    "affectedVersion",
-    "fixedVersion",
-    "consumers",
-    "acceptanceProfile",
-    "validity",
-}
-VALIDITY_KEYS = {"notBefore", "expiresAt", "revoked"}
+CANONICAL_TIME = CONTRACT.CANONICAL_TIME
+REQUEST_KEYS = CONTRACT.REQUEST_KEYS
+METADATA_KEYS = CONTRACT.METADATA_KEYS
+VALIDITY_KEYS = CONTRACT.VALIDITY_KEYS
 FORBIDDEN_PATHS = {
     ".lit/security-release-profiles.json",
+    "scripts/security_release_contract.py",
+    "scripts/security-release-dispatch.py",
     "scripts/security-release-intake.py",
+    "scripts/release-version.py",
     ".github/workflows/security-release-intake.yml",
 }
 RUNTIME_PRODUCT_PREFIXES = (
@@ -89,66 +66,12 @@ FORBIDDEN_SUPPORTING_PATHS = {
 MAX_DIFF_BYTES = 4 * 1024 * 1024
 
 
-class IntakeError(ValueError):
-    """Raised when the intake cannot be proven safe."""
-
-
-def fail(message: str) -> None:
-    raise IntakeError(message)
-
-
-def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for key, value in pairs:
-        if key in result:
-            fail(f"duplicate JSON key: {key}")
-        result[key] = value
-    return result
-
-
-def load_json_bytes(raw: bytes, label: str) -> dict[str, Any]:
-    try:
-        value = json.loads(
-            raw.decode("utf-8"),
-            object_pairs_hook=reject_duplicate_keys,
-            parse_constant=lambda value: fail(f"invalid JSON constant: {value}"),
-        )
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise IntakeError(f"{label} is not valid UTF-8 JSON: {exc}") from exc
-    if not isinstance(value, dict):
-        fail(f"{label} must be a JSON object")
-    return value
-
-
-def load_json_file(path: Path, label: str) -> dict[str, Any]:
-    if path.is_symlink() or not path.is_file():
-        fail(f"{label} must be a regular non-symlink file")
-    return load_json_bytes(path.read_bytes(), label)
-
-
-def exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
-    if set(value) != expected:
-        missing = sorted(expected - set(value))
-        unknown = sorted(set(value) - expected)
-        fail(f"{label} fields mismatch; missing={missing}, unknown={unknown}")
-
-
-def require_string(value: object, label: str) -> str:
-    if not isinstance(value, str) or not value or value != value.strip():
-        fail(f"{label} must be a non-empty trimmed string")
-    if "\n" in value or "\r" in value or "\x00" in value:
-        fail(f"{label} must be a single-line string")
-    return value
-
-
-def timestamp(value: object, label: str) -> datetime:
-    text = require_string(value, label)
-    if CANONICAL_TIME.fullmatch(text) is None:
-        fail(f"{label} must be canonical UTC RFC3339")
-    try:
-        return datetime.strptime(text, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=UTC)
-    except ValueError as exc:
-        raise IntakeError(f"{label} is not a valid timestamp") from exc
+IntakeError = CONTRACT.ContractError
+fail = CONTRACT.fail
+reject_duplicate_keys = CONTRACT.reject_duplicate_keys
+load_json_bytes = CONTRACT.load_json_bytes
+require_string = CONTRACT.require_string
+timestamp = CONTRACT.timestamp
 
 
 def git_environment() -> dict[str, str]:
@@ -158,10 +81,17 @@ def git_environment() -> dict[str, str]:
     return environment
 
 
+def git_binary() -> str:
+    executable = shutil.which("git")
+    if executable is None:
+        fail("git executable is unavailable")
+    return executable
+
+
 def run_git(root: Path, *args: str, text: bool = False) -> bytes | str:
     try:
-        result = subprocess.run(
-            ["git", *args],
+        result = subprocess.run(  # noqa: S603 -- arguments are exact validated contract inputs.
+            [git_binary(), *args],
             cwd=root,
             check=True,
             capture_output=True,
@@ -169,11 +99,7 @@ def run_git(root: Path, *args: str, text: bool = False) -> bytes | str:
             env=git_environment(),
         )
     except subprocess.CalledProcessError as exc:
-        stderr = (
-            exc.stderr
-            if isinstance(exc.stderr, str)
-            else exc.stderr.decode("utf-8", errors="replace")
-        )
+        stderr = exc.stderr if isinstance(exc.stderr, str) else exc.stderr.decode("utf-8", errors="replace")
         raise IntakeError(f"git {' '.join(args)} failed: {stderr.strip()}") from exc
     return result.stdout
 
@@ -190,49 +116,25 @@ def git_bytes(root: Path, *args: str) -> bytes:
     return value
 
 
-def validate_request(
-    request: dict[str, Any], repository: str, now: datetime
-) -> dict[str, Any]:
-    exact_keys(request, REQUEST_KEYS, "Security intake request")
-    if request["schemaVersion"] != 1:
-        fail("Security intake schemaVersion must be 1")
-    if request["event"] != "mlx90-security-release":
-        fail("Security intake event is unsupported")
-    if request["repository"] != repository:
-        fail("Security intake repository does not match the live repository")
-    if request["humanActions"] != 0:
-        fail("Security Zero-Touch intake must declare humanActions=0")
+def validate_request(request: dict[str, Any], repository: str, now: datetime) -> dict[str, Any]:
+    return CONTRACT.validate_request(request, repository, now)
 
-    for field in ("baseSha", "candidateBaseSha", "candidateHeadSha"):
-        value = require_string(request[field], field)
-        if SHA.fullmatch(value) is None:
-            fail(f"{field} must be a full lowercase commit SHA")
-    if request["candidateBaseSha"] == request["candidateHeadSha"]:
-        fail("candidate source range must not be empty")
-    if request["candidateBaseSha"] != request["baseSha"]:
-        fail("candidate source range must start at the authorized protected-main SHA")
-    digest = require_string(request["candidateDiffSha256"], "candidateDiffSha256")
-    if DIGEST.fullmatch(digest) is None:
-        fail("candidateDiffSha256 must be a canonical SHA-256 digest")
-    evidence_id = require_string(request["evidenceId"], "evidenceId")
-    if EVIDENCE_ID.fullmatch(evidence_id) is None:
-        fail("evidenceId is invalid")
-    version = require_string(request["fixedVersion"], "fixedVersion")
-    if SEMVER.fullmatch(version) is None:
-        fail("fixedVersion must be stable SemVer")
-    candidate_ref = require_string(request["candidateRef"], "candidateRef")
-    if REF.fullmatch(candidate_ref) is None or candidate_ref.startswith("/"):
-        fail("candidateRef is invalid")
-    if candidate_ref != "develop":
-        fail("candidateRef must be the protected develop integration branch")
 
-    issued = timestamp(request["issuedAt"], "issuedAt")
-    expires = timestamp(request["expiresAt"], "expiresAt")
-    if expires <= issued:
-        fail("Security intake validity interval is empty")
-    if now < issued or now >= expires:
-        fail("Security intake request is not currently valid")
-    return request
+def load_canonical_document(path: Path, label: str) -> dict[str, Any]:
+    raw = CONTRACT.read_bounded_regular_file(
+        path.parent,
+        Path(path.name),
+        label,
+        CONTRACT.MAX_JSON_BYTES,
+    )
+    value = load_json_bytes(raw, label)
+    if raw != CONTRACT.canonical_document_bytes(value):
+        fail(f"{label} must be canonical compact JSON with one trailing newline")
+    return value
+
+
+def load_canonical_request(path: Path) -> dict[str, Any]:
+    return load_canonical_document(path, "Security intake request")
 
 
 def canonical_diff(root: Path, base_sha: str, head_sha: str) -> bytes:
@@ -240,11 +142,24 @@ def canonical_diff(root: Path, base_sha: str, head_sha: str) -> bytes:
         root,
         "-c",
         "core.safecrlf=false",
+        "-c",
+        "core.attributesFile=/dev/null",
+        "-c",
+        "diff.renames=false",
+        "-c",
+        "diff.algorithm=myers",
+        "-c",
+        "diff.indentHeuristic=false",
         "diff",
         "--binary",
         "--full-index",
         "--no-color",
         "--no-ext-diff",
+        "--no-textconv",
+        "--no-renames",
+        "--diff-algorithm=myers",
+        "--no-indent-heuristic",
+        "--unified=3",
         "--src-prefix=a/",
         "--dst-prefix=b/",
         base_sha,
@@ -260,7 +175,7 @@ def canonical_diff(root: Path, base_sha: str, head_sha: str) -> bytes:
 
 
 def sha256(value: bytes) -> str:
-    return "sha256:" + hashlib.sha256(value).hexdigest()
+    return CONTRACT.sha256_bytes(value)
 
 
 def changed_paths(root: Path, base_sha: str, head_sha: str) -> list[tuple[str, str]]:
@@ -311,115 +226,55 @@ def validate_metadata(
     request: dict[str, Any],
     paths: list[tuple[str, str]],
     now: datetime,
-) -> tuple[str, str]:
+) -> tuple[str, str, str, str]:
     version = request["fixedVersion"]
     metadata_path = f".lit/security-releases/{version}.json"
-    if paths.count(("A", metadata_path)) != 1:
-        fail("candidate must add exactly one immutable Security metadata file")
-    if any(path == metadata_path and status != "A" for status, path in paths):
-        fail("existing Security metadata must never be replaced")
-    if any(
-        path.startswith(".github/") or path in FORBIDDEN_PATHS
-        for _path_status, path in paths
-    ):
+    CONTRACT.validate_immutable_marker_changes(paths, version)
+    if any(path.startswith(".github/") or path in FORBIDDEN_PATHS for _path_status, path in paths):
         fail("candidate diff modifies Security controls or workflow policy")
     fragments = [
-        path
-        for status, path in paths
-        if status == "A" and re.fullmatch(r"changelogs/fragments/[^/]+\.ya?ml", path)
+        path for status, path in paths if status == "A" and re.fullmatch(r"changelogs/fragments/[^/]+\.ya?ml", path)
     ]
     if len(fragments) != 1:
         fail("candidate must add exactly one Security changelog fragment")
-    product_paths = [
-        path
-        for _path_status, path in paths
-        if path not in {metadata_path, fragments[0]}
-    ]
+    fragment_raw = git_bytes(root, "show", f"{request['candidateHeadSha']}:{fragments[0]}")
+    CONTRACT.validate_security_fragment(fragment_raw, "Security changelog fragment")
+    fragment_digest = sha256(fragment_raw)
+    product_paths = [path for _path_status, path in paths if path not in {metadata_path, fragments[0]}]
     if not product_paths:
         fail("candidate must contain an evidence-bound product change")
     unsupported_paths = [
         path
         for path in product_paths
         if path in FORBIDDEN_SUPPORTING_PATHS
-        or (
-            path not in SUPPORTING_PRODUCT_PATHS
-            and not path.startswith(PRODUCT_PATH_PREFIXES)
-        )
+        or (path not in SUPPORTING_PRODUCT_PATHS and not path.startswith(PRODUCT_PATH_PREFIXES))
     ]
     if unsupported_paths:
-        fail(
-            "candidate modifies paths outside the Security product allowlist: "
-            + ", ".join(sorted(unsupported_paths))
-        )
+        fail("candidate modifies paths outside the Security product allowlist: " + ", ".join(sorted(unsupported_paths)))
     if not any(path.startswith(RUNTIME_PRODUCT_PREFIXES) for path in product_paths):
         fail("candidate must contain a runtime product change")
 
-    metadata = show_json(
-        root,
-        request["candidateHeadSha"],
-        metadata_path,
-        "Security release metadata",
+    metadata_raw = git_bytes(root, "show", f"{request['candidateHeadSha']}:{metadata_path}")
+    metadata_digest = sha256(metadata_raw)
+    if metadata_digest != request["metadataSha256"]:
+        fail("Security metadata digest does not match the intake request")
+    metadata = load_json_bytes(metadata_raw, "Security release metadata")
+    profile_id = request["acceptanceProfile"]
+    CONTRACT.validate_metadata_payload(
+        metadata,
+        expected_evidence_id=request["evidenceId"],
+        expected_version=version,
+        expected_profile=profile_id,
+        checked_at=now,
     )
-    exact_keys(metadata, METADATA_KEYS, "Security release metadata")
-    if metadata["schemaVersion"] != 1:
-        fail("Security release metadata schemaVersion must be 1")
-    if metadata["evidenceId"] != request["evidenceId"]:
-        fail("Security metadata evidenceId does not match the intake")
-    if metadata["fixedVersion"] != version:
-        fail("Security metadata fixedVersion does not match the intake")
-    identifiers = metadata["securityIdentifiers"]
-    if (
-        not isinstance(identifiers, list)
-        or not identifiers
-        or len(identifiers) != len(set(identifiers))
-        or any(
-            not isinstance(item, str) or SECURITY_ID.fullmatch(item) is None
-            for item in identifiers
-        )
-    ):
-        fail("Security metadata identifiers are invalid")
-    affected_version = require_string(metadata["affectedVersion"], "affectedVersion")
-    if SEMVER.fullmatch(affected_version) is None or affected_version == version:
-        fail("Security metadata affectedVersion is invalid")
-    consumers = metadata["consumers"]
-    if (
-        not isinstance(consumers, list)
-        or not consumers
-        or len(consumers) != len(set(consumers))
-        or any(
-            not isinstance(consumer, str) or REPOSITORY.fullmatch(consumer) is None
-            for consumer in consumers
-        )
-    ):
-        fail("Security metadata consumer allowlist is invalid")
-    if metadata["validity"].__class__ is not dict:
-        fail("Security metadata validity must be an object")
-    exact_keys(metadata["validity"], VALIDITY_KEYS, "Security release validity")
-    if metadata["validity"]["revoked"] is not False:
-        fail("Security release metadata is revoked")
-    created = timestamp(metadata["createdAt"], "createdAt")
-    not_before = timestamp(metadata["validity"]["notBefore"], "validity.notBefore")
-    expires = timestamp(metadata["validity"]["expiresAt"], "validity.expiresAt")
-    if created < not_before or created >= expires:
-        fail("Security metadata createdAt is outside its validity interval")
-    if now < not_before or now >= expires:
-        fail("Security release metadata is not currently valid")
-
-    profile_id = require_string(metadata["acceptanceProfile"], "acceptanceProfile")
-    if PROFILE.fullmatch(profile_id) is None:
-        fail("acceptanceProfile is invalid")
+    CONTRACT.validate_request_metadata_binding(request, metadata)
     profiles = show_json(
         root,
         request["baseSha"],
         ".lit/security-release-profiles.json",
         "protected-main acceptance-profile registry",
     )
-    exact_keys(profiles, {"schemaVersion", "profiles"}, "acceptance-profile registry")
-    if profiles["schemaVersion"] != 1 or not isinstance(profiles["profiles"], dict):
-        fail("acceptance-profile registry is unsupported")
-    profile = profiles["profiles"].get(profile_id)
-    if not isinstance(profile, dict) or profile.get("releaseEligible") is not True:
-        fail("acceptance profile was not pre-approved on protected main")
+    CONTRACT.validate_profile_registry(profiles, profile_id)
 
     galaxy = git_text(root, "show", f"{request['baseSha']}:galaxy.yml")
     match = re.search(r"(?m)^version:\s*[\"']?([^\s\"']+)", galaxy)
@@ -429,7 +284,7 @@ def validate_metadata(
     fixed = tuple(int(part) for part in version.split("."))
     if fixed != (current[0], current[1], current[2] + 1):
         fail("Security intake fixedVersion must be the next patch after protected main")
-    return metadata_path, profile_id
+    return metadata_path, profile_id, fragments[0], fragment_digest
 
 
 def reject_special_modes(root: Path, base_sha: str, head_sha: str) -> None:
@@ -460,13 +315,11 @@ def verify_repository(
     live_main = git_text(root, "rev-parse", "refs/remotes/origin/main").strip()
     if live_main != request["baseSha"]:
         fail("protected main changed after Security intake authorization")
-    live_candidate = git_text(
-        root, "rev-parse", f"refs/remotes/origin/{request['candidateRef']}"
-    ).strip()
+    live_candidate = git_text(root, "rev-parse", f"refs/remotes/origin/{request['candidateRef']}").strip()
     if (
-        subprocess.run(
+        subprocess.run(  # noqa: S603 -- commit identities are exact validated lowercase SHAs.
             [
-                "git",
+                git_binary(),
                 "merge-base",
                 "--is-ancestor",
                 request["candidateHeadSha"],
@@ -480,9 +333,9 @@ def verify_repository(
     ):
         fail("candidateHeadSha is not reachable from the declared live candidateRef")
     if (
-        subprocess.run(
+        subprocess.run(  # noqa: S603 -- commit identities are exact validated lowercase SHAs.
             [
-                "git",
+                git_binary(),
                 "merge-base",
                 "--is-ancestor",
                 request["candidateBaseSha"],
@@ -496,18 +349,16 @@ def verify_repository(
     ):
         fail("candidate source range is not an ancestry-ordered range")
 
-    patch = canonical_diff(
-        root, request["candidateBaseSha"], request["candidateHeadSha"]
-    )
+    patch = canonical_diff(root, request["candidateBaseSha"], request["candidateHeadSha"])
     actual_digest = sha256(patch)
     if actual_digest != request["candidateDiffSha256"]:
         fail("candidate diff digest does not match the approved intake")
-    paths = changed_paths(
-        root, request["candidateBaseSha"], request["candidateHeadSha"]
-    )
+    paths = changed_paths(root, request["candidateBaseSha"], request["candidateHeadSha"])
     reject_special_modes(root, request["candidateBaseSha"], request["candidateHeadSha"])
-    metadata_path, profile_id = validate_metadata(root, request, paths, now)
+    metadata_path, profile_id, fragment_path, fragment_digest = validate_metadata(root, request, paths, now)
     result = {
+        "schemaVersion": CONTRACT.INTAKE_RESULT_SCHEMA_VERSION,
+        "chainId": request["chainId"],
         "branch": f"security-release/{request['evidenceId']}",
         "baseSha": request["baseSha"],
         "candidateBaseSha": request["candidateBaseSha"],
@@ -516,10 +367,14 @@ def verify_repository(
         "evidenceId": request["evidenceId"],
         "fixedVersion": request["fixedVersion"],
         "metadataPath": metadata_path,
+        "metadataSha256": request["metadataSha256"],
         "acceptanceProfile": profile_id,
-        "changedPaths": [path for _path_status, path in paths],
+        "changelogFragmentPath": fragment_path,
+        "changelogFragmentSha256": fragment_digest,
+        "changedPaths": sorted(path for _path_status, path in paths),
         "humanActions": 0,
     }
+    CONTRACT.validate_intake_result(request, result)
     return patch, result
 
 
@@ -543,21 +398,68 @@ def main() -> int:
     parser.add_argument("--now", default="")
     parser.add_argument("--output-patch", type=Path)
     parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--output-intake-receipt", type=Path)
+    parser.add_argument("--workflow-run-id", default=os.environ.get("GITHUB_RUN_ID", ""))
+    parser.add_argument("--workflow-attempt", default=os.environ.get("GITHUB_RUN_ATTEMPT", ""))
+    parser.add_argument("--workflow-ref", default=os.environ.get("GITHUB_WORKFLOW_REF", ""))
+    parser.add_argument("--workflow-event", default=os.environ.get("GITHUB_EVENT_NAME", ""))
+    parser.add_argument("--workflow-actor", default=os.environ.get("GITHUB_ACTOR", ""))
+    parser.add_argument(
+        "--workflow-triggering-actor",
+        default=os.environ.get("GITHUB_TRIGGERING_ACTOR", ""),
+    )
+    parser.add_argument("--observed-app-slug", default="")
+    parser.add_argument("--observed-app-installation-id", default="")
+    parser.add_argument("--observed-app-login", default="")
+    parser.add_argument("--observed-app-account-id", default="")
+    parser.add_argument("--observed-app-permissions", type=Path)
+    parser.add_argument("--observed-app-repository", action="append", default=[])
     args = parser.parse_args()
     try:
         now = timestamp(args.now, "--now") if args.now else datetime.now(UTC)
         request = validate_request(
-            load_json_file(args.request, "Security intake request"),
+            load_canonical_request(args.request),
             require_string(args.repository, "--repository"),
             now,
         )
         patch, result = verify_repository(args.root.resolve(), request, now)
-        serialized = json.dumps(result, sort_keys=True, separators=(",", ":")) + "\n"
+        serialized = CONTRACT.canonical_document_bytes(result)
         if args.output_patch:
             write_exclusive(args.output_patch, patch)
         if args.output_json:
-            write_exclusive(args.output_json, serialized.encode("utf-8"))
-        print(serialized, end="")
+            write_exclusive(args.output_json, serialized)
+        if args.output_intake_receipt:
+            if args.observed_app_permissions is None:
+                fail("--observed-app-permissions is required for an intake receipt")
+            observed_automation = {
+                "slug": args.observed_app_slug,
+                "installationId": args.observed_app_installation_id,
+                "login": args.observed_app_login,
+                "accountId": args.observed_app_account_id,
+                "type": "Bot",
+                "selectedRepositories": sorted(args.observed_app_repository),
+                "permissions": load_canonical_document(
+                    args.observed_app_permissions,
+                    "observed App permissions",
+                ),
+            }
+            receipt = CONTRACT.build_intake_receipt(
+                request,
+                result,
+                checked_at=now,
+                workflow_run_id=args.workflow_run_id,
+                workflow_attempt=args.workflow_attempt,
+                workflow_ref=args.workflow_ref,
+                workflow_event=args.workflow_event,
+                workflow_actor=args.workflow_actor,
+                workflow_triggering_actor=args.workflow_triggering_actor,
+                observed_automation=observed_automation,
+            )
+            write_exclusive(
+                args.output_intake_receipt,
+                CONTRACT.canonical_document_bytes(receipt),
+            )
+        print(serialized.decode("utf-8"), end="")
     except (IntakeError, OSError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return 2

--- a/scripts/security_release_contract.py
+++ b/scripts/security_release_contract.py
@@ -24,12 +24,28 @@ RELEASE_APP_INSTALLATION_ID = "148019054"
 RELEASE_APP_LOGIN = f"{RELEASE_APP_SLUG}[bot]"
 RELEASE_APP_ACCOUNT_ID = "307565056"
 RELEASE_APP_EMAIL = f"{RELEASE_APP_ACCOUNT_ID}+{RELEASE_APP_LOGIN}@users.noreply.github.com"
+RELEASE_APP_SELECTED_REPOSITORIES = [
+    "lightning-it/ansible-collection-supplementary",
+    "lightning-it/container-ee-wunder-ansible-ubi9",
+    "lightning-it/github-management-lit",
+    "lightning-it/modulix-validation",
+    "lightning-it/shared-assets-lit",
+]
+RELEASE_APP_PERMISSIONS = {
+    "actions": "write",
+    "checks": "read",
+    "contents": "write",
+    "metadata": "read",
+    "pull_requests": "write",
+}
 RELEASE_APP_IDENTITY = {
     "slug": RELEASE_APP_SLUG,
     "installationId": RELEASE_APP_INSTALLATION_ID,
     "login": RELEASE_APP_LOGIN,
     "accountId": RELEASE_APP_ACCOUNT_ID,
     "type": "Bot",
+    "selectedRepositories": RELEASE_APP_SELECTED_REPOSITORIES,
+    "permissions": RELEASE_APP_PERMISSIONS,
 }
 
 SHA = re.compile(r"^[0-9a-f]{40}$")
@@ -120,6 +136,7 @@ CONTROLLER_KEYS = {
     "event",
     "gitRef",
     "actor",
+    "triggeringActor",
 }
 CHAIN_BINDING_KEYS = {
     "repository",
@@ -583,18 +600,22 @@ def build_intake_receipt(
     workflow_ref: str,
     workflow_event: str,
     workflow_actor: str,
+    workflow_triggering_actor: str,
     observed_automation: dict[str, Any],
 ) -> dict[str, Any]:
     validate_request(request, PRODUCER_REPOSITORY, checked_at)
     validate_intake_result(request, verified)
     if observed_automation != RELEASE_APP_IDENTITY:
         fail("observed release automation identity is unauthorized")
+    automation = dict(observed_automation)
+    automation["selectedRepositories"] = list(observed_automation["selectedRepositories"])
+    automation["permissions"] = dict(observed_automation["permissions"])
     receipt = {
         "schemaVersion": INTAKE_RECEIPT_SCHEMA_VERSION,
         "chainId": request["chainId"],
         "request": request,
         "verified": verified,
-        "automation": dict(observed_automation),
+        "automation": automation,
         "controller": {
             "path": ".github/workflows/security-release-intake.yml",
             "ref": workflow_ref,
@@ -604,6 +625,7 @@ def build_intake_receipt(
             "event": workflow_event,
             "gitRef": "refs/heads/main",
             "actor": workflow_actor,
+            "triggeringActor": workflow_triggering_actor,
         },
     }
     verify_intake_receipt(receipt, checked_at=checked_at)
@@ -637,9 +659,10 @@ def verify_intake_receipt(
         controller["path"] != ".github/workflows/security-release-intake.yml"
         or controller["ref"] != expected_ref
         or controller["sourceSha"] != request["baseSha"]
-        or controller["event"] != "repository_dispatch"
+        or controller["event"] != "workflow_dispatch"
         or controller["gitRef"] != "refs/heads/main"
         or controller["actor"] != RELEASE_APP_LOGIN
+        or controller["triggeringActor"] != RELEASE_APP_LOGIN
         or not isinstance(controller["runId"], str)
         or re.fullmatch(r"[1-9][0-9]*", controller["runId"]) is None
         or not isinstance(controller["runAttempt"], str)

--- a/tests/unit/test_release_version.py
+++ b/tests/unit/test_release_version.py
@@ -7,6 +7,7 @@ import importlib.util
 import json
 import tempfile
 import unittest
+from datetime import UTC, datetime
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -34,6 +35,123 @@ class ReleaseVersionTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
+
+    def _security_contract(self, root: Path) -> tuple[dict[str, object], datetime]:
+        contract = VERSION.CONTRACT
+        version = "3.2.4"
+        evidence_id = "MLX90-KEYCLOAK-26.7.1-3.2.4"
+        profile = "lit.supplementary/keycloak-26.7.1-security-v1"
+        checked_at = datetime(2026, 8, 8, 23, 0, tzinfo=UTC)
+        profiles = root / ".lit/security-release-profiles.json"
+        profiles.parent.mkdir(parents=True)
+        profiles.write_text(
+            json.dumps(
+                {
+                    "schemaVersion": 1,
+                    "profiles": {
+                        profile: {
+                            "description": "Exact Keycloak acceptance",
+                            "releaseEligible": True,
+                        }
+                    },
+                },
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        metadata = {
+            "schemaVersion": 1,
+            "evidenceId": evidence_id,
+            "createdAt": "2026-08-08T22:30:00Z",
+            "securityIdentifiers": ["CVE-2026-9793"],
+            "affectedVersion": "3.2.3",
+            "fixedVersion": version,
+            "consumers": [contract.CONSUMER_REPOSITORY],
+            "acceptanceProfile": profile,
+            "validity": {
+                "notBefore": "2026-08-08T22:30:00Z",
+                "expiresAt": "2026-09-08T22:30:00Z",
+                "revoked": False,
+            },
+        }
+        metadata_raw = (json.dumps(metadata, indent=2, sort_keys=True) + "\n").encode()
+        metadata_path = root / f".lit/security-releases/{version}.json"
+        metadata_path.parent.mkdir(parents=True)
+        metadata_path.write_bytes(metadata_raw)
+        candidate_digest = "sha256:" + "c" * 64
+        chain_id = contract.compute_chain_id(
+            repository=contract.PRODUCER_REPOSITORY,
+            repository_id=contract.PRODUCER_REPOSITORY_ID,
+            base_sha="a" * 40,
+            candidate_head_sha="b" * 40,
+            candidate_diff_sha256=candidate_digest,
+            evidence_id=evidence_id,
+            fixed_version=version,
+            acceptance_profile=profile,
+        )
+        request = {
+            "schemaVersion": 2,
+            "event": "mlx90-security-release",
+            "repository": contract.PRODUCER_REPOSITORY,
+            "repositoryId": contract.PRODUCER_REPOSITORY_ID,
+            "baseSha": "a" * 40,
+            "candidateRef": "develop",
+            "candidateBaseSha": "a" * 40,
+            "candidateHeadSha": "b" * 40,
+            "candidateDiffSha256": candidate_digest,
+            "evidenceId": evidence_id,
+            "fixedVersion": version,
+            "acceptanceProfile": profile,
+            "metadataSha256": contract.sha256_bytes(metadata_raw),
+            "chainId": chain_id,
+            "issuedAt": "2026-08-08T22:30:00Z",
+            "expiresAt": "2026-09-08T22:30:00Z",
+            "humanActions": 0,
+        }
+        fragment = contract.canonical_security_fragment_bytes(["Keycloak fix."])
+        verified = {
+            "schemaVersion": 2,
+            "chainId": chain_id,
+            "branch": f"security-release/{evidence_id}",
+            "baseSha": "a" * 40,
+            "candidateBaseSha": "a" * 40,
+            "candidateHeadSha": "b" * 40,
+            "candidateDiffSha256": candidate_digest,
+            "evidenceId": evidence_id,
+            "fixedVersion": version,
+            "metadataPath": f".lit/security-releases/{version}.json",
+            "metadataSha256": contract.sha256_bytes(metadata_raw),
+            "acceptanceProfile": profile,
+            "changelogFragmentPath": "changelogs/fragments/keycloak-security.yml",
+            "changelogFragmentSha256": contract.sha256_bytes(fragment),
+            "changedPaths": [
+                f".lit/security-releases/{version}.json",
+                "changelogs/fragments/keycloak-security.yml",
+                "roles/keycloak_deploy/defaults/main.yml",
+            ],
+            "humanActions": 0,
+        }
+        intake = contract.build_intake_receipt(
+            request,
+            verified,
+            checked_at=checked_at,
+            workflow_run_id="123456",
+            workflow_attempt="1",
+            workflow_ref=(
+                f"{contract.PRODUCER_REPOSITORY}/.github/workflows/security-release-intake.yml@refs/heads/main"
+            ),
+            workflow_event="workflow_dispatch",
+            workflow_actor=contract.RELEASE_APP_LOGIN,
+            workflow_triggering_actor=contract.RELEASE_APP_LOGIN,
+            observed_automation=contract.RELEASE_APP_IDENTITY,
+        )
+        intake_path = root / f".lit/security-release-intakes/{version}.json"
+        intake_path.parent.mkdir(parents=True)
+        intake_path.write_bytes(contract.canonical_document_bytes(intake))
+        fragment_path = root / verified["changelogFragmentPath"]
+        fragment_path.parent.mkdir(parents=True)
+        fragment_path.write_bytes(fragment)
+        return intake, checked_at
 
     def test_highest_reviewed_impact_selects_exact_next_stable_version(self) -> None:
         cases = (
@@ -66,6 +184,7 @@ class ReleaseVersionTests(unittest.TestCase):
             workflow_ref=(f"{repository}/.github/workflows/release-prepare.yml@refs/heads/main"),
             workflow_event="workflow_dispatch",
             workflow_actor="release-operator",
+            root=Path(self.temporary.name),
         )
         VERSION.verify_preparation_receipt(
             receipt,
@@ -73,6 +192,7 @@ class ReleaseVersionTests(unittest.TestCase):
             expected_repository_id=repository_id,
             expected_base_sha=base_sha,
             expected_version="1.41.0",
+            root=Path(self.temporary.name),
         )
         fragment = fragments / "change.yml"
         self.assertEqual("change.yml", receipt["fragments"][0]["path"])
@@ -80,6 +200,17 @@ class ReleaseVersionTests(unittest.TestCase):
             hashlib.sha256(fragment.read_bytes()).hexdigest(),
             receipt["fragments"][0]["sha256"],
         )
+        self.assertEqual(2, receipt["schema_version"])
+        self.assertEqual("normal", receipt["release_mode"])
+        self.assertIsNone(receipt["chain_id"])
+        self.assertIsNone(receipt["security"])
+
+        receipt_path = Path(self.temporary.name) / "release-preparation.json"
+        receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(VERSION.VersionError, "not canonical JSON"):
+            VERSION._load_unique_json(receipt_path)
+        receipt_path.write_bytes(VERSION.CONTRACT.canonical_document_bytes(receipt))
+        self.assertEqual(receipt, VERSION._load_unique_json(receipt_path))
 
         for label, mutate in (
             ("version", lambda value: value.__setitem__("next_version", "1.41.1")),
@@ -96,7 +227,169 @@ class ReleaseVersionTests(unittest.TestCase):
                         expected_repository_id=repository_id,
                         expected_base_sha=base_sha,
                         expected_version="1.41.0",
+                        root=Path(self.temporary.name),
                     )
+
+    def test_security_preparation_receipt_binds_exact_v2_intake(self) -> None:
+        root = Path(self.temporary.name)
+        galaxy, _fragments = self._fixture("security_fixes", version="3.2.3", root=root)
+        _intake, checked_at = self._security_contract(root)
+        fragments = root / "changelogs/fragments"
+        resolution = VERSION.resolve_version(galaxy, fragments)
+        contract = VERSION.CONTRACT
+        receipt = VERSION.build_preparation_receipt(
+            resolution,
+            repository=contract.PRODUCER_REPOSITORY,
+            repository_id=contract.PRODUCER_REPOSITORY_ID,
+            base_sha="d" * 40,
+            workflow_run_id="98765",
+            workflow_attempt="2",
+            workflow_ref=(f"{contract.PRODUCER_REPOSITORY}/.github/workflows/release-prepare.yml@refs/heads/main"),
+            workflow_event="push",
+            workflow_actor=contract.RELEASE_APP_LOGIN,
+            root=root,
+            checked_at=checked_at,
+        )
+        VERSION.verify_preparation_receipt(
+            receipt,
+            expected_repository=contract.PRODUCER_REPOSITORY,
+            expected_repository_id=contract.PRODUCER_REPOSITORY_ID,
+            expected_base_sha="d" * 40,
+            expected_version="3.2.4",
+            root=root,
+            checked_at=checked_at,
+        )
+        self.assertEqual("security", receipt["release_mode"])
+        self.assertRegex(str(receipt["chain_id"]), r"^sha256:[0-9a-f]{64}$")
+        self.assertEqual(0, receipt["security"]["human_actions"])
+        self.assertEqual(
+            f".lit/security-release-intakes/{resolution['version']}.json",
+            receipt["security"]["intake_receipt_path"],
+        )
+
+        for label, mutate in (
+            ("schema-type", lambda value: value.__setitem__("schema_version", True)),
+            ("mode", lambda value: value.__setitem__("release_mode", "normal")),
+            ("chain", lambda value: value.__setitem__("chain_id", "sha256:" + "0" * 64)),
+            ("intake", lambda value: value["security"].__setitem__("intake_receipt_sha256", "sha256:" + "0" * 64)),
+            ("actor", lambda value: value["workflow"].__setitem__("actor", "human")),
+            ("event", lambda value: value["workflow"].__setitem__("event", "workflow_dispatch")),
+            ("run-id-type", lambda value: value["workflow"].__setitem__("run_id", 98765)),
+            ("human-actions-type", lambda value: value["security"].__setitem__("human_actions", False)),
+        ):
+            with self.subTest(label=label):
+                tampered = json.loads(json.dumps(receipt))
+                mutate(tampered)
+                with self.assertRaises(VERSION.VersionError):
+                    VERSION.verify_preparation_receipt(
+                        tampered,
+                        expected_repository=contract.PRODUCER_REPOSITORY,
+                        expected_repository_id=contract.PRODUCER_REPOSITORY_ID,
+                        expected_base_sha="d" * 40,
+                        expected_version="3.2.4",
+                        root=root,
+                        checked_at=checked_at,
+                    )
+
+        wrong_fragment = json.loads(json.dumps(receipt))
+        wrong_fragment["fragments"][0]["sha256"] = "0" * 64
+        with self.assertRaisesRegex(VERSION.VersionError, "immutable intake fragment digest"):
+            VERSION.verify_preparation_receipt(
+                wrong_fragment,
+                expected_repository=contract.PRODUCER_REPOSITORY,
+                expected_repository_id=contract.PRODUCER_REPOSITORY_ID,
+                expected_base_sha="d" * 40,
+                expected_version="3.2.4",
+                root=root,
+                checked_at=checked_at,
+            )
+
+        fragment = fragments / "keycloak-security.yml"
+        original_fragment = fragment.read_bytes()
+        fragment.write_bytes(contract.canonical_security_fragment_bytes(["Different fix."]))
+        with self.assertRaisesRegex(VERSION.VersionError, "fragment digest differs"):
+            VERSION.build_preparation_receipt(
+                resolution,
+                repository=contract.PRODUCER_REPOSITORY,
+                repository_id=contract.PRODUCER_REPOSITORY_ID,
+                base_sha="d" * 40,
+                workflow_run_id="98765",
+                workflow_attempt="2",
+                workflow_ref=(f"{contract.PRODUCER_REPOSITORY}/.github/workflows/release-prepare.yml@refs/heads/main"),
+                workflow_event="push",
+                workflow_actor=contract.RELEASE_APP_LOGIN,
+                root=root,
+                checked_at=checked_at,
+            )
+        fragment.write_bytes(original_fragment)
+
+        fragment.unlink()
+        with self.assertRaisesRegex(VERSION.VersionError, "Security changelog fragment"):
+            VERSION.verify_preparation_receipt(
+                receipt,
+                expected_repository=contract.PRODUCER_REPOSITORY,
+                expected_repository_id=contract.PRODUCER_REPOSITORY_ID,
+                expected_base_sha="d" * 40,
+                expected_version="3.2.4",
+                root=root,
+                checked_at=checked_at,
+            )
+        fragment.write_bytes(original_fragment)
+        VERSION.verify_preparation_receipt(
+            receipt,
+            expected_repository=contract.PRODUCER_REPOSITORY,
+            expected_repository_id=contract.PRODUCER_REPOSITORY_ID,
+            expected_base_sha="d" * 40,
+            expected_version="3.2.4",
+            root=root,
+            checked_at=checked_at,
+        )
+
+    def test_partial_security_marker_never_falls_back_to_normal(self) -> None:
+        root = Path(self.temporary.name)
+        galaxy, _fragments = self._fixture("security_fixes", version="3.2.3", root=root)
+        _intake, checked_at = self._security_contract(root)
+        fragments = root / "changelogs/fragments"
+        (root / ".lit/security-release-intakes/3.2.4.json").unlink()
+        with self.assertRaisesRegex(VERSION.VersionError, "partial Security marker"):
+            VERSION.build_preparation_receipt(
+                VERSION.resolve_version(galaxy, fragments),
+                repository=VERSION.CONTRACT.PRODUCER_REPOSITORY,
+                repository_id=VERSION.CONTRACT.PRODUCER_REPOSITORY_ID,
+                base_sha="d" * 40,
+                workflow_run_id="98765",
+                workflow_attempt="1",
+                workflow_ref=(
+                    f"{VERSION.CONTRACT.PRODUCER_REPOSITORY}/.github/workflows/release-prepare.yml@refs/heads/main"
+                ),
+                workflow_event="push",
+                workflow_actor=VERSION.CONTRACT.RELEASE_APP_LOGIN,
+                root=root,
+                checked_at=checked_at,
+            )
+
+    def test_pending_security_marker_cannot_fall_back_to_normal_target(self) -> None:
+        root = Path(self.temporary.name)
+        galaxy, fragments = self._fixture("minor_changes", version="3.2.3", root=root)
+        _intake, checked_at = self._security_contract(root)
+        resolution = VERSION.resolve_version(galaxy, fragments)
+        self.assertEqual("3.3.0", resolution["version"])
+        with self.assertRaisesRegex(VERSION.VersionError, "does not match"):
+            VERSION.build_preparation_receipt(
+                resolution,
+                repository=VERSION.CONTRACT.PRODUCER_REPOSITORY,
+                repository_id=VERSION.CONTRACT.PRODUCER_REPOSITORY_ID,
+                base_sha="d" * 40,
+                workflow_run_id="98765",
+                workflow_attempt="1",
+                workflow_ref=(
+                    f"{VERSION.CONTRACT.PRODUCER_REPOSITORY}/.github/workflows/release-prepare.yml@refs/heads/main"
+                ),
+                workflow_event="workflow_dispatch",
+                workflow_actor="release-operator",
+                root=root,
+                checked_at=checked_at,
+            )
 
     def test_manual_version_must_equal_reviewed_impact(self) -> None:
         galaxy, fragments = self._fixture("major_changes")

--- a/tests/unit/test_security_release_contract.py
+++ b/tests/unit/test_security_release_contract.py
@@ -132,8 +132,9 @@ class SecurityReleaseContractTests(unittest.TestCase):
             workflow_ref=(
                 f"{CONTRACT.PRODUCER_REPOSITORY}/.github/workflows/security-release-intake.yml@refs/heads/main"
             ),
-            workflow_event="repository_dispatch",
+            workflow_event="workflow_dispatch",
             workflow_actor=CONTRACT.RELEASE_APP_LOGIN,
+            workflow_triggering_actor=CONTRACT.RELEASE_APP_LOGIN,
             observed_automation=CONTRACT.RELEASE_APP_IDENTITY,
         )
 
@@ -177,6 +178,10 @@ class SecurityReleaseContractTests(unittest.TestCase):
         mutations = (
             lambda value: value["automation"].__setitem__("installationId", "1"),
             lambda value: value["controller"].__setitem__("actor", "human"),
+            lambda value: value["controller"].__setitem__("triggeringActor", "human"),
+            lambda value: value["controller"].__setitem__("event", "repository_dispatch"),
+            lambda value: value["automation"]["selectedRepositories"].append("example/extra"),
+            lambda value: value["automation"]["permissions"].__setitem__("checks", "write"),
             lambda value: value.__setitem__("unknown", True),
             lambda value: value["request"].__setitem__("chainId", "sha256:" + "0" * 64),
             lambda value: value["request"].__setitem__("schemaVersion", 2.0),
@@ -220,8 +225,9 @@ class SecurityReleaseContractTests(unittest.TestCase):
                 workflow_ref=(
                     f"{CONTRACT.PRODUCER_REPOSITORY}/.github/workflows/security-release-intake.yml@refs/heads/main"
                 ),
-                workflow_event="repository_dispatch",
+                workflow_event="workflow_dispatch",
                 workflow_actor=CONTRACT.RELEASE_APP_LOGIN,
+                workflow_triggering_actor=CONTRACT.RELEASE_APP_LOGIN,
                 observed_automation=observed,
             )
 

--- a/tests/unit/test_security_release_request_dispatch.py
+++ b/tests/unit/test_security_release_request_dispatch.py
@@ -3,18 +3,23 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr, redirect_stdout
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts/security-release-dispatch.py"
 WORKFLOW = ROOT / ".github/workflows/security-release-dispatch.yml"
+INTAKE_WORKFLOW = ROOT / ".github/workflows/security-release-intake.yml"
 SPEC = importlib.util.spec_from_file_location("security_request_dispatch", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -111,7 +116,7 @@ class SecurityReleaseRequestDispatchTests(unittest.TestCase):
         )
         fragment = self.root / "changelogs/fragments/keycloak-security.yml"
         fragment.parent.mkdir(parents=True)
-        fragment.write_text("---\nsecurity_fixes:\n  - Keycloak fix.\n", encoding="utf-8")
+        fragment.write_bytes(MODULE.INTAKE.CONTRACT.canonical_security_fragment_bytes(["Keycloak fix."]))
         git(self.root, "add", ".")
         git(self.root, "commit", "-q", "-m", "Security candidate")
         self.head = git(self.root, "rev-parse", "HEAD")
@@ -119,6 +124,15 @@ class SecurityReleaseRequestDispatchTests(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.temporary.cleanup()
+
+    def commit_candidate_mutation(self, path: Path, content: str) -> str:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-q", "-m", "mutate Security candidate")
+        head = git(self.root, "rev-parse", "HEAD")
+        git(self.root, "update-ref", "refs/remotes/origin/develop", head)
+        return head
 
     def test_exact_candidate_builds_a_valid_human_actions_zero_request(self) -> None:
         envelope = MODULE.build_envelope(
@@ -134,6 +148,134 @@ class SecurityReleaseRequestDispatchTests(unittest.TestCase):
         self.assertEqual(self.head, request["candidateHeadSha"])
         self.assertEqual(EVIDENCE_ID, request["evidenceId"])
         self.assertEqual(0, request["humanActions"])
+        self.assertEqual(2, request["schemaVersion"])
+        self.assertEqual(MODULE.INTAKE.CONTRACT.PRODUCER_REPOSITORY_ID, request["repositoryId"])
+        self.assertEqual(PROFILE, request["acceptanceProfile"])
+        self.assertRegex(request["chainId"], r"^sha256:[0-9a-f]{64}$")
+        self.assertRegex(request["metadataSha256"], r"^sha256:[0-9a-f]{64}$")
+
+    def test_candidate_diff_is_independent_of_hostile_local_git_diff_config(self) -> None:
+        expected = MODULE.INTAKE.canonical_diff(self.root, self.base, self.head)
+        attributes = self.root / "host-global-attributes"
+        attributes.write_text("*.yml diff=hostile\n", encoding="utf-8")
+        git(self.root, "config", "core.attributesFile", str(attributes))
+        git(self.root, "config", "diff.renames", "copies")
+        git(self.root, "config", "diff.algorithm", "histogram")
+        git(self.root, "config", "diff.indentHeuristic", "true")
+        git(self.root, "config", "diff.external", "false")
+        git(self.root, "config", "diff.hostile.textconv", "false")
+        self.assertEqual(
+            expected,
+            MODULE.INTAKE.canonical_diff(self.root, self.base, self.head),
+        )
+
+    def test_dispatch_cli_emits_canonical_request_json_for_workflow_input(self) -> None:
+        envelope_path = self.root / "dispatch-envelope.json"
+        request_path = self.root / "workflow-request.json"
+        arguments = [
+            "security-release-dispatch.py",
+            "--repository",
+            REPOSITORY,
+            "--base-sha",
+            self.base,
+            "--head-sha",
+            self.head,
+            "--root",
+            str(self.root),
+            "--now",
+            "2026-08-08T23:00:00Z",
+            "--output-json",
+            str(envelope_path),
+            "--output-request-json",
+            str(request_path),
+        ]
+        with (
+            mock.patch.object(sys, "argv", arguments),
+            redirect_stdout(io.StringIO()),
+            redirect_stderr(io.StringIO()),
+        ):
+            self.assertEqual(0, MODULE.main())
+        envelope = MODULE.INTAKE.CONTRACT.load_json_file(
+            self.root,
+            envelope_path.relative_to(self.root),
+            "dispatch envelope",
+        )
+        request = MODULE.INTAKE.load_canonical_request(request_path)
+        self.assertEqual(envelope["request"], request)
+        self.assertEqual(request_path.read_bytes(), MODULE.INTAKE.CONTRACT.canonical_document_bytes(request))
+
+    def test_intake_cli_emits_only_canonical_observed_app_receipt(self) -> None:
+        request = MODULE.build_envelope(self.root, REPOSITORY, self.base, self.head, NOW)["request"]
+        request_path = self.root / "intake-request.json"
+        request_path.write_bytes(MODULE.INTAKE.CONTRACT.canonical_document_bytes(request))
+        result_path = self.root / "intake-result.json"
+        receipt_path = self.root / "intake-receipt.json"
+        permissions_path = self.root / "app-permissions.json"
+        permissions_path.write_bytes(
+            MODULE.INTAKE.CONTRACT.canonical_document_bytes(MODULE.INTAKE.CONTRACT.RELEASE_APP_PERMISSIONS)
+        )
+        arguments = [
+            "security-release-intake.py",
+            "--request",
+            str(request_path),
+            "--repository",
+            REPOSITORY,
+            "--root",
+            str(self.root),
+            "--now",
+            "2026-08-08T23:00:00Z",
+            "--output-json",
+            str(result_path),
+            "--output-intake-receipt",
+            str(receipt_path),
+            "--workflow-run-id",
+            "123456",
+            "--workflow-attempt",
+            "1",
+            "--workflow-ref",
+            f"{REPOSITORY}/.github/workflows/security-release-intake.yml@refs/heads/main",
+            "--workflow-event",
+            "workflow_dispatch",
+            "--workflow-actor",
+            MODULE.INTAKE.CONTRACT.RELEASE_APP_LOGIN,
+            "--workflow-triggering-actor",
+            MODULE.INTAKE.CONTRACT.RELEASE_APP_LOGIN,
+            "--observed-app-slug",
+            MODULE.INTAKE.CONTRACT.RELEASE_APP_SLUG,
+            "--observed-app-installation-id",
+            MODULE.INTAKE.CONTRACT.RELEASE_APP_INSTALLATION_ID,
+            "--observed-app-login",
+            MODULE.INTAKE.CONTRACT.RELEASE_APP_LOGIN,
+            "--observed-app-account-id",
+            MODULE.INTAKE.CONTRACT.RELEASE_APP_ACCOUNT_ID,
+            "--observed-app-permissions",
+            str(permissions_path),
+        ]
+        for repository in MODULE.INTAKE.CONTRACT.RELEASE_APP_SELECTED_REPOSITORIES:
+            arguments.extend(("--observed-app-repository", repository))
+        with (
+            mock.patch.object(sys, "argv", arguments),
+            redirect_stdout(io.StringIO()),
+            redirect_stderr(io.StringIO()),
+        ):
+            self.assertEqual(0, MODULE.INTAKE.main())
+        result = MODULE.INTAKE.CONTRACT.load_json_file(
+            self.root,
+            result_path.relative_to(self.root),
+            "intake result",
+        )
+        receipt = MODULE.INTAKE.CONTRACT.load_json_file(
+            self.root,
+            receipt_path.relative_to(self.root),
+            "intake receipt",
+        )
+        self.assertEqual(result_path.read_bytes(), MODULE.INTAKE.CONTRACT.canonical_document_bytes(result))
+        self.assertEqual(receipt_path.read_bytes(), MODULE.INTAKE.CONTRACT.canonical_document_bytes(receipt))
+        self.assertEqual(MODULE.INTAKE.CONTRACT.RELEASE_APP_IDENTITY, receipt["automation"])
+        noncanonical = self.root / "noncanonical-request.json"
+        noncanonical.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        with self.assertRaisesRegex(MODULE.INTAKE.IntakeError, "canonical compact JSON"):
+            MODULE.INTAKE.load_canonical_request(noncanonical)
 
     def test_ordinary_develop_change_does_not_mint_a_dispatch_request(self) -> None:
         git(self.root, "checkout", "-q", self.base)
@@ -148,36 +290,219 @@ class SecurityReleaseRequestDispatchTests(unittest.TestCase):
             MODULE.build_envelope(self.root, REPOSITORY, self.base, head, NOW),
         )
 
-    def test_controller_workflow_is_default_branch_bound_and_least_privilege(self) -> None:
-        workflow = WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn("workflow_run:", workflow)
-        self.assertIn("workflows: [Collection CI]", workflow)
-        self.assertIn("branches: [develop]", workflow)
-        self.assertIn("workflow_dispatch:", workflow)
-        self.assertIn("source_run_id:", workflow)
-        self.assertIn("gh workflow run security-release-dispatch.yml", workflow)
-        self.assertIn("--ref main", workflow)
-        self.assertIn("github.actor == 'github-actions[bot]'", workflow)
-        self.assertIn("github.triggering_actor == 'github-actions[bot]'", workflow)
-        self.assertNotIn("pull_request:", workflow)
-        self.assertIn("github.event.workflow_run.event == 'push'", workflow)
-        self.assertEqual(2, workflow.count("ref: ${{ github.sha }}"))
-        self.assertNotIn("ref: ${{ github.event.workflow_run.head_sha }}", workflow)
-        self.assertNotIn("ref: ${{ needs.classify.outputs.source-sha }}", workflow)
-        self.assertIn("needs.classify.outputs['source-sha']", workflow)
-        self.assertIn('test "$(git rev-parse HEAD)" = "$CONTROLLER_SHA"', workflow)
-        self.assertIn('test "$(git rev-parse origin/develop)" = "$SOURCE_SHA"', workflow)
-        self.assertIn("needs.classify.outputs.dispatch == 'true'", workflow)
-        self.assertIn("environment: mlx90-security-release-evidence", workflow)
-        self.assertIn("permission-contents: write", workflow)
-        self.assertIn('test "$APP_INSTALLATION_ID" = 148019054', workflow)
-        self.assertIn(".client_payload.humanActions == 0", workflow)
-        self.assertNotIn("permission-actions", workflow)
-        self.assertNotIn("permission-pull-requests", workflow)
-        self.assertLess(
-            workflow.index("Reconstruct exact validated request before token access"),
-            workflow.index("Mint repository-scoped release automation App token"),
+    def test_wrong_consumer_fails_before_dispatch(self) -> None:
+        metadata_path = self.root / f".lit/security-releases/{VERSION}.json"
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata["consumers"] = [
+            "lightning-it/container-ee-wunder-ansible-ubi9",
+            "example/unapproved",
+        ]
+        head = self.commit_candidate_mutation(
+            metadata_path,
+            json.dumps(metadata, sort_keys=True) + "\n",
         )
+        with self.assertRaisesRegex(MODULE.INTAKE.IntakeError, "exact MLX-90 consumer"):
+            MODULE.build_envelope(self.root, REPOSITORY, self.base, head, NOW)
+
+    def test_noncanonical_security_fragment_fails_before_dispatch(self) -> None:
+        fragment = self.root / "changelogs/fragments/keycloak-security.yml"
+        head = self.commit_candidate_mutation(
+            fragment,
+            "---\nsecurity_fixes:\n  - Non-canonical YAML.\n",
+        )
+        with self.assertRaisesRegex(MODULE.INTAKE.IntakeError, "invalid quoted YAML scalar"):
+            MODULE.build_envelope(self.root, REPOSITORY, self.base, head, NOW)
+
+    def test_candidate_cannot_supply_or_mutate_app_owned_receipts(self) -> None:
+        receipt = self.root / f".lit/security-release-intakes/{VERSION}.json"
+        head = self.commit_candidate_mutation(receipt, '{"forged":true}\n')
+        with self.assertRaisesRegex(MODULE.INTAKE.IntakeError, "App-owned Security intake receipts"):
+            MODULE.build_envelope(self.root, REPOSITORY, self.base, head, NOW)
+
+    def test_duplicate_metadata_keys_fail_closed(self) -> None:
+        metadata_path = self.root / f".lit/security-releases/{VERSION}.json"
+        content = metadata_path.read_text(encoding="utf-8").rstrip()
+        duplicate = content[:-1] + ',"fixedVersion":"3.2.4"}\n'
+        head = self.commit_candidate_mutation(metadata_path, duplicate)
+        with self.assertRaisesRegex(MODULE.INTAKE.IntakeError, "duplicate JSON key"):
+            MODULE.build_envelope(self.root, REPOSITORY, self.base, head, NOW)
+
+    def test_controller_workflow_is_default_branch_bound_and_least_privilege(self) -> None:
+        dispatch = WORKFLOW.read_text(encoding="utf-8")
+        intake = INTAKE_WORKFLOW.read_text(encoding="utf-8")
+        allowlist = tuple(MODULE.INTAKE.CONTRACT.RELEASE_APP_SELECTED_REPOSITORIES)
+
+        self.assertIn("workflow_run:", dispatch)
+        self.assertIn("workflows: [Collection CI]", dispatch)
+        self.assertIn("branches: [develop]", dispatch)
+        self.assertIn("source_run_id:", dispatch)
+        self.assertIn("gh workflow run security-release-dispatch.yml", dispatch)
+        self.assertIn("--ref main", dispatch)
+        self.assertIn("github.actor == 'github-actions[bot]'", dispatch)
+        self.assertIn("github.triggering_actor == 'github-actions[bot]'", dispatch)
+        self.assertIn("github.event.workflow_run.event == 'push'", dispatch)
+        self.assertNotIn("pull_request:", dispatch)
+        self.assertEqual(2, dispatch.count("ref: ${{ github.sha }}"))
+        self.assertNotIn("ref: ${{ github.event.workflow_run.head_sha }}", dispatch)
+        self.assertNotIn("ref: ${{ needs.classify.outputs.source-sha }}", dispatch)
+        self.assertIn("needs.classify.outputs['source-sha']", dispatch)
+        self.assertIn("needs.classify.outputs.dispatch == 'true'", dispatch)
+        self.assertIn("environment: mlx90-security-release-evidence", dispatch)
+        self.assertIn("permission-actions: write", dispatch)
+        self.assertEqual(1, dispatch.count("permission-metadata: read"))
+        self.assertNotIn("permission-contents: write", dispatch)
+        self.assertNotIn("permission-pull-requests: write", dispatch)
+        self.assertNotIn("permission-workflows", dispatch)
+        self.assertNotIn("repository_dispatch", dispatch)
+        self.assertIn("--output-request-json", dispatch)
+        self.assertIn("inputs:{request_json:$request_json}", dispatch)
+        self.assertIn(
+            "actions/workflows/security-release-intake.yml/dispatches",
+            dispatch,
+        )
+        self.assertIn('test "$APP_INSTALLATION_ID" = 148019054', dispatch)
+        self.assertIn(".id == 307565056", dispatch)
+        self.assertIn('gh api "apps/${APP_SLUG}"', dispatch)
+        self.assertIn('"checks": "read"', dispatch)
+        self.assertIn("gh api --paginate --slurp", dispatch)
+        self.assertEqual(
+            1,
+            dispatch.count("repositories: ${{ github.event.repository.name }}"),
+        )
+        dispatch_attestation = dispatch[
+            dispatch.index("- name: Mint installation-wide metadata-only App attestation token") : dispatch.index(
+                "- name: Verify exact App installation and repository scope"
+            )
+        ]
+        dispatch_mutation = dispatch[
+            dispatch.index("- name: Mint repository-scoped release automation App token") : dispatch.index(
+                "- name: Revalidate and dispatch exact request to immutable main intake"
+            )
+        ]
+        self.assertIn("permission-metadata: read", dispatch_attestation)
+        self.assertNotIn("repositories:", dispatch_attestation)
+        self.assertNotIn("permission-actions: write", dispatch_attestation)
+        self.assertIn(
+            "repositories: ${{ github.event.repository.name }}",
+            dispatch_mutation,
+        )
+        self.assertIn("permission-actions: write", dispatch_mutation)
+        self.assertNotIn("permission-metadata: read", dispatch_mutation)
+        for repository in allowlist:
+            self.assertEqual(1, dispatch.count(f'"{repository}"'))
+        self.assertLess(
+            dispatch.index("Reconstruct exact validated request before token access"),
+            dispatch.index("Mint installation-wide metadata-only App attestation token"),
+        )
+        self.assertLess(
+            dispatch.index("Mint installation-wide metadata-only App attestation token"),
+            dispatch.index("Verify exact App installation and repository scope"),
+        )
+        self.assertLess(
+            dispatch.index("Verify exact App installation and repository scope"),
+            dispatch.index("Mint repository-scoped release automation App token"),
+        )
+        self.assertLess(
+            dispatch.index("Mint repository-scoped release automation App token"),
+            dispatch.index("Revalidate and dispatch exact request to immutable main intake"),
+        )
+        relay_run = dispatch[
+            dispatch.index("- name: Dispatch immutable main-ref controller") : dispatch.index("  classify:")
+        ]
+        classify_start = dispatch.index("- name: Construct and fully validate immutable Security request")
+        classify_run = dispatch[classify_start : dispatch.index("\n  dispatch:\n", classify_start)]
+        self.assertNotIn("authenticated_fetch()", relay_run)
+        self.assertIn("authenticated_fetch()", classify_run)
+
+        self.assertIn("workflow_dispatch:", intake)
+        self.assertIn("request_json:", intake)
+        self.assertNotIn("repository_dispatch:", intake)
+        self.assertNotIn("client_payload", intake)
+        self.assertIn("github.ref == 'refs/heads/main'", intake)
+        self.assertGreaterEqual(
+            intake.count("github.actor == 'lightning-it-release-automation[bot]'"),
+            2,
+        )
+        self.assertGreaterEqual(
+            intake.count("github.triggering_actor == 'lightning-it-release-automation[bot]'"),
+            2,
+        )
+        self.assertIn("permission-contents: write", intake)
+        self.assertIn("permission-pull-requests: write", intake)
+        self.assertEqual(1, intake.count("permission-metadata: read"))
+        self.assertNotIn("permission-actions: write", intake)
+        self.assertNotIn("permission-workflows", intake)
+        self.assertEqual(
+            1,
+            intake.count("repositories: ${{ github.event.repository.name }}"),
+        )
+        intake_attestation = intake[
+            intake.index("- name: Mint installation-wide metadata-only App attestation token") : intake.index(
+                "- name: Verify exact App installation identity and complete allowlist"
+            )
+        ]
+        intake_mutation = intake[
+            intake.index("- name: Mint repository-scoped release automation App token") : intake.index(
+                "- name: Revalidate exact request and mint canonical v2 receipt before mutation"
+            )
+        ]
+        self.assertIn("permission-metadata: read", intake_attestation)
+        self.assertNotIn("repositories:", intake_attestation)
+        self.assertNotIn("permission-contents: write", intake_attestation)
+        self.assertNotIn("permission-pull-requests: write", intake_attestation)
+        self.assertIn(
+            "repositories: ${{ github.event.repository.name }}",
+            intake_mutation,
+        )
+        self.assertIn("permission-contents: write", intake_mutation)
+        self.assertIn("permission-pull-requests: write", intake_mutation)
+        self.assertNotIn("permission-metadata: read", intake_mutation)
+        self.assertIn("--output-intake-receipt", intake)
+        self.assertIn("--workflow-triggering-actor", intake)
+        self.assertIn(".schemaVersion == 2", intake)
+        self.assertIn('.controller.event == "workflow_dispatch"', intake)
+        self.assertIn('test "$APP_INSTALLATION_ID" = 148019054', intake)
+        self.assertIn(".id == 307565056", intake)
+        self.assertIn('gh api "apps/${APP_SLUG}"', intake)
+        self.assertIn("--observed-app-permissions", intake)
+        self.assertIn(".automation.permissions == {", intake)
+        self.assertIn("gh api --paginate --slurp", intake)
+        for repository in allowlist:
+            self.assertGreaterEqual(intake.count(repository), 2)
+        self.assertLess(
+            intake.index("Revalidate live request and run before App token access"),
+            intake.index("Mint installation-wide metadata-only App attestation token"),
+        )
+        self.assertLess(
+            intake.index("Mint installation-wide metadata-only App attestation token"),
+            intake.index("Verify exact App installation identity and complete allowlist"),
+        )
+        self.assertLess(
+            intake.index("Verify exact App installation identity and complete allowlist"),
+            intake.index("Mint repository-scoped release automation App token"),
+        )
+        self.assertLess(
+            intake.index("Mint repository-scoped release automation App token"),
+            intake.index("Revalidate exact request and mint canonical v2 receipt before mutation"),
+        )
+        self.assertIn(
+            'test "$MUTATION_APP_INSTALLATION_ID" = "$APP_INSTALLATION_ID"',
+            intake,
+        )
+        self.assertLess(
+            intake.index("Revalidate exact request and mint canonical v2 receipt before mutation"),
+            intake.index("Create or prove exact App-authored isolated commit"),
+        )
+        self.assertIn('test "$(git show -s --format=%P "$head_sha")" = "$BASE_SHA"', intake)
+        self.assertIn('test "$(git show -s --format=%T "$head_sha")" = "$tree_sha"', intake)
+        self.assertIn(".user.id == 307565056", intake)
+        self.assertIn("--auto --merge --match-head-commit", intake)
+        self.assertIn('.auto_merge.merge_method == "merge"', intake)
+        self.assertIn(".merged_by.id == 307565056", intake)
+        self.assertIn('test "$first_parent" = "$BASE_SHA"', intake)
+        self.assertIn('test "$second_parent" = "$HEAD_SHA"', intake)
+        self.assertNotIn("--admin", intake)
+        self.assertNotIn("--force", intake)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -861,6 +861,7 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("Required merge method: \\`merge commit\\`", prepare)
         self.assertIn("Immutable tag v${VERSION} already exists", prepare)
         publish = (WORKFLOWS / "collection-publish.yml").read_text(encoding="utf-8")
+        copilot = (WORKFLOWS / "copilot-review.yml").read_text(encoding="utf-8")
         self.assertIn("Re-prove fragment-derived version and authorized preparation", publish)
         self.assertIn('test "${#preparation_parents[@]}" -eq 1', publish)
         self.assertIn(
@@ -868,6 +869,22 @@ class WorkflowSecurityTests(unittest.TestCase):
             publish,
         )
         self.assertIn("--verify-preparation-receipt", publish)
+        self.assertIn('git worktree add --detach --quiet "$base_tree" "$REVIEWED_BASE_SHA"', publish)
+        self.assertIn('--root "$base_tree"', publish)
+        self.assertIn(
+            'git worktree add --detach --quiet "$base_tree" "$BASE_SHA"',
+            copilot,
+        )
+        self.assertIn(
+            'python "$base_tree/scripts/release-version.py"',
+            copilot,
+        )
+        self.assertIn('--root "$base_tree"', copilot)
+        self.assertNotIn(".schema_version == 1", copilot)
+        self.assertIn(
+            "Verified schema-v2 preparation against the immutable base tree",
+            copilot,
+        )
         self.assertIn("actions/runs/${preparation_run_id}", publish)
         self.assertIn('.conclusion == "success"', publish)
         action = ACTION.read_text(encoding="utf-8")

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -871,6 +871,10 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertIn("--verify-preparation-receipt", publish)
         self.assertIn('git worktree add --detach --quiet "$base_tree" "$REVIEWED_BASE_SHA"', publish)
         self.assertIn('--root "$base_tree"', publish)
+        self.assertEqual(
+            2,
+            publish.count('python "$base_tree/scripts/release-version.py"'),
+        )
         self.assertIn(
             'git worktree add --detach --quiet "$base_tree" "$BASE_SHA"',
             copilot,


### PR DESCRIPTION
## Summary

- activate the MLX-90 App-authored Security intake and dispatch receipt chain
- bind schema-v2 preparation receipts to the immutable Security request and exact base tree
- separate installation-wide metadata attestation from repository-scoped mutation tokens
- preserve human approval for normal releases while Security releases remain humanActions=0

## Exact ancestry

- base: 612d1de86b4dc86cc275d2228e4442d547ba02da (normal merge of #654)
- head: 2fdac9a04d28d2bb81c32e238b4c9c5906a445ba

## Local evidence

- Python 3.13.14, ansible-core 2.18.18: 242 unit tests PASS
- targeted release/workflow regressions: 32 PASS
- yamllint and pinned actionlint: PASS for the changed workflows
- exact history-free Copilot review: PASS, no findings
- exact history-free Codex review: PASS, no findings
- exact 40-line/binary review input: 196599 bytes below 200000

The authoritative current-head GitHub Copilot review and every protected GitHub Actions gate remain mandatory. The local container-backed full profile could not be repeated after Docker became unavailable; no gate was weakened or bypassed.

Part of lightning-it/github-management-lit#267.