### PR TITLE
feat(release): enforce immutable zero-touch promotions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,11 +21,17 @@
 /scripts/classify-security-release.py @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/enrich-cyclonedx-sbom.py @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/devtools-*.sh @lightning-it/lightning-it-security-and-compliance-maintainers
+/scripts/main-promotion-authorization.py @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/modulix-validation-receipt.py @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/nexus-galaxy-v3-stage.py @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/quality_cell_identity.py @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/quality_evidence.py @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/release-version.py @lightning-it/lightning-it-security-and-compliance-maintainers
+/scripts/verify_release_back_sync.py @lightning-it/lightning-it-security-and-compliance-maintainers
+/scripts/security-release-dispatch.py @lightning-it/lightning-it-security-and-compliance-maintainers
+/scripts/security-release-intake.py @lightning-it/lightning-it-security-and-compliance-maintainers
+/scripts/security_main_promotion.py @lightning-it/lightning-it-security-and-compliance-maintainers
+/scripts/security_release_contract.py @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/select-quality-impact.py @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/source_dependencies.py @lightning-it/lightning-it-security-and-compliance-maintainers
 /scripts/validate-role-coverage.py @lightning-it/lightning-it-security-and-compliance-maintainers

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -110,6 +110,8 @@ jobs:
               ' "$receipt"
             )"
           fi
+          git cat-file -e "${binding_sha}^{commit}"
+          git merge-base --is-ancestor "$binding_sha" "$SOURCE_SHA"
           echo "base_sha=$binding_sha" >>"$GITHUB_OUTPUT"
       - name: Checkout immutable pre-consumption Security binding
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7

--- a/.github/workflows/collection-ci.yml
+++ b/.github/workflows/collection-ci.yml
@@ -73,6 +73,50 @@ jobs:
           ref: ${{ env.SOURCE_SHA }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Resolve immutable pre-consumption Security binding
+        id: binding
+        env:
+          BASE_SHA: ${{ env.COMPARE_BASE_SHA }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ env.COMPARE_HEAD_REF }}
+          SECURITY_VERSION: ${{ inputs.security_version || '' }}
+        run: |
+          set -euo pipefail
+          binding_sha="$SOURCE_SHA"
+          receipt=changelogs/release-preparation.json
+          require_receipt=false
+          if [ "$EVENT_NAME" = pull_request ] && [[ "$HEAD_REF" == release/v* ]]; then
+            require_receipt=true
+          elif [ "$EVENT_NAME" = push ] && [ -n "$BASE_SHA" ] && \
+              git diff --name-only --no-renames "$BASE_SHA" "$SOURCE_SHA" -- \
+                "$receipt" | grep -Fxq "$receipt"
+          then
+            require_receipt=true
+          elif [ "$EVENT_NAME" = workflow_dispatch ] && [ -n "$SECURITY_VERSION" ]; then
+            require_receipt=true
+          fi
+          if [ "$require_receipt" = true ]; then
+            test -f "$receipt"
+            test ! -L "$receipt"
+            receipt_version="$SECURITY_VERSION"
+            if [ "$EVENT_NAME" = pull_request ]; then
+              receipt_version="${HEAD_REF#release/v}"
+            fi
+            binding_sha="$(
+              jq -er --arg version "$receipt_version" '
+                select($version == "" or .next_version == $version)
+                | .base_sha
+                | select(test("^[0-9a-f]{40}$"))
+              ' "$receipt"
+            )"
+          fi
+          echo "base_sha=$binding_sha" >>"$GITHUB_OUTPUT"
+      - name: Checkout immutable pre-consumption Security binding
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ steps.binding.outputs.base_sha }}
+          path: security-binding-base
+          persist-credentials: false
       - name: Classify exact event without granting an environment
         id: classify
         env:
@@ -94,7 +138,8 @@ jobs:
                 --head-sha "$HEAD_SHA" \
                 --base-ref "$BASE_REF" \
                 --head-ref "$HEAD_REF" \
-                --evidence-id "$EVIDENCE_ID"
+                --evidence-id "$EVIDENCE_ID" \
+                --binding-root security-binding-base
               ;;
             push)
               commit_message="$(git show -s --format=%B "$HEAD_SHA")"
@@ -104,13 +149,15 @@ jobs:
                 --head-sha "$HEAD_SHA" \
                 --ref "$EVENT_REF" \
                 --commit-message "$commit_message" \
-                --evidence-id "$EVIDENCE_ID"
+                --evidence-id "$EVIDENCE_ID" \
+                --binding-root security-binding-base
               ;;
             workflow_dispatch)
               python scripts/classify-security-release.py \
                 --event-kind version \
                 --version "$SECURITY_VERSION" \
-                --evidence-id "$EVIDENCE_ID"
+                --evidence-id "$EVIDENCE_ID" \
+                --binding-root security-binding-base
               ;;
             *)
               echo "Unsupported classification event: $EVENT_NAME" >&2

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -294,84 +294,6 @@ jobs:
               ;;
           esac
 
-  release-validation:
-    if: >-
-      github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/main'
-    name: Wait for exact-SHA Release Validation
-    needs: security-classification
-    runs-on: ubuntu-latest
-    timeout-minutes: 130
-    permissions:
-      actions: read
-      contents: read
-    outputs:
-      ci-run-id: ${{ steps.exact.outputs.ci-run-id }}
-    steps:
-      - name: Wait for exact-SHA main Release Validation
-        id: exact
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_SHA: ${{ inputs.release_sha }}
-        run: |
-          set -euo pipefail
-
-          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]
-          for attempt in $(seq 1 240); do
-            runs="$(
-              gh api --method GET \
-                "repos/${GITHUB_REPOSITORY}/actions/workflows/collection-ci.yml/runs" \
-                -f branch=main \
-                -f event=push \
-                -f head_sha="$RELEASE_SHA" \
-                -f per_page=100
-            )"
-            run_id="$(
-              jq -r --arg sha "$RELEASE_SHA" '
-                [
-                  .workflow_runs[]
-                  | select(
-                      .event == "push"
-                      and .head_branch == "main"
-                      and .head_sha == $sha
-                      and .status == "completed"
-                      and .conclusion == "success"
-                    )
-                ]
-                | sort_by(.run_attempt, .id)
-                | last
-                | .id // empty
-              ' <<< "$runs"
-            )"
-            if [ -n "$run_id" ]; then
-              jobs="$(
-                gh api --method GET --paginate --slurp \
-                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
-                  -f per_page=100
-              )"
-              gate_count="$(
-                jq '[
-                  .[].jobs[]
-                  | select(
-                      .name == "Collection / Release Validation"
-                      and .status == "completed"
-                      and .conclusion == "success"
-                    )
-                ] | length' <<< "$jobs"
-              )"
-              if [ "$gate_count" -eq 1 ]; then
-                echo "ci-run-id=$run_id" >> "$GITHUB_OUTPUT"
-                echo "Using successful exact-SHA Collection CI run $run_id."
-                exit 0
-              fi
-            fi
-            echo "Waiting for exact-SHA main Release Validation (attempt $attempt/240)."
-            sleep 30
-          done
-
-          echo "No successful exact-SHA main Release Validation was found." >&2
-          exit 1
-
   publish:
     if: >-
       github.event_name == 'workflow_dispatch' &&
@@ -381,7 +303,7 @@ jobs:
         github.actor == 'lightning-it-release-automation[bot]' &&
         github.actor_id == '307565056'))
     name: Publish collection release
-    needs: [security-classification, release-validation]
+    needs: security-classification
     runs-on: ${{ fromJSON(needs.security-classification.outputs.publish-runner) }}
     timeout-minutes: 360
     environment:
@@ -641,9 +563,69 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
+      - name: Wait for exact-SHA main Release Validation
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          for attempt in $(seq 1 240); do
+            runs="$(
+              gh api --method GET \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/collection-ci.yml/runs" \
+                -f branch=main \
+                -f event=push \
+                -f head_sha="$RELEASE_SHA" \
+                -f per_page=100
+            )"
+            run_id="$(
+              jq -r --arg sha "$RELEASE_SHA" '
+                [
+                  .workflow_runs[]
+                  | select(
+                      .event == "push"
+                      and .head_branch == "main"
+                      and .head_sha == $sha
+                      and .status == "completed"
+                      and .conclusion == "success"
+                    )
+                ]
+                | sort_by(.run_attempt, .id)
+                | last
+                | .id // empty
+              ' <<< "$runs"
+            )"
+            if [ -n "$run_id" ]; then
+              jobs="$(
+                gh api --method GET --paginate --slurp \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
+                  -f per_page=100
+              )"
+              gate_count="$(
+                jq '[
+                  .[].jobs[]
+                  | select(
+                      .name == "Collection / Release Validation"
+                      and .status == "completed"
+                      and .conclusion == "success"
+                    )
+                ] | length' <<< "$jobs"
+              )"
+              if [ "$gate_count" -eq 1 ]; then
+                echo "CI_RUN_ID=$run_id" >> "$GITHUB_ENV"
+                echo "Using successful exact-SHA Collection CI run $run_id."
+                exit 0
+              fi
+            fi
+            echo "Waiting for exact-SHA main Release Validation (attempt $attempt/240)."
+            sleep 30
+          done
+
+          echo "No successful exact-SHA main Release Validation was found." >&2
+          exit 1
+
       - name: Download exact candidate and evidence from validated run
         env:
-          CI_RUN_ID: ${{ needs.release-validation.outputs.ci-run-id }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail

--- a/.github/workflows/collection-publish.yml
+++ b/.github/workflows/collection-publish.yml
@@ -294,6 +294,84 @@ jobs:
               ;;
           esac
 
+  release-validation:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main'
+    name: Wait for exact-SHA Release Validation
+    needs: security-classification
+    runs-on: ubuntu-latest
+    timeout-minutes: 130
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      ci-run-id: ${{ steps.exact.outputs.ci-run-id }}
+    steps:
+      - name: Wait for exact-SHA main Release Validation
+        id: exact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+        run: |
+          set -euo pipefail
+
+          [[ "$RELEASE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          for attempt in $(seq 1 240); do
+            runs="$(
+              gh api --method GET \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/collection-ci.yml/runs" \
+                -f branch=main \
+                -f event=push \
+                -f head_sha="$RELEASE_SHA" \
+                -f per_page=100
+            )"
+            run_id="$(
+              jq -r --arg sha "$RELEASE_SHA" '
+                [
+                  .workflow_runs[]
+                  | select(
+                      .event == "push"
+                      and .head_branch == "main"
+                      and .head_sha == $sha
+                      and .status == "completed"
+                      and .conclusion == "success"
+                    )
+                ]
+                | sort_by(.run_attempt, .id)
+                | last
+                | .id // empty
+              ' <<< "$runs"
+            )"
+            if [ -n "$run_id" ]; then
+              jobs="$(
+                gh api --method GET --paginate --slurp \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
+                  -f per_page=100
+              )"
+              gate_count="$(
+                jq '[
+                  .[].jobs[]
+                  | select(
+                      .name == "Collection / Release Validation"
+                      and .status == "completed"
+                      and .conclusion == "success"
+                    )
+                ] | length' <<< "$jobs"
+              )"
+              if [ "$gate_count" -eq 1 ]; then
+                echo "ci-run-id=$run_id" >> "$GITHUB_OUTPUT"
+                echo "Using successful exact-SHA Collection CI run $run_id."
+                exit 0
+              fi
+            fi
+            echo "Waiting for exact-SHA main Release Validation (attempt $attempt/240)."
+            sleep 30
+          done
+
+          echo "No successful exact-SHA main Release Validation was found." >&2
+          exit 1
+
   publish:
     if: >-
       github.event_name == 'workflow_dispatch' &&
@@ -303,7 +381,7 @@ jobs:
         github.actor == 'lightning-it-release-automation[bot]' &&
         github.actor_id == '307565056'))
     name: Publish collection release
-    needs: security-classification
+    needs: [security-classification, release-validation]
     runs-on: ${{ fromJSON(needs.security-classification.outputs.publish-runner) }}
     timeout-minutes: 360
     environment:
@@ -563,69 +641,9 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
-      - name: Wait for exact-SHA main Release Validation
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          for attempt in $(seq 1 240); do
-            runs="$(
-              gh api --method GET \
-                "repos/${GITHUB_REPOSITORY}/actions/workflows/collection-ci.yml/runs" \
-                -f branch=main \
-                -f event=push \
-                -f head_sha="$RELEASE_SHA" \
-                -f per_page=100
-            )"
-            run_id="$(
-              jq -r --arg sha "$RELEASE_SHA" '
-                [
-                  .workflow_runs[]
-                  | select(
-                      .event == "push"
-                      and .head_branch == "main"
-                      and .head_sha == $sha
-                      and .status == "completed"
-                      and .conclusion == "success"
-                    )
-                ]
-                | sort_by(.run_attempt, .id)
-                | last
-                | .id // empty
-              ' <<< "$runs"
-            )"
-            if [ -n "$run_id" ]; then
-              jobs="$(
-                gh api --method GET --paginate --slurp \
-                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
-                  -f per_page=100
-              )"
-              gate_count="$(
-                jq '[
-                  .[].jobs[]
-                  | select(
-                      .name == "Collection / Release Validation"
-                      and .status == "completed"
-                      and .conclusion == "success"
-                    )
-                ] | length' <<< "$jobs"
-              )"
-              if [ "$gate_count" -eq 1 ]; then
-                echo "CI_RUN_ID=$run_id" >> "$GITHUB_ENV"
-                echo "Using successful exact-SHA Collection CI run $run_id."
-                exit 0
-              fi
-            fi
-            echo "Waiting for exact-SHA main Release Validation (attempt $attempt/240)."
-            sleep 30
-          done
-
-          echo "No successful exact-SHA main Release Validation was found." >&2
-          exit 1
-
       - name: Download exact candidate and evidence from validated run
         env:
+          CI_RUN_ID: ${{ needs.release-validation.outputs.ci-run-id }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -1180,6 +1198,7 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: modulix-validation
           permission-actions: write
+          permission-contents: read
 
       - name: Require signed successful ModuLix validation receipt
         if: env.SECURITY_RELEASE == 'true' && env.GALAXY_REQUIRED == 'true'

--- a/.github/workflows/main-promotion-authorization.yml
+++ b/.github/workflows/main-promotion-authorization.yml
@@ -43,6 +43,14 @@ jobs:
           path: policy
           persist-credentials: false
 
+      - name: Checkout exact promotion head as non-executable evidence
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          path: candidate
+          persist-credentials: false
+
       - name: Classify exact live pull request
         id: classify
         env:
@@ -94,6 +102,8 @@ jobs:
             --repository "$REPOSITORY" \
             --expected-base "$EVENT_BASE_SHA" \
             --expected-head "$EVENT_HEAD_SHA" \
+            --base-root policy \
+            --head-root candidate \
             --classification-only)"
           environment="$(jq -er .environment <<<"$classification")"
           gh api "repos/${REPOSITORY}/environments/${environment}" \
@@ -104,6 +114,8 @@ jobs:
             --repository "$REPOSITORY" \
             --expected-base "$EVENT_BASE_SHA" \
             --expected-head "$EVENT_HEAD_SHA" \
+            --base-root policy \
+            --head-root candidate \
             --github-output "$GITHUB_OUTPUT"
           echo 'bootstrap=false' >>"$GITHUB_OUTPUT"
 
@@ -126,6 +138,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           path: policy
+          persist-credentials: false
+
+      - name: Checkout exact promotion head as non-executable evidence
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          path: candidate
           persist-credentials: false
 
       - name: Revalidate exact live state after authorization
@@ -190,6 +210,8 @@ jobs:
               --repository "$REPOSITORY" \
               --expected-base "$EVENT_BASE_SHA" \
               --expected-head "$EVENT_HEAD_SHA" \
+              --base-root policy \
+              --head-root candidate \
               --expected-mode "$EXPECTED_MODE"
           fi
           {

--- a/.github/workflows/release-back-sync.yml
+++ b/.github/workflows/release-back-sync.yml
@@ -66,6 +66,8 @@ jobs:
               | select(test("^[0-9a-f]{40}$"))
             ' "$receipt"
           )"
+          git cat-file -e "${base_sha}^{commit}"
+          git merge-base --is-ancestor "$base_sha" "$GITHUB_SHA"
           echo "base_sha=$base_sha" >>"$GITHUB_OUTPUT"
       - name: Checkout immutable pre-consumption Security binding
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7

--- a/.github/workflows/release-back-sync.yml
+++ b/.github/workflows/release-back-sync.yml
@@ -27,7 +27,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: release-back-sync-${{ github.repository }}-${{ inputs.tag }}
+  group: main-develop-transition-${{ github.repository }}
   cancel-in-progress: false
 
 jobs:
@@ -49,6 +49,30 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Resolve the immutable pre-consumption binding base
+        id: binding
+        env:
+          TAG_INPUT: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          receipt=changelogs/release-preparation.json
+          test -f "$receipt"
+          test ! -L "$receipt"
+          version="${TAG_INPUT#v}"
+          base_sha="$(
+            jq -er --arg version "$version" '
+              select(.next_version == $version)
+              | .base_sha
+              | select(test("^[0-9a-f]{40}$"))
+            ' "$receipt"
+          )"
+          echo "base_sha=$base_sha" >>"$GITHUB_OUTPUT"
+      - name: Checkout immutable pre-consumption Security binding
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ steps.binding.outputs.base_sha }}
+          path: security-binding-base
+          persist-credentials: false
       - name: Verify tag-shaped input and classify before environment selection
         id: classify
         env:
@@ -63,7 +87,8 @@ jobs:
           python scripts/classify-security-release.py \
             --event-kind version \
             --version "${TAG_INPUT#v}" \
-            --evidence-id "$EVIDENCE_ID"
+            --evidence-id "$EVIDENCE_ID" \
+            --binding-root security-binding-base
 
   back-sync:
     name: Open release back-sync PR
@@ -124,6 +149,10 @@ jobs:
           EXPECTED_TAG_APP_ID: ${{ github.event.inputs.release_tag_app_id }}
           EXPECTED_TAG_APP_CLIENT_ID: ${{ github.event.inputs.release_tag_app_client_id }}
           REPO: ${{ github.repository }}
+          SECURITY_EVIDENCE_ID: ${{ needs.security-classification.outputs.security-evidence-id }}
+          SECURITY_RELEASE: ${{ needs.security-classification.outputs.security-release }}
+          SECURITY_VERSION: ${{ needs.security-classification.outputs.security-version }}
+          WORKFLOW_ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
 
@@ -231,6 +260,15 @@ jobs:
           PY
           )"
           test "$tag" = "v${tagged_version}"
+          if [ "$SECURITY_RELEASE" = true ]; then
+            test "$WORKFLOW_ACTOR" = 'lightning-it-release-automation[bot]'
+            test "$SECURITY_VERSION" = "$tagged_version"
+            [[ "$SECURITY_EVIDENCE_ID" =~ ^MLX90-[A-Z0-9][A-Z0-9._-]{2,127}$ ]]
+          else
+            test "$SECURITY_RELEASE" = false
+            test -z "$SECURITY_VERSION"
+            test -z "$SECURITY_EVIDENCE_ID"
+          fi
 
           if git merge-base --is-ancestor "$release_sha" origin/develop; then
             echo "develop already contains the tagged release; release back-sync not needed."
@@ -256,6 +294,11 @@ jobs:
           body+="\`${tag}\` was published.\n\n"
           body+=$'Merge this PR with a merge commit, not squash or rebase, '
           body+=$'so the exact tagged release becomes an ancestor of `develop`.'
+          if [ "$SECURITY_RELEASE" = true ]; then
+            body+=$'\n\nEvidence-bound MLX-90 Security back-sync: `'
+            body+="${SECURITY_EVIDENCE_ID}"
+            body+=$'`; human actions in the successful path: `0`.'
+          fi
 
           git switch -C "$branch" origin/develop
           git merge --no-ff -X ours "$release_sha" \
@@ -265,8 +308,16 @@ jobs:
             CHANGELOG.rst
             changelogs/.plugin-cache.yaml
             changelogs/changelog.yaml
+            changelogs/release-preparation.json
             galaxy.yml
           )
+          if [ "$SECURITY_RELEASE" = true ]; then
+            security_metadata=".lit/security-releases/${SECURITY_VERSION}.json"
+            security_receipt=".lit/security-release-intakes/${SECURITY_VERSION}.json"
+            git cat-file -e "${release_sha}:${security_metadata}"
+            git cat-file -e "${release_sha}:${security_receipt}"
+            release_paths+=("$security_metadata" "$security_receipt")
+          fi
           for path in "${release_paths[@]}"; do
             if git cat-file -e "${release_sha}:${path}" 2>/dev/null; then
               git checkout "$release_sha" -- "$path"
@@ -280,7 +331,7 @@ jobs:
             "$release_base" "$release_sha" -- changelogs/fragments/ \
             | xargs -r rm -f
 
-          git add -A CHANGELOG.rst changelogs galaxy.yml
+          git add -A -- "${release_paths[@]}" changelogs/fragments/
           if ! git diff --cached --quiet; then
             git commit --amend --no-edit
           fi
@@ -290,14 +341,38 @@ jobs:
             exit 0
           fi
 
-          if ! authenticated_push \
-              "--force-with-lease=${branch_ref}:${remote_branch_sha}" \
-              origin "HEAD:${branch_ref}"
-          then
-            echo "::error::Release back-sync branch changed concurrently; rerun from fresh state."
-            exit 1
-          fi
           pushed_sha="$(git rev-parse HEAD)"
+          if [ -n "$remote_branch_sha" ]; then
+            git fetch --no-tags origin "$branch_ref"
+            test "$(git rev-parse FETCH_HEAD)" = "$remote_branch_sha"
+            git switch --detach "$remote_branch_sha"
+            pushed_sha="$remote_branch_sha"
+          fi
+
+          current_develop="$(git rev-parse origin/develop)"
+          back_sync_policy="$RUNNER_TEMP/release-back-sync-policy"
+          test ! -e "$back_sync_policy"
+          git worktree add --detach "$back_sync_policy" "$release_sha"
+          python "$back_sync_policy/scripts/verify_release_back_sync.py" \
+            --root "$GITHUB_WORKSPACE" \
+            --develop-tip "$current_develop" \
+            --release-sha "$release_sha" \
+            --head-sha "$pushed_sha" \
+            --tag "$tag" \
+            --security-version "$SECURITY_VERSION" \
+            --evidence-id "$SECURITY_EVIDENCE_ID"
+          git worktree remove "$back_sync_policy"
+
+          if [ -z "$remote_branch_sha" ]; then
+            if ! authenticated_push origin "HEAD:${branch_ref}"; then
+              echo "::error::Release back-sync branch appeared concurrently; refusing to overwrite it."
+              exit 1
+            fi
+            test "$(git ls-remote origin "$branch_ref" | awk '{print $1}')" = \
+              "$pushed_sha"
+          else
+            echo "Reusing the already verified immutable back-sync head ${pushed_sha}."
+          fi
 
           owned_pulls="$(
             gh api --method GET "repos/${REPO}/pulls" \
@@ -342,3 +417,12 @@ jobs:
             --repo "$REPO" \
             --title "$title" \
             --body "$body"
+
+          if [ "$SECURITY_RELEASE" = true ]; then
+            test "$(jq -er '.[0].user.login' <<< "$owned_pulls")" = \
+              'lightning-it-release-automation[bot]'
+            test "$(jq -er '.[0].head.sha' <<< "$owned_pulls")" = "$pushed_sha"
+            gh pr merge "$existing" \
+              --repo "$REPO" \
+              --auto --merge --match-head-commit "$pushed_sha"
+          fi

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -63,6 +63,33 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Resolve immutable pre-consumption binding base
+        id: binding
+        env:
+          BEFORE_SHA: ${{ github.event.before || github.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          base_sha="$GITHUB_SHA"
+          if [ "$EVENT_NAME" = push ] && \
+              git diff --name-only --no-renames "$BEFORE_SHA" "$GITHUB_SHA" -- \
+                changelogs/release-preparation.json \
+                | grep -Fxq changelogs/release-preparation.json
+          then
+            receipt=changelogs/release-preparation.json
+            test -f "$receipt"
+            test ! -L "$receipt"
+            base_sha="$(
+              jq -er '.base_sha | select(test("^[0-9a-f]{40}$"))' "$receipt"
+            )"
+          fi
+          echo "base_sha=$base_sha" >>"$GITHUB_OUTPUT"
+      - name: Checkout immutable pre-consumption Security binding
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ steps.binding.outputs.base_sha }}
+          path: security-binding-base
+          persist-credentials: false
       - name: Classify before selecting a protected environment
         id: classify
         env:
@@ -80,12 +107,14 @@ jobs:
               --head-sha "$GITHUB_SHA" \
               --ref "$GITHUB_REF" \
               --commit-message "$commit_message" \
-              --evidence-id "$EVIDENCE_ID"
+              --evidence-id "$EVIDENCE_ID" \
+              --binding-root security-binding-base
           else
             python scripts/classify-security-release.py \
               --event-kind version \
               --version "$VERSION" \
-              --evidence-id "$EVIDENCE_ID"
+              --evidence-id "$EVIDENCE_ID" \
+              --binding-root security-binding-base
           fi
 
   prepare:
@@ -173,6 +202,7 @@ jobs:
           CREATE_GITHUB_RELEASE_INPUT: ${{ github.event.inputs.create_github_release }}
           PUBLISH_GALAXY_INPUT: ${{ github.event.inputs.publish_galaxy }}
           REPOSITORY_ID: ${{ github.repository_id }}
+          SECURITY_RELEASE: ${{ needs.security-classification.outputs.security-release }}
           WORKFLOW_REF: ${{ github.workflow_ref }}
           WORKFLOW_EVENT: ${{ github.event_name }}
           WORKFLOW_ACTOR: ${{ github.actor }}
@@ -242,6 +272,16 @@ jobs:
           )"
           VERSION="$(jq -er '.version' <<< "$version_resolution")"
           RELEASE_IMPACT="$(jq -er '.impact' <<< "$version_resolution")"
+          PREPARATION_MODE="$(jq -er '.release_mode' changelogs/release-preparation.json)"
+          if [ "$SECURITY_RELEASE" = true ]; then
+            test "$PREPARATION_MODE" = security
+            SECURITY_CHAIN_ID="$(jq -er '.chain_id' changelogs/release-preparation.json)"
+            [[ "$SECURITY_CHAIN_ID" =~ ^sha256:[0-9a-f]{64}$ ]]
+          else
+            test "$SECURITY_RELEASE" = false
+            test "$PREPARATION_MODE" = normal
+            SECURITY_CHAIN_ID=""
+          fi
           export VERSION
 
           tag_matches="$(
@@ -379,10 +419,32 @@ jobs:
 
           git add galaxy.yml changelogs CHANGELOG.rst
           git commit -m "chore(release): prepare v${VERSION}"
-          authenticated_push \
-            "--force-with-lease=${release_ref}:${remote_release_sha}" \
-            origin "HEAD:${release_ref}"
           pushed_sha="$(git rev-parse HEAD)"
+          if [ -n "$remote_release_sha" ]; then
+            git fetch --no-tags origin "$release_ref"
+            test "$(git rev-parse FETCH_HEAD)" = "$remote_release_sha"
+            git switch --detach "$remote_release_sha"
+            pushed_sha="$remote_release_sha"
+          fi
+
+          promotion_base="$RUNNER_TEMP/release-promotion-base"
+          test ! -e "$promotion_base"
+          git worktree add --detach "$promotion_base" "$BASE_SHA"
+          python "$promotion_base/scripts/security_main_promotion.py" \
+            --base-root "$promotion_base" \
+            --head-root "$GITHUB_WORKSPACE" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$pushed_sha" \
+            --head-ref "$RELEASE_BRANCH" >/dev/null
+          git worktree remove "$promotion_base"
+
+          if [ -z "$remote_release_sha" ]; then
+            authenticated_push origin "HEAD:${release_ref}"
+            test "$(git ls-remote origin "$release_ref" | awk '{print $1}')" = \
+              "$pushed_sha"
+          else
+            echo "Reusing the already verified immutable release branch head ${pushed_sha}."
+          fi
 
           body_file="$(mktemp)"
           {
@@ -394,6 +456,11 @@ jobs:
             echo "GitHub release creation: \`${CREATE_GITHUB_RELEASE}\`"
             echo "Galaxy publishing: \`${PUBLISH_GALAXY}\`"
             echo "Reviewed semantic impact: \`${RELEASE_IMPACT}\`"
+            echo "Release mode: \`${PREPARATION_MODE}\`"
+            if [ "$PREPARATION_MODE" = security ]; then
+              echo "MLX-90 chain: \`${SECURITY_CHAIN_ID}\`"
+              echo "- Human actions in the successful Security path: \`0\`"
+            fi
             echo "Required merge method: \`merge commit\` (squash and rebase are prohibited)"
             echo
             echo "## Changelog summary"
@@ -521,3 +588,13 @@ jobs:
           gh pr edit "$existing" \
             --title "Release v${VERSION}" \
             --body-file "$body_file"
+
+          if [ "$SECURITY_RELEASE" = true ]; then
+            test "$WORKFLOW_ACTOR" = 'lightning-it-release-automation[bot]'
+            test "$(jq -er '.[0].user.login' <<< "$owned_pulls")" = \
+              'lightning-it-release-automation[bot]'
+            test "$(jq -er '.[0].head.sha' <<< "$owned_pulls")" = "$pushed_sha"
+            gh pr merge "$existing" \
+              --repo "$GITHUB_REPOSITORY" \
+              --auto --merge --match-head-commit "$pushed_sha"
+          fi

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -83,6 +83,8 @@ jobs:
               jq -er '.base_sha | select(test("^[0-9a-f]{40}$"))' "$receipt"
             )"
           fi
+          git cat-file -e "${base_sha}^{commit}"
+          git merge-base --is-ancestor "$base_sha" "$GITHUB_SHA"
           echo "base_sha=$base_sha" >>"$GITHUB_OUTPUT"
       - name: Checkout immutable pre-consumption Security binding
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7

--- a/.github/workflows/sync-main-to-develop.yml
+++ b/.github/workflows/sync-main-to-develop.yml
@@ -7,18 +7,59 @@ name: Sync main back to develop
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: sync-main-to-develop
+  group: main-develop-transition-${{ github.repository }}
   cancel-in-progress: false
 
 jobs:
+  classify:
+    name: Classify main-to-develop ownership
+    if: >-
+      github.repository_owner == 'lightning-it' &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      chain-owned: ${{ steps.classify.outputs.chain_owned }}
+    steps:
+      - name: Checkout exact protected-main push
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Reserve Security intake and release transitions for exact back-sync
+        id: classify
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          [[ "$BEFORE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          changed="$RUNNER_TEMP/main-transition-paths.txt"
+          git diff --name-only --no-renames "$BEFORE_SHA" "$HEAD_SHA" -- . >"$changed"
+          chain_owned=false
+          if grep -Eq \
+              '^(changelogs/release-preparation\.json|\.lit/security-release-intakes/[0-9]+\.[0-9]+\.[0-9]+\.json)$' \
+              "$changed"
+          then
+            chain_owned=true
+          fi
+          echo "chain_owned=$chain_owned" >>"$GITHUB_OUTPUT"
+
   backmerge:
-    if: github.repository_owner == 'lightning-it'
+    needs: classify
+    if: >-
+      needs.classify.result == 'success' &&
+      needs.classify.outputs['chain-owned'] == 'false'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/scripts/classify-security-release.py
+++ b/scripts/classify-security-release.py
@@ -1,5 +1,3 @@
-"""Classify only evidence-bound MLX-90 Security release events."""
-
 from __future__ import annotations
 
 import argparse
@@ -28,7 +26,7 @@ PREPARE_TITLE = re.compile(r"(?:^|\n)chore\(release\): prepare v([0-9]+\.[0-9]+\
 
 
 class ClassificationError(ValueError):
-    """Raised when an event claims Security semantics without valid evidence."""
+    pass
 
 
 @dataclass(frozen=True)
@@ -45,24 +43,30 @@ def fail(message: str) -> NoReturn:
 def git_binary() -> str:
     executable = shutil.which("git")
     if executable is None:
-        fail("git executable is unavailable")
+        fail("git unavailable")
     return executable
+
+
+def git_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for variable in ("GIT_COMMON_DIR", "GIT_DIR", "GIT_WORK_TREE"):
+        environment.pop(variable, None)
+    return environment
 
 
 def timestamp(value: Any, field: str) -> datetime:
     if not isinstance(value, str) or not value:
-        fail(f"{field} must be a non-empty RFC3339 timestamp")
+        fail(f"{field} must be RFC3339")
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError as exc:
         raise ClassificationError(f"{field} must be RFC3339") from exc
     if parsed.tzinfo is None:
-        fail(f"{field} must include a timezone")
+        fail(f"{field} needs a timezone")
     return parsed.astimezone(UTC)
 
 
 def is_regular_file_beneath(root: Path, relative: Path) -> bool:
-    """Reject symlinks at every repository-relative path component."""
     current = root
     if current.is_symlink() or not current.is_dir():
         return False
@@ -83,16 +87,16 @@ def classify_version(
     binding_root: Path | None = None,
 ) -> Classification:
     if SEMVER.fullmatch(version) is None:
-        fail("Security release version is not stable SemVer")
+        fail("invalid version")
     metadata_path = root / ".lit" / "security-releases" / f"{version}.json"
     intake_path = root / ".lit" / "security-release-intakes" / f"{version}.json"
     metadata_exists = metadata_path.exists() or metadata_path.is_symlink()
     intake_exists = intake_path.exists() or intake_path.is_symlink()
     if metadata_exists != intake_exists:
-        fail("partial Security marker: metadata and intake receipt must exist together")
+        fail("partial marker")
     if not metadata_exists:
         if expected_evidence_id:
-            fail("claimed Security release binding is missing")
+            fail("Security binding missing")
         return Classification(False)
     source = root
     if binding_root is not None:
@@ -109,16 +113,16 @@ def classify_version(
                 or not is_regular_file_beneath(source, relative)
                 or current.read_bytes() != bound.read_bytes()
             ):
-                fail(f"released Security binding differs from its pre-consumption base: {relative}")
+                fail(f"binding differs from its pre-consumption base: {relative}")
     try:
         binding = CONTRACT.load_security_binding(source, version, checked_at=checked_at)
     except CONTRACT.ContractError as exc:
         raise ClassificationError(str(exc)) from exc
     if binding is None:
-        fail("claimed Security release binding is unavailable")
+        fail("binding unavailable")
     evidence_id = binding["evidence_id"]
     if expected_evidence_id and evidence_id != expected_evidence_id:
-        fail("Security release evidenceId does not match the event binding")
+        fail("evidenceId does not match")
     return Classification(True, evidence_id, version)
 
 
@@ -141,12 +145,14 @@ def changed_preparation_version(root: Path, base_sha: str, head_sha: str) -> str
         check=True,
         text=True,
         capture_output=True,
+        env=git_environment(),
+        timeout=30,
     )
     paths = [line for line in result.stdout.splitlines() if line]
     if not paths:
         return ""
     if paths != ["changelogs/release-preparation.json"]:
-        fail("release preparation change is ambiguous")
+        fail("ambiguous change")
     try:
         receipt_relative = Path("changelogs/release-preparation.json")
         receipt_path = root / receipt_relative
@@ -158,10 +164,10 @@ def changed_preparation_version(root: Path, base_sha: str, head_sha: str) -> str
     except CONTRACT.ContractError as exc:
         raise ClassificationError(str(exc)) from exc
     if receipt_path.read_bytes() != CONTRACT.canonical_document_bytes(receipt):
-        fail("release preparation receipt is not canonical JSON")
+        fail("receipt not canonical")
     version = receipt.get("next_version")
     if not isinstance(version, str) or SEMVER.fullmatch(version) is None:
-        fail("release preparation receipt has no stable next version")
+        fail("invalid next version")
     return version
 
 
@@ -184,15 +190,17 @@ def changed_security_versions(root: Path, base_sha: str, head_sha: str) -> list[
         check=True,
         text=True,
         capture_output=True,
+        env=git_environment(),
+        timeout=30,
     )
     versions: list[str] = []
     for raw in result.stdout.splitlines():
         match = METADATA_PATH.fullmatch(raw)
         if match is None:
-            fail("Security release metadata change has an invalid path")
+            fail("invalid metadata path")
         versions.append(match.group(1))
     if len(versions) > 1 or len(versions) != len(set(versions)):
-        fail("an event may bind at most one Security release metadata file")
+        fail("multiple metadata files")
     return versions
 
 
@@ -202,7 +210,7 @@ def classify(args: argparse.Namespace, root: Path, checked_at: datetime) -> Clas
     if args.event_kind == "version":
         if not args.version:
             if args.evidence_id:
-                fail("Security evidenceId requires an exact version")
+                fail("evidenceId needs a version")
             return Classification(False)
         return classify_version(
             root,
@@ -229,7 +237,7 @@ def classify(args: argparse.Namespace, root: Path, checked_at: datetime) -> Clas
             return Classification(False)
         versions = changed_security_versions(root, args.base_sha, args.head_sha)
         if len(versions) != 1:
-            fail("Security release branch must change exactly one metadata file")
+            fail("metadata mismatch")
         # The intake PR creates the binding; its signed App receipt verifies the candidate diff.
         return classify_version(
             root,

--- a/scripts/classify-security-release.py
+++ b/scripts/classify-security-release.py
@@ -148,9 +148,11 @@ def changed_preparation_version(root: Path, base_sha: str, head_sha: str) -> str
     if paths != ["changelogs/release-preparation.json"]:
         fail("release preparation change is ambiguous")
     try:
-        receipt_path = root / "changelogs/release-preparation.json"
+        receipt_relative = Path("changelogs/release-preparation.json")
+        receipt_path = root / receipt_relative
         receipt = CONTRACT.load_json_file(
-            receipt_path,
+            root,
+            receipt_relative,
             "release preparation receipt",
         )
     except CONTRACT.ContractError as exc:

--- a/scripts/classify-security-release.py
+++ b/scripts/classify-security-release.py
@@ -7,35 +7,23 @@ import json
 import os
 import re
 import subprocess
+import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import security_release_contract as CONTRACT  # noqa: E402
 
 SEMVER = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 SHA = re.compile(r"^[0-9a-f]{40}$")
 EVIDENCE_ID = re.compile(r"^MLX90-[A-Z0-9][A-Z0-9._-]{2,127}$")
-SECURITY_ID = re.compile(r"^(?:CVE-[0-9]{4}-[0-9]{4,}|GHSA-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4}-[23456789cfghjmpqrvwx]{4})$")
-PROFILE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{2,127}$")
 METADATA_PATH = re.compile(r"^\.lit/security-releases/([0-9]+\.[0-9]+\.[0-9]+)\.json$")
 RELEASE_BRANCH = re.compile(r"^release/v([0-9]+\.[0-9]+\.[0-9]+)$")
 SECURITY_BRANCH = re.compile(r"^security-release/(MLX90-[A-Z0-9][A-Z0-9._-]{2,127})$")
 PREPARE_TITLE = re.compile(r"(?:^|\n)chore\(release\): prepare v([0-9]+\.[0-9]+\.[0-9]+)(?:$|\n)")
-PRODUCER = "lightning-it/ansible-collection-supplementary"
-CONSUMER = "lightning-it/container-ee-wunder-ansible-ubi9"
-METADATA_KEYS = {
-    "schemaVersion",
-    "evidenceId",
-    "createdAt",
-    "securityIdentifiers",
-    "affectedVersion",
-    "fixedVersion",
-    "consumers",
-    "acceptanceProfile",
-    "validity",
-}
-VALIDITY_KEYS = {"notBefore", "expiresAt", "revoked"}
 
 
 class ClassificationError(ValueError):
@@ -49,7 +37,7 @@ class Classification:
     version: str = ""
 
 
-def fail(message: str) -> None:
+def fail(message: str) -> NoReturn:
     raise ClassificationError(message)
 
 
@@ -62,24 +50,7 @@ def timestamp(value: Any, field: str) -> datetime:
         raise ClassificationError(f"{field} must be RFC3339") from exc
     if parsed.tzinfo is None:
         fail(f"{field} must include a timezone")
-    return parsed.astimezone(timezone.utc)
-
-
-def load_json(path: Path, label: str) -> dict[str, Any]:
-    if not path.is_file() or path.is_symlink():
-        fail(f"{label} must be a regular file")
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
-        raise ClassificationError(f"{label} is not valid UTF-8 JSON") from exc
-    if not isinstance(payload, dict):
-        fail(f"{label} must be a JSON object")
-    return payload
-
-
-def exact_keys(payload: dict[str, Any], expected: set[str], label: str) -> None:
-    if set(payload) != expected:
-        fail(f"{label} has unexpected or missing fields")
+    return parsed.astimezone(UTC)
 
 
 def is_regular_file_beneath(root: Path, relative: Path) -> bool:
@@ -106,91 +77,91 @@ def classify_version(
     if SEMVER.fullmatch(version) is None:
         fail("Security release version is not stable SemVer")
     metadata_path = root / ".lit" / "security-releases" / f"{version}.json"
-    if not metadata_path.exists():
+    intake_path = root / ".lit" / "security-release-intakes" / f"{version}.json"
+    metadata_exists = metadata_path.exists() or metadata_path.is_symlink()
+    intake_exists = intake_path.exists() or intake_path.is_symlink()
+    if metadata_exists != intake_exists:
+        fail("partial Security marker: metadata and intake receipt must exist together")
+    if not metadata_exists:
         if expected_evidence_id:
-            fail("claimed Security release metadata is missing")
+            fail("claimed Security release binding is missing")
         return Classification(False)
-
+    source = root
     if binding_root is not None:
+        source = binding_root
         for relative in (
             Path(".lit/security-releases") / f"{version}.json",
             Path(".lit/security-release-intakes") / f"{version}.json",
             Path(".lit/security-release-profiles.json"),
         ):
             current = root / relative
-            bound = binding_root / relative
+            bound = source / relative
             if (
                 not is_regular_file_beneath(root, relative)
-                or not is_regular_file_beneath(binding_root, relative)
+                or not is_regular_file_beneath(source, relative)
                 or current.read_bytes() != bound.read_bytes()
             ):
-                fail(
-                    "released Security binding differs from its "
-                    f"pre-consumption base: {relative}"
-                )
-
-    metadata = load_json(metadata_path, "Security release metadata")
-    exact_keys(metadata, METADATA_KEYS, "Security release metadata")
-    if metadata["schemaVersion"] != 1:
-        fail("Security release metadata schemaVersion must be 1")
-    evidence_id = metadata["evidenceId"]
-    if not isinstance(evidence_id, str) or EVIDENCE_ID.fullmatch(evidence_id) is None:
-        fail("Security release evidenceId is invalid")
+                fail(f"released Security binding differs from its pre-consumption base: {relative}")
+    try:
+        binding = CONTRACT.load_security_binding(source, version, checked_at=checked_at)
+    except CONTRACT.ContractError as exc:
+        raise ClassificationError(str(exc)) from exc
+    if binding is None:
+        fail("claimed Security release binding is unavailable")
+    evidence_id = binding["evidence_id"]
     if expected_evidence_id and evidence_id != expected_evidence_id:
         fail("Security release evidenceId does not match the event binding")
-    if metadata["fixedVersion"] != version:
-        fail("Security release fixedVersion does not match its path")
-    affected = metadata["affectedVersion"]
-    if not isinstance(affected, str) or SEMVER.fullmatch(affected) is None or affected == version:
-        fail("Security release affectedVersion is invalid")
-    identifiers = metadata["securityIdentifiers"]
-    if (
-        not isinstance(identifiers, list)
-        or not identifiers
-        or len(identifiers) != len(set(identifiers))
-        or any(not isinstance(item, str) or SECURITY_ID.fullmatch(item) is None for item in identifiers)
-    ):
-        fail("Security release identifiers are invalid")
-    if metadata["consumers"] != [CONSUMER]:
-        fail("Security release consumer allowlist is invalid")
-    profile_id = metadata["acceptanceProfile"]
-    if not isinstance(profile_id, str) or PROFILE_ID.fullmatch(profile_id) is None:
-        fail("Security release acceptanceProfile is invalid")
-
-    profiles = load_json(
-        root / ".lit" / "security-release-profiles.json",
-        "Security release profile registry",
-    )
-    exact_keys(profiles, {"schemaVersion", "profiles"}, "Security release profile registry")
-    if profiles["schemaVersion"] != 1 or not isinstance(profiles["profiles"], dict):
-        fail("Security release profile registry is unsupported")
-    profile = profiles["profiles"].get(profile_id)
-    if not isinstance(profile, dict) or profile.get("releaseEligible") is not True:
-        fail("Security release acceptanceProfile is not release eligible")
-
-    validity = metadata["validity"]
-    if not isinstance(validity, dict):
-        fail("Security release validity must be an object")
-    exact_keys(validity, VALIDITY_KEYS, "Security release validity")
-    if validity["revoked"] is not False:
-        fail("Security release metadata is revoked")
-    created_at = timestamp(metadata["createdAt"], "createdAt")
-    not_before = timestamp(validity["notBefore"], "validity.notBefore")
-    expires_at = timestamp(validity["expiresAt"], "validity.expiresAt")
-    if not_before > created_at or created_at >= expires_at:
-        fail("Security release createdAt is outside its validity interval")
-    if checked_at < not_before or checked_at >= expires_at:
-        fail("Security release metadata is not currently valid")
     return Classification(True, evidence_id, version)
+
+
+def changed_preparation_version(root: Path, base_sha: str, head_sha: str) -> str:
+    for label, value in (("base SHA", base_sha), ("head SHA", head_sha)):
+        if SHA.fullmatch(value) is None:
+            fail(f"{label} is invalid")
+    result = subprocess.run(  # noqa: S603
+        [
+            "/usr/bin/git",
+            "diff",
+            "--name-only",
+            "--no-renames",
+            base_sha,
+            head_sha,
+            "--",
+            "changelogs/release-preparation.json",
+        ],
+        cwd=root,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    paths = [line for line in result.stdout.splitlines() if line]
+    if not paths:
+        return ""
+    if paths != ["changelogs/release-preparation.json"]:
+        fail("release preparation change is ambiguous")
+    try:
+        receipt_path = root / "changelogs/release-preparation.json"
+        receipt = CONTRACT.load_json_file(
+            receipt_path,
+            "release preparation receipt",
+        )
+    except CONTRACT.ContractError as exc:
+        raise ClassificationError(str(exc)) from exc
+    if receipt_path.read_bytes() != CONTRACT.canonical_document_bytes(receipt):
+        fail("release preparation receipt is not canonical JSON")
+    version = receipt.get("next_version")
+    if not isinstance(version, str) or SEMVER.fullmatch(version) is None:
+        fail("release preparation receipt has no stable next version")
+    return version
 
 
 def changed_security_versions(root: Path, base_sha: str, head_sha: str) -> list[str]:
     for label, value in (("base SHA", base_sha), ("head SHA", head_sha)):
         if SHA.fullmatch(value) is None:
             fail(f"{label} is invalid")
-    result = subprocess.run(
+    result = subprocess.run(  # noqa: S603
         [
-            "git",
+            "/usr/bin/git",
             "diff",
             "--name-only",
             "--diff-filter=AM",
@@ -216,7 +187,8 @@ def changed_security_versions(root: Path, base_sha: str, head_sha: str) -> list[
 
 
 def classify(args: argparse.Namespace, root: Path, checked_at: datetime) -> Classification:
-    binding_root = getattr(args, "binding_root", None)
+    requested_binding_root = getattr(args, "binding_root", None)
+    binding_root = requested_binding_root
     if args.event_kind == "version":
         if not args.version:
             if args.evidence_id:
@@ -248,7 +220,14 @@ def classify(args: argparse.Namespace, root: Path, checked_at: datetime) -> Clas
         versions = changed_security_versions(root, args.base_sha, args.head_sha)
         if len(versions) != 1:
             fail("Security release branch must change exactly one metadata file")
-        return classify_version(root, versions[0], security.group(1), checked_at)
+        # The intake PR creates the binding; its signed App receipt verifies the candidate diff.
+        return classify_version(
+            root,
+            versions[0],
+            security.group(1),
+            checked_at,
+            None,
+        )
 
     if args.event_kind == "push":
         if args.ref != "refs/heads/main":
@@ -258,6 +237,15 @@ def classify(args: argparse.Namespace, root: Path, checked_at: datetime) -> Clas
             return classify_version(
                 root,
                 versions[0],
+                args.evidence_id,
+                checked_at,
+                binding_root,
+            )
+        prepared_version = changed_preparation_version(root, args.base_sha, args.head_sha)
+        if prepared_version:
+            return classify_version(
+                root,
+                prepared_version,
                 args.evidence_id,
                 checked_at,
                 binding_root,
@@ -305,11 +293,7 @@ def main() -> int:
     parser.add_argument("--binding-root", type=Path)
     parser.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT", ""))
     args = parser.parse_args()
-    checked_at = (
-        timestamp(args.checked_at, "--checked-at")
-        if args.checked_at
-        else datetime.now(timezone.utc)
-    )
+    checked_at = timestamp(args.checked_at, "--checked-at") if args.checked_at else datetime.now(UTC)
     try:
         result = classify(args, Path.cwd(), checked_at)
     except (ClassificationError, subprocess.CalledProcessError) as exc:

--- a/scripts/classify-security-release.py
+++ b/scripts/classify-security-release.py
@@ -6,6 +6,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -39,6 +40,13 @@ class Classification:
 
 def fail(message: str) -> NoReturn:
     raise ClassificationError(message)
+
+
+def git_binary() -> str:
+    executable = shutil.which("git")
+    if executable is None:
+        fail("git executable is unavailable")
+    return executable
 
 
 def timestamp(value: Any, field: str) -> datetime:
@@ -120,7 +128,7 @@ def changed_preparation_version(root: Path, base_sha: str, head_sha: str) -> str
             fail(f"{label} is invalid")
     result = subprocess.run(  # noqa: S603
         [
-            "/usr/bin/git",
+            git_binary(),
             "diff",
             "--name-only",
             "--no-renames",
@@ -161,7 +169,7 @@ def changed_security_versions(root: Path, base_sha: str, head_sha: str) -> list[
             fail(f"{label} is invalid")
     result = subprocess.run(  # noqa: S603
         [
-            "/usr/bin/git",
+            git_binary(),
             "diff",
             "--name-only",
             "--diff-filter=AM",

--- a/scripts/main-promotion-authorization.py
+++ b/scripts/main-promotion-authorization.py
@@ -7,16 +7,12 @@ import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, NoReturn
 
+from security_main_promotion import verify_promotion
 
 SHA = re.compile(r"^[0-9a-f]{40}$")
-SUPPLEMENTARY_SECURITY_BRANCH = re.compile(
-    r"^security-release/MLX90-[A-Z0-9][A-Z0-9._-]{2,127}$"
-)
-CONTAINER_SECURITY_BRANCH = re.compile(
-    r"^security/mlx90-(?:cleanup-)?[a-z0-9][a-z0-9._-]*$"
-)
+CONTAINER_SECURITY_BRANCH = re.compile(r"^security/mlx90-(?:cleanup-)?[a-z0-9][a-z0-9._-]*$")
 RELEASE_APP_LOGIN = "lightning-it-release-automation[bot]"
 RELEASE_APP_USER_ID = 307565056
 RELEASE_TEAM_ID = 15545798
@@ -45,7 +41,7 @@ class Authorization:
     head_ref: str
 
 
-def fail(message: str) -> None:
+def fail(message: str) -> NoReturn:
     raise AuthorizationError(message)
 
 
@@ -98,11 +94,7 @@ def validate_environment(payload: dict[str, Any], result: Authorization) -> None
         for rule in protection_rules
         if isinstance(rule, dict) and rule.get("type") == "required_reviewers"
     ]
-    wait_rules = [
-        rule
-        for rule in protection_rules
-        if isinstance(rule, dict) and rule.get("type") == "wait_timer"
-    ]
+    wait_rules = [rule for rule in protection_rules if isinstance(rule, dict) and rule.get("type") == "wait_timer"]
     if wait_rules:
         fail("live environment must not substitute a wait timer for authorization")
 
@@ -120,13 +112,8 @@ def validate_environment(payload: dict[str, Any], result: Authorization) -> None
     if not isinstance(reviewers, list) or len(reviewers) != 1:
         fail("normal promotion environment must have exactly one reviewer")
     reviewer = require_dict(reviewers[0], "environment reviewer")
-    reviewer_identity = require_dict(
-        reviewer.get("reviewer"), "environment reviewer identity"
-    )
-    if (
-        reviewer.get("type") != "BusinessTeam"
-        or reviewer_identity.get("id") != RELEASE_TEAM_ID
-    ):
+    reviewer_identity = require_dict(reviewer.get("reviewer"), "environment reviewer identity")
+    if reviewer.get("type") != "BusinessTeam" or reviewer_identity.get("id") != RELEASE_TEAM_ID:
         fail("normal promotion environment reviewer must be the release team")
 
 
@@ -135,6 +122,9 @@ def classify(
     repository: str,
     expected_base: str,
     expected_head: str,
+    *,
+    base_root: Path | None = None,
+    head_root: Path | None = None,
 ) -> Authorization:
     if repository not in ALLOWED_REPOSITORIES:
         fail("repository is outside the MLX-90 promotion allowlist")
@@ -164,23 +154,37 @@ def classify(
     if head_repository != repository:
         fail("cross-repository main promotion is not authorized")
 
-    reserved_security_prefix = False
-    security_branch = False
+    release_app = author_login == RELEASE_APP_LOGIN and author_id == RELEASE_APP_USER_ID and author_type == "Bot"
     if repository == SUPPLEMENTARY:
-        reserved_security_prefix = head_ref.startswith("security-release/")
-        security_branch = SUPPLEMENTARY_SECURITY_BRANCH.fullmatch(head_ref) is not None
-    elif repository == CONTAINER:
-        reserved_security_prefix = head_ref.startswith("security/mlx90-")
-        security_branch = CONTAINER_SECURITY_BRANCH.fullmatch(head_ref) is not None
+        reserved_release = head_ref.startswith("security-release/") or head_ref.startswith("release/")
+        if reserved_release:
+            if not release_app:
+                fail("Supplementary release promotion must be authored by the release App")
+            if base_root is None or head_root is None:
+                fail("Supplementary release promotion requires exact base and head checkouts")
+            try:
+                verified = verify_promotion(
+                    base_root=base_root,
+                    head_root=head_root,
+                    base_sha=expected_base,
+                    head_sha=expected_head,
+                    head_ref=head_ref,
+                )
+            except ValueError as exc:
+                raise AuthorizationError(str(exc)) from exc
+            return Authorization(
+                mode=verified.mode,
+                environment=(SECURITY_ENVIRONMENT if verified.mode == "security" else NORMAL_ENVIRONMENT),
+                head_sha=head_sha,
+                head_ref=head_ref,
+            )
+        if head_ref != "develop":
+            fail("normal Supplementary main promotion must originate from develop")
 
-    if reserved_security_prefix:
-        if not security_branch:
+    elif repository == CONTAINER and head_ref.startswith("security/mlx90-"):
+        if CONTAINER_SECURITY_BRANCH.fullmatch(head_ref) is None:
             fail("reserved MLX-90 Security branch name is malformed")
-        if (
-            author_login != RELEASE_APP_LOGIN
-            or author_id != RELEASE_APP_USER_ID
-            or author_type != "Bot"
-        ):
+        if not release_app:
             fail("MLX-90 Security promotion must be authored by the release App")
         return Authorization(
             mode="security",
@@ -188,6 +192,9 @@ def classify(
             head_sha=head_sha,
             head_ref=head_ref,
         )
+
+    elif head_ref != "develop":
+        fail("normal main promotion must originate from develop")
 
     return Authorization(
         mode="normal",
@@ -221,6 +228,8 @@ def main() -> int:
     parser.add_argument("--repository", required=True)
     parser.add_argument("--expected-base", required=True)
     parser.add_argument("--expected-head", required=True)
+    parser.add_argument("--base-root", type=Path)
+    parser.add_argument("--head-root", type=Path)
     parser.add_argument("--expected-mode", choices=("normal", "security"))
     parser.add_argument("--github-output", type=Path)
     args = parser.parse_args()
@@ -230,6 +239,8 @@ def main() -> int:
             args.repository,
             args.expected_base,
             args.expected_head,
+            base_root=args.base_root.resolve() if args.base_root else None,
+            head_root=args.head_root.resolve() if args.head_root else None,
         )
         if args.expected_mode is not None and result.mode != args.expected_mode:
             fail("live promotion mode changed after environment authorization")

--- a/scripts/modulix-validation-receipt.py
+++ b/scripts/modulix-validation-receipt.py
@@ -58,7 +58,11 @@ ARTIFACT_RE = re.compile(
 )
 EVIDENCE_ID_RE = re.compile(r"MLX90-[A-Z0-9][A-Z0-9._-]{2,121}\Z")
 NEXUS_REPOSITORY_RE = re.compile(r"[a-z0-9][a-z0-9._-]{0,126}\Z")
-DEFAULT_TIMEOUT_SECONDS = 10_200
+# The controller executes validation, Nexus readback, the Heavy and Application
+# matrices in parallel, then signs its receipt.  Keep the bounded Producer wait
+# below the 360-minute publish-job limit while covering the controller's full
+# 255-minute execution budget plus queue/startup allowance.
+DEFAULT_TIMEOUT_SECONDS = 16_200
 DEFAULT_POLL_SECONDS = 10
 COMMAND_TIMEOUT_SECONDS = 120
 
@@ -244,35 +248,25 @@ def build_request(
 
 
 class ControllerClient(Protocol):
-    def installation(self) -> dict[str, Any]:
-        ...
+    def installation(self) -> dict[str, Any]: ...
 
-    def installation_repositories(self) -> list[str]:
-        ...
+    def installation_repositories(self) -> list[str]: ...
 
-    def controller_sha(self) -> str:
-        ...
+    def controller_sha(self) -> str: ...
 
-    def workflow(self) -> dict[str, Any]:
-        ...
+    def workflow(self) -> dict[str, Any]: ...
 
-    def dispatch(self, request_json: str, request_id: str) -> None:
-        ...
+    def dispatch(self, request_json: str, request_id: str) -> None: ...
 
-    def workflow_runs(self) -> list[dict[str, Any]]:
-        ...
+    def workflow_runs(self) -> list[dict[str, Any]]: ...
 
-    def jobs(self, run_id: int) -> list[dict[str, Any]]:
-        ...
+    def jobs(self, run_id: int) -> list[dict[str, Any]]: ...
 
-    def artifacts(self, run_id: int) -> list[dict[str, Any]]:
-        ...
+    def artifacts(self, run_id: int) -> list[dict[str, Any]]: ...
 
-    def download(self, run_id: int, artifact_name: str, destination: Path) -> None:
-        ...
+    def download(self, run_id: int, artifact_name: str, destination: Path) -> None: ...
 
-    def verify_signature(self, receipt: Path, bundle: Path, controller_sha: str) -> None:
-        ...
+    def verify_signature(self, receipt: Path, bundle: Path, controller_sha: str) -> None: ...
 
 
 class GhControllerClient:
@@ -688,9 +682,7 @@ def main() -> int:
         dispatch_if_absent(client, request_json, request_id, controller_sha)
         run = wait_for_run(client, request_id, controller_sha, args.timeout_seconds)
         validate_run_jobs(client.jobs(positive_integer(run.get("id"), "controller run ID")))
-        receipt_path = download_and_verify_receipt(
-            client, request, request_id, run, args.output_directory
-        )[0]
+        receipt_path = download_and_verify_receipt(client, request, request_id, run, args.output_directory)[0]
     except ReceiptError as exc:
         parser.error(str(exc))
 

--- a/scripts/modulix-validation-receipt.py
+++ b/scripts/modulix-validation-receipt.py
@@ -248,25 +248,35 @@ def build_request(
 
 
 class ControllerClient(Protocol):
-    def installation(self) -> dict[str, Any]: ...
+    def installation(self) -> dict[str, Any]:
+        raise NotImplementedError
 
-    def installation_repositories(self) -> list[str]: ...
+    def installation_repositories(self) -> list[str]:
+        raise NotImplementedError
 
-    def controller_sha(self) -> str: ...
+    def controller_sha(self) -> str:
+        raise NotImplementedError
 
-    def workflow(self) -> dict[str, Any]: ...
+    def workflow(self) -> dict[str, Any]:
+        raise NotImplementedError
 
-    def dispatch(self, request_json: str, request_id: str) -> None: ...
+    def dispatch(self, request_json: str, request_id: str) -> None:
+        raise NotImplementedError
 
-    def workflow_runs(self) -> list[dict[str, Any]]: ...
+    def workflow_runs(self) -> list[dict[str, Any]]:
+        raise NotImplementedError
 
-    def jobs(self, run_id: int) -> list[dict[str, Any]]: ...
+    def jobs(self, run_id: int) -> list[dict[str, Any]]:
+        raise NotImplementedError
 
-    def artifacts(self, run_id: int) -> list[dict[str, Any]]: ...
+    def artifacts(self, run_id: int) -> list[dict[str, Any]]:
+        raise NotImplementedError
 
-    def download(self, run_id: int, artifact_name: str, destination: Path) -> None: ...
+    def download(self, run_id: int, artifact_name: str, destination: Path) -> None:
+        raise NotImplementedError
 
-    def verify_signature(self, receipt: Path, bundle: Path, controller_sha: str) -> None: ...
+    def verify_signature(self, receipt: Path, bundle: Path, controller_sha: str) -> None:
+        raise NotImplementedError
 
 
 class GhControllerClient:

--- a/scripts/security_main_promotion.py
+++ b/scripts/security_main_promotion.py
@@ -111,13 +111,13 @@ def require_checkout(root: Path, expected_sha: str, label: str) -> None:
 def require_app_commit(head_root: Path, base_sha: str, head_sha: str, message: str) -> None:
     parents = git_text(head_root, "show", "-s", "--format=%P", head_sha).split()
     if parents != [base_sha]:
-        fail("promotion head must have the exact protected-main commit as its sole parent")
+        fail("promotion parent mismatch")
     expected_identity = f"{CONTRACT.RELEASE_APP_LOGIN} <{CONTRACT.RELEASE_APP_EMAIL}>"
     for field, label in (("%an <%ae>", "author"), ("%cn <%ce>", "committer")):
         if git_text(head_root, "show", "-s", f"--format={field}", head_sha) != expected_identity:
             fail(f"promotion commit {label} is not the release App")
     if git_text(head_root, "show", "-s", "--format=%B", head_sha) != message:
-        fail("promotion commit message differs from the deterministic contract")
+        fail("promotion message mismatch")
 
 
 def changed_paths(root: Path, base_sha: str, head_sha: str) -> list[tuple[str, str]]:
@@ -136,7 +136,7 @@ def changed_paths(root: Path, base_sha: str, head_sha: str) -> list[tuple[str, s
     if fields and fields[-1] == b"":
         fields.pop()
     if len(fields) % 2:
-        fail("promotion diff returned malformed path status data")
+        fail("malformed promotion diff")
     result: list[tuple[str, str]] = []
     for index in range(0, len(fields), 2):
         try:
@@ -145,7 +145,7 @@ def changed_paths(root: Path, base_sha: str, head_sha: str) -> list[tuple[str, s
         except UnicodeDecodeError as exc:
             raise PromotionError("promotion diff contains a non-UTF-8 path") from exc
         if status not in {"A", "D", "M", "T"} or not path or path.startswith("/"):
-            fail("promotion diff contains an unsupported path transition")
+            fail("unsupported promotion path transition")
         result.append((status, path))
     if not result:
         fail("promotion diff is empty")
@@ -189,17 +189,17 @@ def candidate_diff_without_receipt(
         f":(exclude){receipt_path}",
     )
     if not value:
-        fail("materialized Security candidate diff is empty")
+        fail("Security candidate diff is empty")
     return value
 
 
 def load_release_version_module(base_root: Path) -> ModuleType:
     path = base_root / "scripts" / "release-version.py"
     if path.is_symlink() or not path.is_file():
-        fail("protected-main release-version policy is unavailable")
+        fail("release-version policy unavailable")
     spec = importlib.util.spec_from_file_location("mlx90_release_version", path)
     if spec is None or spec.loader is None:
-        fail("protected-main release-version policy cannot be loaded")
+        fail("release-version policy load failed")
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
@@ -241,7 +241,7 @@ def verify_intake_promotion(
         if INTAKE_RECEIPT.fullmatch(path) is not None
     ]
     if len(receipts) != 1 or receipts[0][0] != "A" or receipts[0][2] is None:
-        fail("Security intake promotion must add exactly one immutable intake receipt")
+        fail("Security intake receipt count mismatch")
     receipt_path = receipts[0][1]
     receipt = load_canonical_document(
         head_root,
@@ -263,14 +263,14 @@ def verify_intake_promotion(
         or verified["branch"] != head_ref
         or request["fixedVersion"] != receipts[0][2].group(1)
     ):
-        fail("Security intake receipt does not bind the exact promotion branch and base")
+        fail("Security intake branch/base mismatch")
     CONTRACT.validate_request(request, CONTRACT.PRODUCER_REPOSITORY, checked_at)
     non_receipt_paths = sorted(path for _status, path in changes if path != receipt_path)
     if non_receipt_paths != verified["changedPaths"]:
-        fail("materialized Security promotion paths differ from the verified candidate")
+        fail("Security promotion paths differ from the verified candidate")
     materialized = candidate_diff_without_receipt(head_root, base_sha, head_sha, receipt_path)
     if CONTRACT.sha256_bytes(materialized) != request["candidateDiffSha256"]:
-        fail("materialized Security promotion diff differs from the approved candidate")
+        fail("Security promotion diff differs from the approved candidate")
     require_app_commit(
         head_root,
         base_sha,
@@ -289,13 +289,13 @@ def verify_intake_promotion(
 
 def galaxy_version(path: Path) -> str:
     if path.is_symlink() or not path.is_file():
-        fail("release promotion galaxy.yml must be a regular file")
+        fail("galaxy.yml is not a regular file")
     matches: list[str] = re.findall(
         r"(?m)^version:\s*[\"']?([^\s\"']+)[\"']?\s*$",
         path.read_text(encoding="utf-8"),
     )
     if len(matches) != 1:
-        fail("release promotion galaxy.yml has no unique version")
+        fail("galaxy.yml version is ambiguous")
     return matches[0]
 
 
@@ -333,12 +333,12 @@ def verify_release_promotion(
     if mode not in {"normal", "security"}:
         fail("release preparation mode is unsupported")
     if galaxy_version(head_root / "galaxy.yml") != version:
-        fail("release branch version differs from its exact galaxy.yml")
+        fail("release branch/version mismatch")
 
     changes = changed_paths(head_root, base_sha, head_sha)
     changed = {path: status for status, path in changes}
     if PREPARATION_RECEIPT.as_posix() not in changed or "galaxy.yml" not in changed:
-        fail("release promotion is missing required generated state")
+        fail("generated release state missing")
     fragment_paths = {
         f"changelogs/fragments/{fragment['path']}"
         for fragment in receipt.get("fragments", [])
@@ -347,11 +347,11 @@ def verify_release_promotion(
     allowed = RELEASE_GENERATED_PATHS | fragment_paths
     unexpected = sorted(set(changed) - allowed)
     if unexpected:
-        fail(f"release promotion contains non-generated paths: {unexpected}")
+        fail(f"non-generated release paths: {unexpected}")
     if any(changed.get(path) != "D" for path in fragment_paths):
-        fail("release promotion did not consume exactly the reviewed changelog fragments")
+        fail("reviewed fragments not consumed")
     if any(path.startswith(".lit/security-") for path in changed):
-        fail("release promotion may not mutate immutable Security bindings")
+        fail("immutable Security bindings changed")
     require_app_commit(
         head_root,
         base_sha,
@@ -360,11 +360,11 @@ def verify_release_promotion(
     )
     if mode == "normal":
         if receipt.get("chain_id") is not None or receipt.get("security") is not None:
-            fail("normal release promotion contains partial Security binding")
+            fail("partial Security binding")
         return Promotion(mode="normal", head_ref=head_ref, head_sha=head_sha, version=version)
     security = receipt.get("security")
     if not isinstance(security, dict):
-        fail("Security release promotion has no immutable Security binding")
+        fail("Security binding missing")
     return Promotion(
         mode="security",
         head_ref=head_ref,
@@ -405,7 +405,7 @@ def verify_promotion(
             head_ref,
             checked_at,
         )
-    fail("head ref is not a reserved Supplementary release promotion")
+    fail("unsupported promotion head")
 
 
 def main() -> int:

--- a/scripts/security_main_promotion.py
+++ b/scripts/security_main_promotion.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Verify an exact Supplementary main-promotion head without trusting its name."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from types import ModuleType
+from typing import Any, NoReturn, cast
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import security_release_contract as CONTRACT  # noqa: E402
+
+SHA = re.compile(r"^[0-9a-f]{40}$")
+SECURITY_BRANCH = re.compile(r"^security-release/(MLX90-[A-Z0-9][A-Z0-9._-]{2,127})$")
+RELEASE_BRANCH = re.compile(r"^release/v((?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))$")
+INTAKE_RECEIPT = re.compile(
+    r"^\.lit/security-release-intakes/((?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*))\.json$"
+)
+PREPARATION_RECEIPT = Path("changelogs/release-preparation.json")
+RELEASE_GENERATED_PATHS = {
+    "CHANGELOG.rst",
+    "changelogs/.plugin-cache.yaml",
+    "changelogs/changelog.yaml",
+    PREPARATION_RECEIPT.as_posix(),
+    "galaxy.yml",
+}
+
+
+class PromotionError(ValueError):
+    """Raised when a main-promotion head is not an exact authorized state."""
+
+
+@dataclass(frozen=True)
+class Promotion:
+    mode: str
+    head_ref: str
+    head_sha: str
+    chain_id: str | None = None
+    evidence_id: str | None = None
+    version: str | None = None
+
+
+def fail(message: str) -> NoReturn:
+    raise PromotionError(message)
+
+
+def git_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for variable in ("GIT_COMMON_DIR", "GIT_DIR", "GIT_WORK_TREE"):
+        environment.pop(variable, None)
+    return environment
+
+
+def git_binary() -> str:
+    executable = shutil.which("git")
+    if executable is None:
+        fail("git executable is unavailable")
+    return executable
+
+
+def run_git(root: Path, *args: str, text: bool = False) -> bytes | str:
+    try:
+        result = subprocess.run(  # noqa: S603 -- all revisions are exact validated SHAs.
+            [git_binary(), *args],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=text,
+            env=git_environment(),
+            timeout=30,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr if isinstance(exc.stderr, str) else exc.stderr.decode("utf-8", errors="replace")
+        raise PromotionError(f"git {' '.join(args)} failed: {stderr.strip()}") from exc
+    return cast("bytes | str", result.stdout)
+
+
+def git_text(root: Path, *args: str) -> str:
+    value = run_git(root, *args, text=True)
+    assert isinstance(value, str)
+    return value.strip()
+
+
+def git_bytes(root: Path, *args: str) -> bytes:
+    value = run_git(root, *args)
+    assert isinstance(value, bytes)
+    return value
+
+
+def require_checkout(root: Path, expected_sha: str, label: str) -> None:
+    if root.is_symlink() or not root.is_dir():
+        fail(f"{label} checkout must be a regular directory")
+    if SHA.fullmatch(expected_sha) is None:
+        fail(f"{label} SHA is invalid")
+    if git_text(root, "rev-parse", "HEAD") != expected_sha:
+        fail(f"{label} checkout is not the exact expected revision")
+    if git_text(root, "cat-file", "-t", expected_sha) != "commit":
+        fail(f"{label} revision is not a commit")
+
+
+def require_app_commit(head_root: Path, base_sha: str, head_sha: str, message: str) -> None:
+    parents = git_text(head_root, "show", "-s", "--format=%P", head_sha).split()
+    if parents != [base_sha]:
+        fail("promotion head must have the exact protected-main commit as its sole parent")
+    expected_identity = f"{CONTRACT.RELEASE_APP_LOGIN} <{CONTRACT.RELEASE_APP_EMAIL}>"
+    for field, label in (("%an <%ae>", "author"), ("%cn <%ce>", "committer")):
+        if git_text(head_root, "show", "-s", f"--format={field}", head_sha) != expected_identity:
+            fail(f"promotion commit {label} is not the release App")
+    if git_text(head_root, "show", "-s", "--format=%B", head_sha) != message:
+        fail("promotion commit message differs from the deterministic contract")
+
+
+def changed_paths(root: Path, base_sha: str, head_sha: str) -> list[tuple[str, str]]:
+    raw = git_bytes(
+        root,
+        "diff",
+        "--name-status",
+        "-z",
+        "--no-renames",
+        base_sha,
+        head_sha,
+        "--",
+        ".",
+    )
+    fields = raw.split(b"\0")
+    if fields and fields[-1] == b"":
+        fields.pop()
+    if len(fields) % 2:
+        fail("promotion diff returned malformed path status data")
+    result: list[tuple[str, str]] = []
+    for index in range(0, len(fields), 2):
+        try:
+            status = fields[index].decode("ascii")
+            path = fields[index + 1].decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise PromotionError("promotion diff contains a non-UTF-8 path") from exc
+        if status not in {"A", "D", "M", "T"} or not path or path.startswith("/"):
+            fail("promotion diff contains an unsupported path transition")
+        result.append((status, path))
+    if not result:
+        fail("promotion diff is empty")
+    return result
+
+
+def candidate_diff_without_receipt(
+    root: Path,
+    base_sha: str,
+    head_sha: str,
+    receipt_path: str,
+) -> bytes:
+    value = git_bytes(
+        root,
+        "-c",
+        "core.safecrlf=false",
+        "-c",
+        "core.attributesFile=/dev/null",
+        "-c",
+        "diff.renames=false",
+        "-c",
+        "diff.algorithm=myers",
+        "-c",
+        "diff.indentHeuristic=false",
+        "diff",
+        "--binary",
+        "--full-index",
+        "--no-color",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-renames",
+        "--diff-algorithm=myers",
+        "--no-indent-heuristic",
+        "--unified=3",
+        "--src-prefix=a/",
+        "--dst-prefix=b/",
+        base_sha,
+        head_sha,
+        "--",
+        ".",
+        f":(exclude){receipt_path}",
+    )
+    if not value:
+        fail("materialized Security candidate diff is empty")
+    return value
+
+
+def load_release_version_module(base_root: Path) -> ModuleType:
+    path = base_root / "scripts" / "release-version.py"
+    if path.is_symlink() or not path.is_file():
+        fail("protected-main release-version policy is unavailable")
+    spec = importlib.util.spec_from_file_location("mlx90_release_version", path)
+    if spec is None or spec.loader is None:
+        fail("protected-main release-version policy cannot be loaded")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_canonical_document(
+    root: Path,
+    relative_path: Path,
+    label: str,
+) -> dict[str, Any]:
+    raw = CONTRACT.read_bounded_regular_file(
+        root,
+        relative_path,
+        label,
+        CONTRACT.MAX_JSON_BYTES,
+    )
+    payload = CONTRACT.load_json_bytes(raw, label)
+    if raw != CONTRACT.canonical_document_bytes(payload):
+        fail(f"{label} is not canonical JSON")
+    return payload
+
+
+def verify_intake_promotion(
+    base_root: Path,
+    head_root: Path,
+    base_sha: str,
+    head_sha: str,
+    head_ref: str,
+    checked_at: datetime,
+) -> Promotion:
+    match = SECURITY_BRANCH.fullmatch(head_ref)
+    if match is None:
+        fail("reserved Security intake branch name is malformed")
+    changes = changed_paths(head_root, base_sha, head_sha)
+    receipts = [
+        (status, path, INTAKE_RECEIPT.fullmatch(path))
+        for status, path in changes
+        if INTAKE_RECEIPT.fullmatch(path) is not None
+    ]
+    if len(receipts) != 1 or receipts[0][0] != "A" or receipts[0][2] is None:
+        fail("Security intake promotion must add exactly one immutable intake receipt")
+    receipt_path = receipts[0][1]
+    receipt = load_canonical_document(
+        head_root,
+        Path(receipt_path),
+        "Security intake receipt",
+    )
+    try:
+        CONTRACT.verify_intake_receipt(receipt, checked_at=checked_at)
+    except CONTRACT.ContractError as exc:
+        raise PromotionError(str(exc)) from exc
+    request = receipt["request"]
+    verified = receipt["verified"]
+    if (
+        request["baseSha"] != base_sha
+        or request["candidateBaseSha"] != base_sha
+        or verified["baseSha"] != base_sha
+        or request["evidenceId"] != match.group(1)
+        or verified["evidenceId"] != match.group(1)
+        or verified["branch"] != head_ref
+        or request["fixedVersion"] != receipts[0][2].group(1)
+    ):
+        fail("Security intake receipt does not bind the exact promotion branch and base")
+    CONTRACT.validate_request(request, CONTRACT.PRODUCER_REPOSITORY, checked_at)
+    non_receipt_paths = sorted(path for _status, path in changes if path != receipt_path)
+    if non_receipt_paths != verified["changedPaths"]:
+        fail("materialized Security promotion paths differ from the verified candidate")
+    materialized = candidate_diff_without_receipt(head_root, base_sha, head_sha, receipt_path)
+    if CONTRACT.sha256_bytes(materialized) != request["candidateDiffSha256"]:
+        fail("materialized Security promotion diff differs from the approved candidate")
+    require_app_commit(
+        head_root,
+        base_sha,
+        head_sha,
+        f"fix(security): {request['evidenceId']}",
+    )
+    return Promotion(
+        mode="security",
+        head_ref=head_ref,
+        head_sha=head_sha,
+        chain_id=request["chainId"],
+        evidence_id=request["evidenceId"],
+        version=request["fixedVersion"],
+    )
+
+
+def galaxy_version(path: Path) -> str:
+    if path.is_symlink() or not path.is_file():
+        fail("release promotion galaxy.yml must be a regular file")
+    matches: list[str] = re.findall(
+        r"(?m)^version:\s*[\"']?([^\s\"']+)[\"']?\s*$",
+        path.read_text(encoding="utf-8"),
+    )
+    if len(matches) != 1:
+        fail("release promotion galaxy.yml has no unique version")
+    return matches[0]
+
+
+def verify_release_promotion(
+    base_root: Path,
+    head_root: Path,
+    base_sha: str,
+    head_sha: str,
+    head_ref: str,
+    checked_at: datetime,
+) -> Promotion:
+    match = RELEASE_BRANCH.fullmatch(head_ref)
+    if match is None:
+        fail("reserved release branch name is malformed")
+    version = match.group(1)
+    receipt = load_canonical_document(
+        head_root,
+        PREPARATION_RECEIPT,
+        "release preparation receipt",
+    )
+    module = load_release_version_module(base_root)
+    try:
+        module.verify_preparation_receipt(
+            receipt,
+            expected_repository=CONTRACT.PRODUCER_REPOSITORY,
+            expected_repository_id=CONTRACT.PRODUCER_REPOSITORY_ID,
+            expected_base_sha=base_sha,
+            expected_version=version,
+            root=base_root,
+            checked_at=checked_at,
+        )
+    except (ValueError, CONTRACT.ContractError) as exc:
+        raise PromotionError(str(exc)) from exc
+    mode = receipt.get("release_mode")
+    if mode not in {"normal", "security"}:
+        fail("release preparation mode is unsupported")
+    if galaxy_version(head_root / "galaxy.yml") != version:
+        fail("release branch version differs from its exact galaxy.yml")
+
+    changes = changed_paths(head_root, base_sha, head_sha)
+    changed = {path: status for status, path in changes}
+    if PREPARATION_RECEIPT.as_posix() not in changed or "galaxy.yml" not in changed:
+        fail("release promotion is missing required generated state")
+    fragment_paths = {
+        f"changelogs/fragments/{fragment['path']}"
+        for fragment in receipt.get("fragments", [])
+        if isinstance(fragment, dict) and isinstance(fragment.get("path"), str)
+    }
+    allowed = RELEASE_GENERATED_PATHS | fragment_paths
+    unexpected = sorted(set(changed) - allowed)
+    if unexpected:
+        fail(f"release promotion contains non-generated paths: {unexpected}")
+    if any(changed.get(path) != "D" for path in fragment_paths):
+        fail("release promotion did not consume exactly the reviewed changelog fragments")
+    if any(path.startswith(".lit/security-") for path in changed):
+        fail("release promotion may not mutate immutable Security bindings")
+    require_app_commit(
+        head_root,
+        base_sha,
+        head_sha,
+        f"chore(release): prepare v{version}",
+    )
+    if mode == "normal":
+        if receipt.get("chain_id") is not None or receipt.get("security") is not None:
+            fail("normal release promotion contains partial Security binding")
+        return Promotion(mode="normal", head_ref=head_ref, head_sha=head_sha, version=version)
+    security = receipt.get("security")
+    if not isinstance(security, dict):
+        fail("Security release promotion has no immutable Security binding")
+    return Promotion(
+        mode="security",
+        head_ref=head_ref,
+        head_sha=head_sha,
+        chain_id=receipt.get("chain_id"),
+        evidence_id=security.get("evidence_id"),
+        version=version,
+    )
+
+
+def verify_promotion(
+    *,
+    base_root: Path,
+    head_root: Path,
+    base_sha: str,
+    head_sha: str,
+    head_ref: str,
+    checked_at: datetime | None = None,
+) -> Promotion:
+    checked_at = checked_at or datetime.now(UTC)
+    require_checkout(base_root, base_sha, "protected-main base")
+    require_checkout(head_root, head_sha, "promotion head")
+    if SECURITY_BRANCH.fullmatch(head_ref) is not None or head_ref.startswith("security-release/"):
+        return verify_intake_promotion(
+            base_root,
+            head_root,
+            base_sha,
+            head_sha,
+            head_ref,
+            checked_at,
+        )
+    if RELEASE_BRANCH.fullmatch(head_ref) is not None or head_ref.startswith("release/"):
+        return verify_release_promotion(
+            base_root,
+            head_root,
+            base_sha,
+            head_sha,
+            head_ref,
+            checked_at,
+        )
+    fail("head ref is not a reserved Supplementary release promotion")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-root", type=Path, required=True)
+    parser.add_argument("--head-root", type=Path, required=True)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--head-ref", required=True)
+    parser.add_argument("--checked-at", default="")
+    args = parser.parse_args()
+    try:
+        checked_at = CONTRACT.timestamp(args.checked_at, "--checked-at") if args.checked_at else datetime.now(UTC)
+        result = verify_promotion(
+            base_root=args.base_root.resolve(),
+            head_root=args.head_root.resolve(),
+            base_sha=args.base_sha,
+            head_sha=args.head_sha,
+            head_ref=args.head_ref,
+            checked_at=checked_at,
+        )
+    except (PromotionError, CONTRACT.ContractError, OSError, UnicodeError) as exc:
+        parser.error(str(exc))
+    print(json.dumps(result.__dict__, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/security_main_promotion.py
+++ b/scripts/security_main_promotion.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Verify an exact Supplementary main-promotion head without trusting its name."""
 
 from __future__ import annotations

--- a/scripts/security_main_promotion.py
+++ b/scripts/security_main_promotion.py
@@ -1,5 +1,3 @@
-"""Verify an exact Supplementary main-promotion head without trusting its name."""
-
 from __future__ import annotations
 
 import argparse
@@ -37,7 +35,7 @@ RELEASE_GENERATED_PATHS = {
 
 
 class PromotionError(ValueError):
-    """Raised when a main-promotion head is not an exact authorized state."""
+    pass
 
 
 @dataclass(frozen=True)
@@ -64,7 +62,7 @@ def git_environment() -> dict[str, str]:
 def git_binary() -> str:
     executable = shutil.which("git")
     if executable is None:
-        fail("git executable is unavailable")
+        fail("git unavailable")
     return executable
 
 
@@ -99,25 +97,25 @@ def git_bytes(root: Path, *args: str) -> bytes:
 
 def require_checkout(root: Path, expected_sha: str, label: str) -> None:
     if root.is_symlink() or not root.is_dir():
-        fail(f"{label} checkout must be a regular directory")
+        fail(f"{label} checkout invalid")
     if SHA.fullmatch(expected_sha) is None:
         fail(f"{label} SHA is invalid")
     if git_text(root, "rev-parse", "HEAD") != expected_sha:
-        fail(f"{label} checkout is not the exact expected revision")
+        fail(f"{label} checkout mismatch")
     if git_text(root, "cat-file", "-t", expected_sha) != "commit":
-        fail(f"{label} revision is not a commit")
+        fail(f"{label} is not a commit")
 
 
 def require_app_commit(head_root: Path, base_sha: str, head_sha: str, message: str) -> None:
     parents = git_text(head_root, "show", "-s", "--format=%P", head_sha).split()
     if parents != [base_sha]:
-        fail("promotion parent mismatch")
+        fail("parent mismatch")
     expected_identity = f"{CONTRACT.RELEASE_APP_LOGIN} <{CONTRACT.RELEASE_APP_EMAIL}>"
     for field, label in (("%an <%ae>", "author"), ("%cn <%ce>", "committer")):
         if git_text(head_root, "show", "-s", f"--format={field}", head_sha) != expected_identity:
-            fail(f"promotion commit {label} is not the release App")
+            fail(f"{label} is not the release App")
     if git_text(head_root, "show", "-s", "--format=%B", head_sha) != message:
-        fail("promotion message mismatch")
+        fail("message mismatch")
 
 
 def changed_paths(root: Path, base_sha: str, head_sha: str) -> list[tuple[str, str]]:
@@ -136,19 +134,19 @@ def changed_paths(root: Path, base_sha: str, head_sha: str) -> list[tuple[str, s
     if fields and fields[-1] == b"":
         fields.pop()
     if len(fields) % 2:
-        fail("malformed promotion diff")
+        fail("malformed diff")
     result: list[tuple[str, str]] = []
     for index in range(0, len(fields), 2):
         try:
             status = fields[index].decode("ascii")
             path = fields[index + 1].decode("utf-8")
         except UnicodeDecodeError as exc:
-            raise PromotionError("promotion diff contains a non-UTF-8 path") from exc
+            raise PromotionError("non-UTF-8 promotion path") from exc
         if status not in {"A", "D", "M", "T"} or not path or path.startswith("/"):
-            fail("unsupported promotion path transition")
+            fail("unsupported path")
         result.append((status, path))
     if not result:
-        fail("promotion diff is empty")
+        fail("empty diff")
     return result
 
 
@@ -189,17 +187,17 @@ def candidate_diff_without_receipt(
         f":(exclude){receipt_path}",
     )
     if not value:
-        fail("Security candidate diff is empty")
+        fail("candidate diff empty")
     return value
 
 
 def load_release_version_module(base_root: Path) -> ModuleType:
     path = base_root / "scripts" / "release-version.py"
     if path.is_symlink() or not path.is_file():
-        fail("release-version policy unavailable")
+        fail("policy unavailable")
     spec = importlib.util.spec_from_file_location("mlx90_release_version", path)
     if spec is None or spec.loader is None:
-        fail("release-version policy load failed")
+        fail("invalid policy")
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
@@ -219,7 +217,7 @@ def load_canonical_document(
     )
     payload = CONTRACT.load_json_bytes(raw, label)
     if raw != CONTRACT.canonical_document_bytes(payload):
-        fail(f"{label} is not canonical JSON")
+        fail(f"{label} not canonical")
     return payload
 
 
@@ -233,7 +231,7 @@ def verify_intake_promotion(
 ) -> Promotion:
     match = SECURITY_BRANCH.fullmatch(head_ref)
     if match is None:
-        fail("reserved Security intake branch name is malformed")
+        fail("Security intake branch malformed")
     changes = changed_paths(head_root, base_sha, head_sha)
     receipts = [
         (status, path, INTAKE_RECEIPT.fullmatch(path))
@@ -241,7 +239,7 @@ def verify_intake_promotion(
         if INTAKE_RECEIPT.fullmatch(path) is not None
     ]
     if len(receipts) != 1 or receipts[0][0] != "A" or receipts[0][2] is None:
-        fail("Security intake receipt count mismatch")
+        fail("receipt count mismatch")
     receipt_path = receipts[0][1]
     receipt = load_canonical_document(
         head_root,
@@ -263,14 +261,14 @@ def verify_intake_promotion(
         or verified["branch"] != head_ref
         or request["fixedVersion"] != receipts[0][2].group(1)
     ):
-        fail("Security intake branch/base mismatch")
+        fail("branch/base mismatch")
     CONTRACT.validate_request(request, CONTRACT.PRODUCER_REPOSITORY, checked_at)
     non_receipt_paths = sorted(path for _status, path in changes if path != receipt_path)
     if non_receipt_paths != verified["changedPaths"]:
-        fail("Security promotion paths differ from the verified candidate")
+        fail("paths differ from the verified candidate")
     materialized = candidate_diff_without_receipt(head_root, base_sha, head_sha, receipt_path)
     if CONTRACT.sha256_bytes(materialized) != request["candidateDiffSha256"]:
-        fail("Security promotion diff differs from the approved candidate")
+        fail("diff mismatch")
     require_app_commit(
         head_root,
         base_sha,
@@ -289,13 +287,13 @@ def verify_intake_promotion(
 
 def galaxy_version(path: Path) -> str:
     if path.is_symlink() or not path.is_file():
-        fail("galaxy.yml is not a regular file")
+        fail("galaxy.yml invalid")
     matches: list[str] = re.findall(
         r"(?m)^version:\s*[\"']?([^\s\"']+)[\"']?\s*$",
         path.read_text(encoding="utf-8"),
     )
     if len(matches) != 1:
-        fail("galaxy.yml version is ambiguous")
+        fail("ambiguous galaxy version")
     return matches[0]
 
 
@@ -309,7 +307,7 @@ def verify_release_promotion(
 ) -> Promotion:
     match = RELEASE_BRANCH.fullmatch(head_ref)
     if match is None:
-        fail("reserved release branch name is malformed")
+        fail("branch malformed")
     version = match.group(1)
     receipt = load_canonical_document(
         head_root,
@@ -331,14 +329,14 @@ def verify_release_promotion(
         raise PromotionError(str(exc)) from exc
     mode = receipt.get("release_mode")
     if mode not in {"normal", "security"}:
-        fail("release preparation mode is unsupported")
+        fail("unsupported mode")
     if galaxy_version(head_root / "galaxy.yml") != version:
-        fail("release branch/version mismatch")
+        fail("branch/version mismatch")
 
     changes = changed_paths(head_root, base_sha, head_sha)
     changed = {path: status for status, path in changes}
     if PREPARATION_RECEIPT.as_posix() not in changed or "galaxy.yml" not in changed:
-        fail("generated release state missing")
+        fail("generated state missing")
     fragment_paths = {
         f"changelogs/fragments/{fragment['path']}"
         for fragment in receipt.get("fragments", [])
@@ -349,9 +347,9 @@ def verify_release_promotion(
     if unexpected:
         fail(f"non-generated release paths: {unexpected}")
     if any(changed.get(path) != "D" for path in fragment_paths):
-        fail("reviewed fragments not consumed")
+        fail("fragments not consumed")
     if any(path.startswith(".lit/security-") for path in changed):
-        fail("immutable Security bindings changed")
+        fail("Security bindings changed")
     require_app_commit(
         head_root,
         base_sha,
@@ -405,7 +403,7 @@ def verify_promotion(
             head_ref,
             checked_at,
         )
-    fail("unsupported promotion head")
+    fail("unsupported head")
 
 
 def main() -> int:

--- a/scripts/verify_release_back_sync.py
+++ b/scripts/verify_release_back_sync.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Verify one immutable App-authored release back-sync head."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+from typing import NoReturn, cast
+
+SHA = re.compile(r"^[0-9a-f]{40}$")
+SEMVER = re.compile(r"^(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)$")
+EVIDENCE_ID = re.compile(r"^MLX90-[A-Z0-9][A-Z0-9._-]{2,127}$")
+APP_IDENTITY = (
+    "lightning-it-release-automation[bot] <307565056+lightning-it-release-automation[bot]@users.noreply.github.com>"
+)
+GENERATED_PATHS = {
+    "CHANGELOG.rst",
+    "changelogs/.plugin-cache.yaml",
+    "changelogs/changelog.yaml",
+    "changelogs/release-preparation.json",
+    "galaxy.yml",
+}
+
+
+class BackSyncError(ValueError):
+    """Raised when a back-sync head differs from the immutable contract."""
+
+
+def fail(message: str) -> NoReturn:
+    raise BackSyncError(message)
+
+
+def git_binary() -> str:
+    executable = shutil.which("git")
+    if executable is None:
+        fail("git executable is unavailable")
+    return executable
+
+
+def git_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for variable in ("GIT_COMMON_DIR", "GIT_DIR", "GIT_WORK_TREE"):
+        environment.pop(variable, None)
+    return environment
+
+
+def git(root: Path, *arguments: str, text: bool = True) -> str | bytes:
+    try:
+        result = subprocess.run(  # noqa: S603 -- revisions are validated exact SHAs.
+            [git_binary(), *arguments],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=text,
+            env=git_environment(),
+            timeout=30,
+        )
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr if isinstance(exc.stderr, str) else exc.stderr.decode(errors="replace")
+        raise BackSyncError(f"git {' '.join(arguments)} failed: {stderr.strip()}") from exc
+    return cast("str | bytes", result.stdout)
+
+
+def git_text(root: Path, *arguments: str) -> str:
+    value = git(root, *arguments)
+    assert isinstance(value, str)
+    return value.strip()
+
+
+def git_bytes(root: Path, *arguments: str) -> bytes:
+    value = git(root, *arguments, text=False)
+    assert isinstance(value, bytes)
+    return value
+
+
+def require_sha(root: Path, value: str, label: str) -> None:
+    if SHA.fullmatch(value) is None or git_text(root, "cat-file", "-t", value) != "commit":
+        fail(f"{label} is not an exact commit SHA")
+
+
+def changes(root: Path, base: str, head: str) -> list[tuple[str, str]]:
+    raw = git_bytes(root, "diff", "--name-status", "-z", "--no-renames", base, head, "--", ".")
+    fields = raw.split(b"\0")
+    if fields and fields[-1] == b"":
+        fields.pop()
+    if len(fields) % 2:
+        fail("back-sync diff returned malformed path status data")
+    result: list[tuple[str, str]] = []
+    for index in range(0, len(fields), 2):
+        try:
+            status = fields[index].decode("ascii")
+            path = fields[index + 1].decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise BackSyncError("back-sync diff contains a non-UTF-8 path") from exc
+        if status not in {"A", "D", "M", "T"} or not path or path.startswith("/"):
+            fail("back-sync diff contains an unsupported path transition")
+        result.append((status, path))
+    if not result:
+        fail("back-sync diff is empty")
+    return result
+
+
+def object_bytes(root: Path, revision: str, path: str) -> bytes | None:
+    result = subprocess.run(  # noqa: S603 -- exact validated SHA and controlled path.
+        [git_binary(), "show", f"{revision}:{path}"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        env=git_environment(),
+        timeout=30,
+    )
+    if result.returncode == 0:
+        return result.stdout
+    if result.returncode == 128:
+        return None
+    fail(f"cannot read {path} from {revision}")
+
+
+def require_same_path(root: Path, release_sha: str, head_sha: str, path: str) -> None:
+    if object_bytes(root, release_sha, path) != object_bytes(root, head_sha, path):
+        fail(f"back-sync path differs from the exact release: {path}")
+
+
+def load_object(root: Path, revision: str, path: str, label: str) -> dict[str, object]:
+    raw = object_bytes(root, revision, path)
+    if raw is None:
+        fail(f"{label} is missing")
+    try:
+        value = json.loads(raw.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise BackSyncError(f"{label} is not valid UTF-8 JSON") from exc
+    if not isinstance(value, dict):
+        fail(f"{label} must be a JSON object")
+    return value
+
+
+def verify(
+    *,
+    root: Path,
+    develop_tip: str,
+    release_sha: str,
+    head_sha: str,
+    tag: str,
+    security_version: str = "",
+    evidence_id: str = "",
+) -> None:
+    if root.is_symlink() or not root.is_dir():
+        fail("repository root must be a regular directory")
+    for value, label in (
+        (develop_tip, "develop tip"),
+        (release_sha, "release SHA"),
+        (head_sha, "back-sync head SHA"),
+    ):
+        require_sha(root, value, label)
+    version = tag.removeprefix("v")
+    if tag != f"v{version}" or SEMVER.fullmatch(version) is None:
+        fail("release tag must contain stable SemVer")
+
+    parents = git_text(root, "show", "-s", "--format=%P", head_sha).split()
+    if len(parents) != 2 or parents[1] != release_sha:
+        fail("back-sync head must merge the exact release as its second parent")
+    develop_base = parents[0]
+    if (
+        subprocess.run(  # noqa: S603 -- exact validated commits.
+            [git_binary(), "merge-base", "--is-ancestor", develop_base, develop_tip],
+            cwd=root,
+            check=False,
+            env=git_environment(),
+            timeout=30,
+        ).returncode
+        != 0
+    ):
+        fail("back-sync first parent is not an ancestor of current develop")
+    for field, label in (("%an <%ae>", "author"), ("%cn <%ce>", "committer")):
+        if git_text(root, "show", "-s", f"--format={field}", head_sha) != APP_IDENTITY:
+            fail(f"back-sync commit {label} is not the release App")
+    if git_text(root, "show", "-s", "--format=%B", head_sha) != f"chore: sync {tag} release back to develop":
+        fail("back-sync commit message differs from the deterministic contract")
+
+    release_parents = git_text(root, "show", "-s", "--format=%P", release_sha).split()
+    if len(release_parents) != 2:
+        fail("release SHA must be a normal two-parent merge commit")
+    released_fragment_changes = changes(root, release_parents[0], release_sha)
+    deleted_fragments = {
+        path for status, path in released_fragment_changes if status == "D" and path.startswith("changelogs/fragments/")
+    }
+
+    allowed = set(GENERATED_PATHS)
+    if security_version:
+        if security_version != version or EVIDENCE_ID.fullmatch(evidence_id) is None:
+            fail("Security back-sync identity is invalid")
+        metadata = f".lit/security-releases/{version}.json"
+        intake = f".lit/security-release-intakes/{version}.json"
+        allowed.update({metadata, intake})
+        metadata_payload = load_object(root, release_sha, metadata, "Security metadata")
+        intake_payload = load_object(root, release_sha, intake, "Security intake receipt")
+        if metadata_payload.get("evidenceId") != evidence_id:
+            fail("Security metadata evidenceId differs from the classified release")
+        request = intake_payload.get("request")
+        if not isinstance(request, dict) or request.get("evidenceId") != evidence_id:
+            fail("Security intake receipt differs from the classified release")
+    elif evidence_id:
+        fail("normal back-sync may not carry a Security evidenceId")
+
+    for status, path in changes(root, develop_base, head_sha):
+        if path.startswith("changelogs/fragments/"):
+            if status != "D" or path not in deleted_fragments:
+                fail(f"back-sync contains an unauthorized fragment transition: {path}")
+        elif path not in allowed:
+            fail(f"back-sync contains a non-release path: {path}")
+
+    for path in sorted(allowed):
+        require_same_path(root, release_sha, head_sha, path)
+    for path in deleted_fragments:
+        if object_bytes(root, head_sha, path) is not None:
+            fail(f"released changelog fragment remains in back-sync head: {path}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path.cwd())
+    parser.add_argument("--develop-tip", required=True)
+    parser.add_argument("--release-sha", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--security-version", default="")
+    parser.add_argument("--evidence-id", default="")
+    args = parser.parse_args()
+    try:
+        verify(
+            root=args.root.resolve(),
+            develop_tip=args.develop_tip,
+            release_sha=args.release_sha,
+            head_sha=args.head_sha,
+            tag=args.tag,
+            security_version=args.security_version,
+            evidence_id=args.evidence_id,
+        )
+    except (BackSyncError, OSError) as exc:
+        parser.error(str(exc))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_back_sync.py
+++ b/scripts/verify_release_back_sync.py
@@ -1,5 +1,3 @@
-"""Verify one immutable App-authored release back-sync head."""
-
 from __future__ import annotations
 
 import argparse
@@ -27,7 +25,7 @@ GENERATED_PATHS = {
 
 
 class BackSyncError(ValueError):
-    """Raised when a back-sync head differs from the immutable contract."""
+    pass
 
 
 def fail(message: str) -> NoReturn:
@@ -37,7 +35,7 @@ def fail(message: str) -> NoReturn:
 def git_binary() -> str:
     executable = shutil.which("git")
     if executable is None:
-        fail("git executable is unavailable")
+        fail("git unavailable")
     return executable
 
 
@@ -79,7 +77,7 @@ def git_bytes(root: Path, *arguments: str) -> bytes:
 
 def require_sha(root: Path, value: str, label: str) -> None:
     if SHA.fullmatch(value) is None or git_text(root, "cat-file", "-t", value) != "commit":
-        fail(f"{label} is not an exact commit SHA")
+        fail(f"{label} is not a commit SHA")
 
 
 def changes(root: Path, base: str, head: str) -> list[tuple[str, str]]:
@@ -88,19 +86,19 @@ def changes(root: Path, base: str, head: str) -> list[tuple[str, str]]:
     if fields and fields[-1] == b"":
         fields.pop()
     if len(fields) % 2:
-        fail("malformed back-sync diff")
+        fail("malformed diff")
     result: list[tuple[str, str]] = []
     for index in range(0, len(fields), 2):
         try:
             status = fields[index].decode("ascii")
             path = fields[index + 1].decode("utf-8")
         except UnicodeDecodeError as exc:
-            raise BackSyncError("back-sync diff contains a non-UTF-8 path") from exc
+            raise BackSyncError("non-UTF-8 back-sync path") from exc
         if status not in {"A", "D", "M", "T"} or not path or path.startswith("/"):
-            fail("unsupported back-sync path transition")
+            fail("unsupported path")
         result.append((status, path))
     if not result:
-        fail("back-sync diff is empty")
+        fail("empty diff")
     return result
 
 
@@ -117,12 +115,12 @@ def object_bytes(root: Path, revision: str, path: str) -> bytes | None:
         return result.stdout
     if result.returncode == 128:
         return None
-    fail(f"cannot read {path} from {revision}")
+    fail(f"cannot read {revision}:{path}")
 
 
 def require_same_path(root: Path, release_sha: str, head_sha: str, path: str) -> None:
     if object_bytes(root, release_sha, path) != object_bytes(root, head_sha, path):
-        fail(f"back-sync path differs from the exact release: {path}")
+        fail(f"back-sync/release mismatch: {path}")
 
 
 def load_object(root: Path, revision: str, path: str, label: str) -> dict[str, object]:
@@ -149,7 +147,7 @@ def verify(
     evidence_id: str = "",
 ) -> None:
     if root.is_symlink() or not root.is_dir():
-        fail("repository root must be a regular directory")
+        fail("invalid repository root")
     for value, label in (
         (develop_tip, "develop tip"),
         (release_sha, "release SHA"),
@@ -158,11 +156,11 @@ def verify(
         require_sha(root, value, label)
     version = tag.removeprefix("v")
     if tag != f"v{version}" or SEMVER.fullmatch(version) is None:
-        fail("release tag must contain stable SemVer")
+        fail("invalid release tag")
 
     parents = git_text(root, "show", "-s", "--format=%P", head_sha).split()
     if len(parents) != 2 or parents[1] != release_sha:
-        fail("back-sync release parent mismatch")
+        fail("release parent mismatch")
     develop_base = parents[0]
     if (
         subprocess.run(  # noqa: S603 -- exact validated commits.
@@ -174,16 +172,16 @@ def verify(
         ).returncode
         != 0
     ):
-        fail("back-sync first parent is not an ancestor of current develop")
+        fail("first parent is not an ancestor")
     for field, label in (("%an <%ae>", "author"), ("%cn <%ce>", "committer")):
         if git_text(root, "show", "-s", f"--format={field}", head_sha) != APP_IDENTITY:
-            fail(f"back-sync commit {label} is not the release App")
+            fail(f"{label} is not the release App")
     if git_text(root, "show", "-s", "--format=%B", head_sha) != f"chore: sync {tag} release back to develop":
-        fail("back-sync message mismatch")
+        fail("message mismatch")
 
     release_parents = git_text(root, "show", "-s", "--format=%P", release_sha).split()
     if len(release_parents) != 2:
-        fail("release SHA is not a two-parent merge")
+        fail("release is not a two-parent merge")
     released_fragment_changes = changes(root, release_parents[0], release_sha)
     deleted_fragments = {
         path for status, path in released_fragment_changes if status == "D" and path.startswith("changelogs/fragments/")
@@ -192,7 +190,7 @@ def verify(
     allowed = set(GENERATED_PATHS)
     if security_version:
         if security_version != version or EVIDENCE_ID.fullmatch(evidence_id) is None:
-            fail("Security back-sync identity is invalid")
+            fail("invalid identity")
         metadata = f".lit/security-releases/{version}.json"
         intake = f".lit/security-release-intakes/{version}.json"
         allowed.update({metadata, intake})
@@ -202,22 +200,22 @@ def verify(
             fail("Security metadata evidenceId differs")
         request = intake_payload.get("request")
         if not isinstance(request, dict) or request.get("evidenceId") != evidence_id:
-            fail("Security intake receipt differs")
+            fail("intake receipt differs")
     elif evidence_id:
-        fail("normal back-sync carries Security evidenceId")
+        fail("unexpected evidenceId")
 
     for status, path in changes(root, develop_base, head_sha):
         if path.startswith("changelogs/fragments/"):
             if status != "D" or path not in deleted_fragments:
-                fail(f"back-sync contains an unauthorized fragment transition: {path}")
+                fail(f"unauthorized fragment transition: {path}")
         elif path not in allowed:
-            fail(f"back-sync contains a non-release path: {path}")
+            fail(f"non-release path: {path}")
 
     for path in sorted(allowed):
         require_same_path(root, release_sha, head_sha, path)
     for path in deleted_fragments:
         if object_bytes(root, head_sha, path) is not None:
-            fail(f"released changelog fragment remains in back-sync head: {path}")
+            fail(f"released fragment remains: {path}")
 
 
 def main() -> int:

--- a/scripts/verify_release_back_sync.py
+++ b/scripts/verify_release_back_sync.py
@@ -88,7 +88,7 @@ def changes(root: Path, base: str, head: str) -> list[tuple[str, str]]:
     if fields and fields[-1] == b"":
         fields.pop()
     if len(fields) % 2:
-        fail("back-sync diff returned malformed path status data")
+        fail("malformed back-sync diff")
     result: list[tuple[str, str]] = []
     for index in range(0, len(fields), 2):
         try:
@@ -97,7 +97,7 @@ def changes(root: Path, base: str, head: str) -> list[tuple[str, str]]:
         except UnicodeDecodeError as exc:
             raise BackSyncError("back-sync diff contains a non-UTF-8 path") from exc
         if status not in {"A", "D", "M", "T"} or not path or path.startswith("/"):
-            fail("back-sync diff contains an unsupported path transition")
+            fail("unsupported back-sync path transition")
         result.append((status, path))
     if not result:
         fail("back-sync diff is empty")
@@ -162,7 +162,7 @@ def verify(
 
     parents = git_text(root, "show", "-s", "--format=%P", head_sha).split()
     if len(parents) != 2 or parents[1] != release_sha:
-        fail("back-sync head must merge the exact release as its second parent")
+        fail("back-sync release parent mismatch")
     develop_base = parents[0]
     if (
         subprocess.run(  # noqa: S603 -- exact validated commits.
@@ -179,11 +179,11 @@ def verify(
         if git_text(root, "show", "-s", f"--format={field}", head_sha) != APP_IDENTITY:
             fail(f"back-sync commit {label} is not the release App")
     if git_text(root, "show", "-s", "--format=%B", head_sha) != f"chore: sync {tag} release back to develop":
-        fail("back-sync commit message differs from the deterministic contract")
+        fail("back-sync message mismatch")
 
     release_parents = git_text(root, "show", "-s", "--format=%P", release_sha).split()
     if len(release_parents) != 2:
-        fail("release SHA must be a normal two-parent merge commit")
+        fail("release SHA is not a two-parent merge")
     released_fragment_changes = changes(root, release_parents[0], release_sha)
     deleted_fragments = {
         path for status, path in released_fragment_changes if status == "D" and path.startswith("changelogs/fragments/")
@@ -199,12 +199,12 @@ def verify(
         metadata_payload = load_object(root, release_sha, metadata, "Security metadata")
         intake_payload = load_object(root, release_sha, intake, "Security intake receipt")
         if metadata_payload.get("evidenceId") != evidence_id:
-            fail("Security metadata evidenceId differs from the classified release")
+            fail("Security metadata evidenceId differs")
         request = intake_payload.get("request")
         if not isinstance(request, dict) or request.get("evidenceId") != evidence_id:
-            fail("Security intake receipt differs from the classified release")
+            fail("Security intake receipt differs")
     elif evidence_id:
-        fail("normal back-sync may not carry a Security evidenceId")
+        fail("normal back-sync carries Security evidenceId")
 
     for status, path in changes(root, develop_base, head_sha):
         if path.startswith("changelogs/fragments/"):

--- a/scripts/verify_release_back_sync.py
+++ b/scripts/verify_release_back_sync.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Verify one immutable App-authored release back-sync head."""
 
 from __future__ import annotations

--- a/tests/unit/test_modulix_validation_receipt.py
+++ b/tests/unit/test_modulix_validation_receipt.py
@@ -207,6 +207,11 @@ class FakeController:
 
 
 class ModuLixValidationReceiptTests(unittest.TestCase):
+    def test_wait_budget_covers_parallel_controller_contract(self) -> None:
+        controller_maximum_seconds = (15 + 45 + 180 + 15) * 60
+        self.assertGreaterEqual(MODULE.DEFAULT_TIMEOUT_SECONDS, controller_maximum_seconds)
+        self.assertLess(MODULE.DEFAULT_TIMEOUT_SECONDS, 360 * 60)
+
     def test_manifest_and_request_are_exact_digest_bound(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             path = Path(temporary_directory) / "nexus.json"

--- a/tests/unit/test_release_back_sync_contract.py
+++ b/tests/unit/test_release_back_sync_contract.py
@@ -1,0 +1,201 @@
+"""Regression tests for immutable, force-free release back-sync heads."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/verify_release_back_sync.py"
+SPEC = importlib.util.spec_from_file_location("release_back_sync_contract", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+GIT = shutil.which("git")
+assert GIT is not None
+VERSION = "3.2.4"
+TAG = f"v{VERSION}"
+EVIDENCE_ID = "MLX90-KEYCLOAK-26.7.1-3.2.4"
+APP_NAME = "lightning-it-release-automation[bot]"
+APP_EMAIL = "307565056+lightning-it-release-automation[bot]@users.noreply.github.com"
+
+
+def git(root: Path, *arguments: str) -> str:
+    environment = os.environ.copy()
+    for variable in ("GIT_COMMON_DIR", "GIT_DIR", "GIT_WORK_TREE"):
+        environment.pop(variable, None)
+    return subprocess.run(  # noqa: S603 -- fixed git binary and test-owned arguments.
+        [GIT, *arguments],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+        timeout=30,
+    ).stdout.strip()
+
+
+class ReleaseBackSyncContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        git(self.root, "init", "-q")
+        git(self.root, "config", "user.name", "Fixture")
+        git(self.root, "config", "user.email", "fixture@example.invalid")
+        (self.root / "changelogs/fragments").mkdir(parents=True)
+        (self.root / "CHANGELOG.rst").write_text("v3.2.3\n=======\n", encoding="utf-8")
+        (self.root / "galaxy.yml").write_text("---\nversion: 3.2.3\n", encoding="utf-8")
+        (self.root / "changelogs/changelog.yaml").write_text("---\nreleases: {}\n", encoding="utf-8")
+        (self.root / "changelogs/.plugin-cache.yaml").write_text("---\ncache: {}\n", encoding="utf-8")
+        (self.root / "changelogs/fragments/security.yml").write_text(
+            '{"security_fixes":["Exact fix."]}\n',
+            encoding="utf-8",
+        )
+        (self.root / "roles/example").mkdir(parents=True)
+        (self.root / "roles/example/main.yml").write_text("---\nfixed: true\n", encoding="utf-8")
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-q", "-m", "develop base")
+        self.develop_base = git(self.root, "rev-parse", "HEAD")
+
+        git(self.root, "switch", "-q", "-c", "main-fixture")
+        metadata_path = self.root / f".lit/security-releases/{VERSION}.json"
+        metadata_path.parent.mkdir(parents=True)
+        metadata_path.write_text(
+            json.dumps({"evidenceId": EVIDENCE_ID}, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        intake_path = self.root / f".lit/security-release-intakes/{VERSION}.json"
+        intake_path.parent.mkdir(parents=True)
+        intake_path.write_text(
+            json.dumps({"request": {"evidenceId": EVIDENCE_ID}}, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        git(self.root, "add", ".lit")
+        git(self.root, "commit", "-q", "-m", "security intake")
+        self.main_base = git(self.root, "rev-parse", "HEAD")
+
+        git(self.root, "switch", "-q", "-c", "release-fixture")
+        (self.root / "CHANGELOG.rst").write_text(
+            "v3.2.4\n=======\n\nSecurity release.\n\nv3.2.3\n=======\n",
+            encoding="utf-8",
+        )
+        (self.root / "galaxy.yml").write_text("---\nversion: 3.2.4\n", encoding="utf-8")
+        (self.root / "changelogs/changelog.yaml").write_text(
+            "---\nreleases:\n  3.2.4: {}\n",
+            encoding="utf-8",
+        )
+        (self.root / "changelogs/.plugin-cache.yaml").write_text(
+            "---\ncache:\n  version: 3.2.4\n",
+            encoding="utf-8",
+        )
+        (self.root / "changelogs/fragments/security.yml").unlink()
+        receipt = {
+            "release_mode": "security",
+            "chain_id": "sha256:" + "a" * 64,
+            "security": {"evidence_id": EVIDENCE_ID},
+            "fragments": [{"path": "security.yml"}],
+        }
+        (self.root / "changelogs/release-preparation.json").write_text(
+            json.dumps(receipt, sort_keys=True, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+        git(self.root, "add", "-A")
+        git(self.root, "commit", "-q", "-m", f"chore(release): prepare v{VERSION}")
+        release_head = git(self.root, "rev-parse", "HEAD")
+
+        git(self.root, "switch", "-q", "main-fixture")
+        git(self.root, "merge", "-q", "--no-ff", release_head, "-m", f"Release v{VERSION}")
+        self.release_sha = git(self.root, "rev-parse", "HEAD")
+        self.head_sha = self._make_back_sync()
+
+    def _app_identity(self) -> None:
+        git(self.root, "config", "user.name", APP_NAME)
+        git(self.root, "config", "user.email", APP_EMAIL)
+
+    def _make_back_sync(self, *, extra_path: str = "", app_identity: bool = True) -> str:
+        git(self.root, "switch", "-q", "--detach", self.develop_base)
+        if app_identity:
+            self._app_identity()
+        else:
+            git(self.root, "config", "user.name", "Human")
+            git(self.root, "config", "user.email", "human@example.invalid")
+        git(
+            self.root,
+            "merge",
+            "-q",
+            "--no-ff",
+            self.release_sha,
+            "-m",
+            f"chore: sync {TAG} release back to develop",
+        )
+        if extra_path:
+            path = self.root / extra_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("unauthorized\n", encoding="utf-8")
+            git(self.root, "add", extra_path)
+            git(self.root, "commit", "-q", "--amend", "--no-edit")
+        return git(self.root, "rev-parse", "HEAD")
+
+    def verify(self, *, head_sha: str | None = None, evidence_id: str = EVIDENCE_ID) -> None:
+        MODULE.verify(
+            root=self.root,
+            develop_tip=self.develop_base,
+            release_sha=self.release_sha,
+            head_sha=head_sha or self.head_sha,
+            tag=TAG,
+            security_version=VERSION,
+            evidence_id=evidence_id,
+        )
+
+    def test_exact_app_authored_back_sync_is_accepted(self) -> None:
+        self.verify()
+
+    def test_non_release_path_is_rejected(self) -> None:
+        malicious = self._make_back_sync(extra_path="unexpected.txt")
+        with self.assertRaisesRegex(MODULE.BackSyncError, "non-release path"):
+            self.verify(head_sha=malicious)
+
+    def test_non_app_commit_is_rejected(self) -> None:
+        human = self._make_back_sync(app_identity=False)
+        with self.assertRaisesRegex(MODULE.BackSyncError, "not the release App"):
+            self.verify(head_sha=human)
+
+    def test_security_evidence_mismatch_is_rejected(self) -> None:
+        with self.assertRaisesRegex(MODULE.BackSyncError, "evidenceId differs"):
+            self.verify(evidence_id="MLX90-OTHER-EVIDENCE")
+
+    def test_first_parent_must_remain_on_current_develop_ancestry(self) -> None:
+        git(self.root, "switch", "-q", "--orphan", "unrelated")
+        for path in list(self.root.iterdir()):
+            if path.name != ".git":
+                if path.is_dir():
+                    shutil.rmtree(path)
+                else:
+                    path.unlink()
+        (self.root / "unrelated.txt").write_text("unrelated\n", encoding="utf-8")
+        git(self.root, "add", "unrelated.txt")
+        git(self.root, "commit", "-q", "-m", "unrelated")
+        unrelated = git(self.root, "rev-parse", "HEAD")
+        with self.assertRaisesRegex(MODULE.BackSyncError, "not an ancestor"):
+            MODULE.verify(
+                root=self.root,
+                develop_tip=unrelated,
+                release_sha=self.release_sha,
+                head_sha=self.head_sha,
+                tag=TAG,
+                security_version=VERSION,
+                evidence_id=EVIDENCE_ID,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_security_main_promotion.py
+++ b/tests/unit/test_security_main_promotion.py
@@ -1,0 +1,293 @@
+"""Tests for exact App-authored Supplementary main promotions."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+PROMOTION = load_module("security_main_promotion_tested", SCRIPTS / "security_main_promotion.py")
+AUTHORIZATION = load_module(
+    "main_promotion_authorization_tested",
+    SCRIPTS / "main-promotion-authorization.py",
+)
+CONTRACT = PROMOTION.CONTRACT
+GIT = shutil.which("git")
+assert GIT is not None
+VERSION = "3.2.4"
+EVIDENCE_ID = "MLX90-KEYCLOAK-26.7.1-3.2.4"
+PROFILE = "lit.supplementary/keycloak-26.7.1-security-v1"
+CHECKED_AT = datetime(2026, 8, 8, 23, 0, tzinfo=UTC)
+
+
+def git(root: Path, *arguments: str) -> str:
+    environment = os.environ.copy()
+    for variable in ("GIT_COMMON_DIR", "GIT_DIR", "GIT_WORK_TREE"):
+        environment.pop(variable, None)
+    return subprocess.run(  # noqa: S603 -- fixed git binary and test-owned arguments.
+        [GIT, *arguments],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+        timeout=30,
+    ).stdout.strip()
+
+
+class SecurityMainPromotionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        git(self.root, "init", "-q")
+        git(self.root, "config", "user.name", "Fixture")
+        git(self.root, "config", "user.email", "fixture@example.invalid")
+        profiles = {
+            "schemaVersion": 1,
+            "profiles": {
+                PROFILE: {
+                    "description": "Exact Keycloak acceptance",
+                    "releaseEligible": True,
+                }
+            },
+        }
+        profile_path = self.root / ".lit/security-release-profiles.json"
+        profile_path.parent.mkdir(parents=True)
+        profile_path.write_bytes(CONTRACT.canonical_document_bytes(profiles))
+        role = self.root / "roles/keycloak_deploy/defaults/main.yml"
+        role.parent.mkdir(parents=True)
+        role.write_text("---\nimage: affected\n", encoding="utf-8")
+        (self.root / "galaxy.yml").write_text("---\nversion: 3.2.3\n", encoding="utf-8")
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-q", "-m", "protected main")
+        self.base_sha = git(self.root, "rev-parse", "HEAD")
+
+        metadata = {
+            "schemaVersion": 1,
+            "evidenceId": EVIDENCE_ID,
+            "createdAt": "2026-08-08T22:30:00Z",
+            "securityIdentifiers": ["CVE-2026-9793"],
+            "affectedVersion": "3.2.3",
+            "fixedVersion": VERSION,
+            "consumers": [CONTRACT.CONSUMER_REPOSITORY],
+            "acceptanceProfile": PROFILE,
+            "validity": {
+                "notBefore": "2026-08-08T22:30:00Z",
+                "expiresAt": "2026-09-08T22:30:00Z",
+                "revoked": False,
+            },
+        }
+        self.metadata_raw = (json.dumps(metadata, indent=2, sort_keys=True) + "\n").encode()
+        self.fragment_raw = b'---\nsecurity_fixes:\n  - "Exact Keycloak fix."\n'
+        self._write_candidate_files()
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-q", "-m", "candidate")
+        self.candidate_sha = git(self.root, "rev-parse", "HEAD")
+        receipt_path = f".lit/security-release-intakes/{VERSION}.json"
+        candidate_diff = PROMOTION.candidate_diff_without_receipt(
+            self.root,
+            self.base_sha,
+            self.candidate_sha,
+            receipt_path,
+        )
+        candidate_digest = CONTRACT.sha256_bytes(candidate_diff)
+        chain_id = CONTRACT.compute_chain_id(
+            repository=CONTRACT.PRODUCER_REPOSITORY,
+            repository_id=CONTRACT.PRODUCER_REPOSITORY_ID,
+            base_sha=self.base_sha,
+            candidate_head_sha=self.candidate_sha,
+            candidate_diff_sha256=candidate_digest,
+            evidence_id=EVIDENCE_ID,
+            fixed_version=VERSION,
+            acceptance_profile=PROFILE,
+        )
+        self.request = {
+            "schemaVersion": 2,
+            "event": "mlx90-security-release",
+            "repository": CONTRACT.PRODUCER_REPOSITORY,
+            "repositoryId": CONTRACT.PRODUCER_REPOSITORY_ID,
+            "baseSha": self.base_sha,
+            "candidateRef": "develop",
+            "candidateBaseSha": self.base_sha,
+            "candidateHeadSha": self.candidate_sha,
+            "candidateDiffSha256": candidate_digest,
+            "evidenceId": EVIDENCE_ID,
+            "fixedVersion": VERSION,
+            "acceptanceProfile": PROFILE,
+            "metadataSha256": CONTRACT.sha256_bytes(self.metadata_raw),
+            "chainId": chain_id,
+            "issuedAt": "2026-08-08T22:30:00Z",
+            "expiresAt": "2026-09-08T22:30:00Z",
+            "humanActions": 0,
+        }
+        self.verified = {
+            "schemaVersion": 2,
+            "chainId": chain_id,
+            "branch": f"security-release/{EVIDENCE_ID}",
+            "baseSha": self.base_sha,
+            "candidateBaseSha": self.base_sha,
+            "candidateHeadSha": self.candidate_sha,
+            "candidateDiffSha256": candidate_digest,
+            "evidenceId": EVIDENCE_ID,
+            "fixedVersion": VERSION,
+            "metadataPath": f".lit/security-releases/{VERSION}.json",
+            "metadataSha256": CONTRACT.sha256_bytes(self.metadata_raw),
+            "acceptanceProfile": PROFILE,
+            "changelogFragmentPath": "changelogs/fragments/keycloak-security.yml",
+            "changelogFragmentSha256": CONTRACT.sha256_bytes(self.fragment_raw),
+            "changedPaths": [
+                f".lit/security-releases/{VERSION}.json",
+                "changelogs/fragments/keycloak-security.yml",
+                "roles/keycloak_deploy/defaults/main.yml",
+            ],
+            "humanActions": 0,
+        }
+        self.receipt = CONTRACT.build_intake_receipt(
+            self.request,
+            self.verified,
+            checked_at=CHECKED_AT,
+            workflow_run_id="123456",
+            workflow_attempt="1",
+            workflow_ref=(
+                f"{CONTRACT.PRODUCER_REPOSITORY}/.github/workflows/security-release-intake.yml@refs/heads/main"
+            ),
+            workflow_event="workflow_dispatch",
+            workflow_actor=CONTRACT.RELEASE_APP_LOGIN,
+            workflow_triggering_actor=CONTRACT.RELEASE_APP_LOGIN,
+            observed_automation=CONTRACT.RELEASE_APP_IDENTITY,
+        )
+        self.head_sha = self._materialize_head()
+        self.base_root = self.root.parent / f"{self.root.name}-base"
+        git(self.root, "worktree", "add", "-q", "--detach", str(self.base_root), self.base_sha)
+
+    def _write_candidate_files(self) -> None:
+        metadata = self.root / f".lit/security-releases/{VERSION}.json"
+        metadata.parent.mkdir(parents=True, exist_ok=True)
+        metadata.write_bytes(self.metadata_raw)
+        fragment = self.root / "changelogs/fragments/keycloak-security.yml"
+        fragment.parent.mkdir(parents=True, exist_ok=True)
+        fragment.write_bytes(self.fragment_raw)
+        (self.root / "roles/keycloak_deploy/defaults/main.yml").write_text(
+            "---\nimage: fixed\n",
+            encoding="utf-8",
+        )
+
+    def _materialize_head(self, *, app_identity: bool = True, extra_path: str = "") -> str:
+        git(self.root, "switch", "-q", "--detach", self.base_sha)
+        self._write_candidate_files()
+        receipt = self.root / f".lit/security-release-intakes/{VERSION}.json"
+        receipt.parent.mkdir(parents=True, exist_ok=True)
+        receipt.write_bytes(CONTRACT.canonical_document_bytes(self.receipt))
+        if extra_path:
+            path = self.root / extra_path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("unexpected\n", encoding="utf-8")
+        if app_identity:
+            git(self.root, "config", "user.name", CONTRACT.RELEASE_APP_LOGIN)
+            git(self.root, "config", "user.email", CONTRACT.RELEASE_APP_EMAIL)
+        else:
+            git(self.root, "config", "user.name", "Human")
+            git(self.root, "config", "user.email", "human@example.invalid")
+        git(self.root, "add", ".")
+        git(self.root, "commit", "-q", "-m", f"fix(security): {EVIDENCE_ID}")
+        return git(self.root, "rev-parse", "HEAD")
+
+    def verify(self, head_sha: str | None = None) -> PROMOTION.Promotion:
+        return PROMOTION.verify_promotion(
+            base_root=self.base_root,
+            head_root=self.root,
+            base_sha=self.base_sha,
+            head_sha=head_sha or self.head_sha,
+            head_ref=f"security-release/{EVIDENCE_ID}",
+            checked_at=CHECKED_AT,
+        )
+
+    def test_exact_materialized_candidate_and_receipt_are_accepted(self) -> None:
+        result = self.verify()
+        self.assertEqual("security", result.mode)
+        self.assertEqual(self.request["chainId"], result.chain_id)
+        self.assertEqual(VERSION, result.version)
+
+    def test_extra_materialized_path_is_rejected(self) -> None:
+        head = self._materialize_head(extra_path="unexpected.txt")
+        with self.assertRaisesRegex(PROMOTION.PromotionError, "differ from the verified candidate"):
+            self.verify(head)
+
+    def test_non_app_commit_is_rejected(self) -> None:
+        head = self._materialize_head(app_identity=False)
+        with self.assertRaisesRegex(PROMOTION.PromotionError, "not the release App"):
+            self.verify(head)
+
+    def test_malformed_reserved_branch_is_rejected(self) -> None:
+        with self.assertRaisesRegex(PROMOTION.PromotionError, "malformed"):
+            PROMOTION.verify_promotion(
+                base_root=self.base_root,
+                head_root=self.root,
+                base_sha=self.base_sha,
+                head_sha=self.head_sha,
+                head_ref="security-release/not-an-evidence-id",
+                checked_at=CHECKED_AT,
+            )
+
+    def test_live_authorization_uses_verified_content_not_branch_name_only(self) -> None:
+        pull = {
+            "number": 42,
+            "state": "open",
+            "draft": False,
+            "base": {"ref": "main", "sha": self.base_sha},
+            "head": {
+                "ref": f"security-release/{EVIDENCE_ID}",
+                "sha": self.head_sha,
+                "repo": {"full_name": CONTRACT.PRODUCER_REPOSITORY},
+            },
+            "user": {
+                "login": CONTRACT.RELEASE_APP_LOGIN,
+                "id": int(CONTRACT.RELEASE_APP_ACCOUNT_ID),
+                "type": "Bot",
+            },
+        }
+        result = AUTHORIZATION.classify(
+            pull,
+            CONTRACT.PRODUCER_REPOSITORY,
+            self.base_sha,
+            self.head_sha,
+            base_root=self.base_root,
+            head_root=self.root,
+        )
+        self.assertEqual("security", result.mode)
+        pull["user"] = {"login": "human", "id": 1, "type": "User"}
+        with self.assertRaisesRegex(AUTHORIZATION.AuthorizationError, "release App"):
+            AUTHORIZATION.classify(
+                pull,
+                CONTRACT.PRODUCER_REPOSITORY,
+                self.base_sha,
+                self.head_sha,
+                base_root=self.base_root,
+                head_root=self.root,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_security_publication_golden_path.py
+++ b/tests/unit/test_security_publication_golden_path.py
@@ -60,6 +60,24 @@ class SecurityPublicationGoldenPathTests(unittest.TestCase):
             self.steps["Stage exact Security candidate in native Nexus Galaxy v3"]["run"],
         )
 
+    def test_release_validation_wait_has_an_independent_timeout_budget(self) -> None:
+        validation = self.workflow["jobs"]["release-validation"]
+        self.assertEqual(130, validation["timeout-minutes"])
+        self.assertEqual("${{ steps.exact.outputs.ci-run-id }}", validation["outputs"]["ci-run-id"])
+        self.assertEqual(
+            ["security-classification", "release-validation"],
+            self.publish["needs"],
+        )
+        self.assertNotIn(
+            "Wait for exact-SHA main Release Validation",
+            self.step_names,
+        )
+        download = self.steps["Download exact candidate and evidence from validated run"]
+        self.assertEqual(
+            "${{ needs.release-validation.outputs.ci-run-id }}",
+            download["env"]["CI_RUN_ID"],
+        )
+
     def test_nexus_stage_is_native_v3_readback_and_fails_without_configuration(self) -> None:
         stage = self.steps["Stage exact Security candidate in native Nexus Galaxy v3"]
         self.assertEqual("${{ vars.NEXUS_GALAXY_REPOSITORY_URL }}", stage["env"]["NEXUS_GALAXY_REPOSITORY_URL"])
@@ -87,6 +105,7 @@ class SecurityPublicationGoldenPathTests(unittest.TestCase):
         token = self.steps["Mint exact ModuLix validation App token"]
         self.assertEqual("modulix-validation", token["with"]["repositories"])
         self.assertEqual("write", token["with"]["permission-actions"])
+        self.assertEqual("read", token["with"]["permission-contents"])
         self.assertNotIn("permission-administration", token["with"])
         self.assertNotIn("permission-environments", token["with"])
         self.assertNotIn("permission-secrets", token["with"])

--- a/tests/unit/test_security_publication_golden_path.py
+++ b/tests/unit/test_security_publication_golden_path.py
@@ -60,24 +60,6 @@ class SecurityPublicationGoldenPathTests(unittest.TestCase):
             self.steps["Stage exact Security candidate in native Nexus Galaxy v3"]["run"],
         )
 
-    def test_release_validation_wait_has_an_independent_timeout_budget(self) -> None:
-        validation = self.workflow["jobs"]["release-validation"]
-        self.assertEqual(130, validation["timeout-minutes"])
-        self.assertEqual("${{ steps.exact.outputs.ci-run-id }}", validation["outputs"]["ci-run-id"])
-        self.assertEqual(
-            ["security-classification", "release-validation"],
-            self.publish["needs"],
-        )
-        self.assertNotIn(
-            "Wait for exact-SHA main Release Validation",
-            self.step_names,
-        )
-        download = self.steps["Download exact candidate and evidence from validated run"]
-        self.assertEqual(
-            "${{ needs.release-validation.outputs.ci-run-id }}",
-            download["env"]["CI_RUN_ID"],
-        )
-
     def test_nexus_stage_is_native_v3_readback_and_fails_without_configuration(self) -> None:
         stage = self.steps["Stage exact Security candidate in native Nexus Galaxy v3"]
         self.assertEqual("${{ vars.NEXUS_GALAXY_REPOSITORY_URL }}", stage["env"]["NEXUS_GALAXY_REPOSITORY_URL"])

--- a/tests/unit/test_security_release_classification.py
+++ b/tests/unit/test_security_release_classification.py
@@ -47,19 +47,18 @@ class SecurityReleaseClassificationTests(unittest.TestCase):
         self.root = Path(self.temporary.name)
         metadata_root = self.root / ".lit" / "security-releases"
         metadata_root.mkdir(parents=True)
-        (self.root / ".lit" / "security-release-profiles.json").write_text(
-            json.dumps(
-                {
-                    "schemaVersion": 1,
-                    "profiles": {
-                        "lit.supplementary/fix-v1": {
-                            "description": "fixture",
-                            "releaseEligible": True,
-                        }
-                    },
+        self.profile = "lit.supplementary/fix-v1"
+        profiles = {
+            "schemaVersion": 1,
+            "profiles": {
+                self.profile: {
+                    "description": "fixture",
+                    "releaseEligible": True,
                 }
-            ),
-            encoding="utf-8",
+            },
+        }
+        (self.root / ".lit" / "security-release-profiles.json").write_bytes(
+            MODULE.CONTRACT.canonical_document_bytes(profiles)
         )
         self.metadata = {
             "schemaVersion": 1,
@@ -69,17 +68,88 @@ class SecurityReleaseClassificationTests(unittest.TestCase):
             "affectedVersion": "3.1.0",
             "fixedVersion": "3.2.2",
             "consumers": ["lightning-it/container-ee-wunder-ansible-ubi9"],
-            "acceptanceProfile": "lit.supplementary/fix-v1",
+            "acceptanceProfile": self.profile,
             "validity": {
                 "notBefore": "2026-08-04T11:31:48Z",
                 "expiresAt": "2026-09-03T11:31:48Z",
                 "revoked": False,
             },
         }
-        (metadata_root / "3.2.2.json").write_text(json.dumps(self.metadata), encoding="utf-8")
-        intake_root = self.root / ".lit" / "security-release-intakes"
-        intake_root.mkdir()
-        (intake_root / "3.2.2.json").write_text("{}\n", encoding="utf-8")
+        metadata_raw = (json.dumps(self.metadata, indent=2, sort_keys=True) + "\n").encode()
+        (metadata_root / "3.2.2.json").write_bytes(metadata_raw)
+        fragment_raw = b'---\nsecurity_fixes:\n  - "Exact fixture fix."\n'
+        fragment_path = self.root / "changelogs/fragments/exact-security.yml"
+        fragment_path.parent.mkdir(parents=True)
+        fragment_path.write_bytes(fragment_raw)
+        candidate_digest = "sha256:" + "c" * 64
+        chain_id = MODULE.CONTRACT.compute_chain_id(
+            repository=MODULE.CONTRACT.PRODUCER_REPOSITORY,
+            repository_id=MODULE.CONTRACT.PRODUCER_REPOSITORY_ID,
+            base_sha="1" * 40,
+            candidate_head_sha="2" * 40,
+            candidate_diff_sha256=candidate_digest,
+            evidence_id=EVIDENCE_ID,
+            fixed_version="3.2.2",
+            acceptance_profile=self.profile,
+        )
+        request = {
+            "schemaVersion": 2,
+            "event": "mlx90-security-release",
+            "repository": MODULE.CONTRACT.PRODUCER_REPOSITORY,
+            "repositoryId": MODULE.CONTRACT.PRODUCER_REPOSITORY_ID,
+            "baseSha": "1" * 40,
+            "candidateRef": "develop",
+            "candidateBaseSha": "1" * 40,
+            "candidateHeadSha": "2" * 40,
+            "candidateDiffSha256": candidate_digest,
+            "evidenceId": EVIDENCE_ID,
+            "fixedVersion": "3.2.2",
+            "acceptanceProfile": self.profile,
+            "metadataSha256": MODULE.CONTRACT.sha256_bytes(metadata_raw),
+            "chainId": chain_id,
+            "issuedAt": "2026-08-04T11:31:48Z",
+            "expiresAt": "2026-09-03T11:31:48Z",
+            "humanActions": 0,
+        }
+        verified = {
+            "schemaVersion": 2,
+            "chainId": chain_id,
+            "branch": f"security-release/{EVIDENCE_ID}",
+            "baseSha": "1" * 40,
+            "candidateBaseSha": "1" * 40,
+            "candidateHeadSha": "2" * 40,
+            "candidateDiffSha256": candidate_digest,
+            "evidenceId": EVIDENCE_ID,
+            "fixedVersion": "3.2.2",
+            "metadataPath": ".lit/security-releases/3.2.2.json",
+            "metadataSha256": MODULE.CONTRACT.sha256_bytes(metadata_raw),
+            "acceptanceProfile": self.profile,
+            "changelogFragmentPath": "changelogs/fragments/exact-security.yml",
+            "changelogFragmentSha256": MODULE.CONTRACT.sha256_bytes(fragment_raw),
+            "changedPaths": [
+                ".lit/security-releases/3.2.2.json",
+                "changelogs/fragments/exact-security.yml",
+                "roles/example/defaults/main.yml",
+            ],
+            "humanActions": 0,
+        }
+        receipt = MODULE.CONTRACT.build_intake_receipt(
+            request,
+            verified,
+            checked_at=CHECKED_AT,
+            workflow_run_id="123456",
+            workflow_attempt="1",
+            workflow_ref=(
+                f"{MODULE.CONTRACT.PRODUCER_REPOSITORY}/.github/workflows/security-release-intake.yml@refs/heads/main"
+            ),
+            workflow_event="workflow_dispatch",
+            workflow_actor=MODULE.CONTRACT.RELEASE_APP_LOGIN,
+            workflow_triggering_actor=MODULE.CONTRACT.RELEASE_APP_LOGIN,
+            observed_automation=MODULE.CONTRACT.RELEASE_APP_IDENTITY,
+        )
+        intake_path = self.root / ".lit/security-release-intakes/3.2.2.json"
+        intake_path.parent.mkdir(parents=True)
+        intake_path.write_bytes(MODULE.CONTRACT.canonical_document_bytes(receipt))
 
     def tearDown(self):
         self.temporary.cleanup()
@@ -180,7 +250,10 @@ class SecurityReleaseClassificationTests(unittest.TestCase):
                 CHECKED_AT,
             ).security_release
         )
-        with mock.patch.object(MODULE, "changed_security_versions", return_value=[]):
+        with (
+            mock.patch.object(MODULE, "changed_security_versions", return_value=[]),
+            mock.patch.object(MODULE, "changed_preparation_version", return_value=""),
+        ):
             self.assertFalse(
                 MODULE.classify(
                     args(event_kind="push", ref="refs/heads/main", commit_message="feat: normal"),
@@ -202,6 +275,7 @@ class SecurityReleaseClassificationTests(unittest.TestCase):
                     event_kind="pull_request",
                     base_ref="main",
                     head_ref=f"security-release/{EVIDENCE_ID}",
+                    binding_root=self.root / "absent",
                 ),
                 self.root,
                 CHECKED_AT,
@@ -216,7 +290,10 @@ class SecurityReleaseClassificationTests(unittest.TestCase):
                 CHECKED_AT,
             )
         self.assertTrue(promoted.security_release)
-        with mock.patch.object(MODULE, "changed_security_versions", return_value=[]):
+        with (
+            mock.patch.object(MODULE, "changed_security_versions", return_value=[]),
+            mock.patch.object(MODULE, "changed_preparation_version", return_value=""),
+        ):
             prepared = MODULE.classify(
                 args(
                     event_kind="push",
@@ -227,6 +304,43 @@ class SecurityReleaseClassificationTests(unittest.TestCase):
                 CHECKED_AT,
             )
         self.assertTrue(prepared.security_release)
+
+    def test_changed_preparation_receipt_is_a_security_binding(self):
+        with (
+            mock.patch.object(MODULE, "changed_security_versions", return_value=[]),
+            mock.patch.object(
+                MODULE,
+                "changed_preparation_version",
+                return_value="3.2.2",
+            ),
+        ):
+            prepared = MODULE.classify(
+                args(event_kind="push", ref="refs/heads/main"),
+                self.root,
+                CHECKED_AT,
+            )
+        self.assertTrue(prepared.security_release)
+        self.assertEqual(EVIDENCE_ID, prepared.evidence_id)
+
+    def test_released_markers_must_equal_the_preconsumption_binding(self):
+        binding_root = self.root.parent / f"{self.root.name}-binding"
+        self.addCleanup(shutil.rmtree, binding_root, True)
+        shutil.copytree(self.root, binding_root)
+        metadata_path = self.root / ".lit/security-releases/3.2.2.json"
+        metadata_path.write_bytes(metadata_path.read_bytes() + b"\n")
+        with self.assertRaisesRegex(
+            MODULE.ClassificationError,
+            "differs from its pre-consumption base",
+        ):
+            MODULE.classify(
+                args(
+                    event_kind="version",
+                    version="3.2.2",
+                    binding_root=binding_root,
+                ),
+                self.root,
+                CHECKED_AT,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_security_release_classification.py
+++ b/tests/unit/test_security_release_classification.py
@@ -154,6 +154,13 @@ class SecurityReleaseClassificationTests(unittest.TestCase):
     def tearDown(self):
         self.temporary.cleanup()
 
+    def test_git_binary(self):
+        with mock.patch.object(MODULE.shutil, "which", return_value="/opt/bin/git"):
+            self.assertEqual("/opt/bin/git", MODULE.git_binary())
+        with mock.patch.object(MODULE.shutil, "which", return_value=None):
+            with self.assertRaises(MODULE.ClassificationError):
+                MODULE.git_binary()
+
     def test_exact_version_classifies_only_real_metadata(self):
         result = MODULE.classify(
             args(event_kind="version", version="3.2.2", evidence_id=EVIDENCE_ID),

--- a/tests/unit/test_security_release_classification.py
+++ b/tests/unit/test_security_release_classification.py
@@ -313,6 +313,14 @@ class SecurityReleaseClassificationTests(unittest.TestCase):
         self.assertTrue(prepared.security_release)
 
     def test_changed_preparation_receipt_is_a_security_binding(self):
+        receipt = self.root / "changelogs/release-preparation.json"
+        receipt.write_bytes(MODULE.CONTRACT.canonical_document_bytes({"next_version": "3.2.2"}))
+        changed = subprocess.CompletedProcess([], 0, "changelogs/release-preparation.json\n", "")
+        with mock.patch.object(MODULE.subprocess, "run", return_value=changed):
+            self.assertEqual(
+                "3.2.2",
+                MODULE.changed_preparation_version(self.root, "1" * 40, "2" * 40),
+            )
         with (
             mock.patch.object(MODULE, "changed_security_versions", return_value=[]),
             mock.patch.object(

--- a/tests/unit/test_security_release_classification.py
+++ b/tests/unit/test_security_release_classification.py
@@ -316,11 +316,14 @@ class SecurityReleaseClassificationTests(unittest.TestCase):
         receipt = self.root / "changelogs/release-preparation.json"
         receipt.write_bytes(MODULE.CONTRACT.canonical_document_bytes({"next_version": "3.2.2"}))
         changed = subprocess.CompletedProcess([], 0, "changelogs/release-preparation.json\n", "")
-        with mock.patch.object(MODULE.subprocess, "run", return_value=changed):
-            self.assertEqual(
-                "3.2.2",
-                MODULE.changed_preparation_version(self.root, "1" * 40, "2" * 40),
-            )
+        with (
+            mock.patch.dict(MODULE.os.environ, {"GIT_DIR": "poison"}),
+            mock.patch.object(MODULE.subprocess, "run", return_value=changed) as run,
+        ):
+            version = MODULE.changed_preparation_version(self.root, "1" * 40, "2" * 40)
+        self.assertEqual(
+            ("3.2.2", False, 30), (version, "GIT_DIR" in run.call_args.kwargs["env"], run.call_args.kwargs["timeout"])
+        )
         with (
             mock.patch.object(MODULE, "changed_security_versions", return_value=[]),
             mock.patch.object(

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -596,6 +596,9 @@ class WorkflowSecurityTests(unittest.TestCase):
         self.assertNotIn("--force-with-lease", release_prepare)
         self.assertIn('"$promotion_base/scripts/security_main_promotion.py"', release_prepare)
         self.assertIn('authenticated_push origin "HEAD:${release_ref}"', release_prepare)
+        for workflow in (back_sync, release_prepare, (WORKFLOWS / "collection-ci.yml").read_text()):
+            self.assertIn("git cat-file -e", workflow)
+            self.assertIn("git merge-base --is-ancestor", workflow)
 
     def test_zero_touch_is_security_only_and_normal_promotion_stays_manual(self) -> None:
         ci = load_yaml(WORKFLOWS / "collection-ci.yml")["jobs"]

--- a/tests/unit/test_workflow_security.py
+++ b/tests/unit/test_workflow_security.py
@@ -584,17 +584,18 @@ class WorkflowSecurityTests(unittest.TestCase):
                 self.assertIn("steps.release-bot.outputs.email", text)
 
         back_sync = (WORKFLOWS / "release-back-sync.yml").read_text(encoding="utf-8")
-        self.assertIn('"--force-with-lease=${branch_ref}:${remote_branch_sha}"', back_sync)
+        self.assertNotIn("--force-with-lease", back_sync)
         self.assertNotIn("authenticated_push --force origin", back_sync)
+        self.assertIn('"$back_sync_policy/scripts/verify_release_back_sync.py"', back_sync)
+        self.assertIn('authenticated_push origin "HEAD:${branch_ref}"', back_sync)
         self.assertNotIn("permission-issues:", back_sync)
         self.assertNotIn("gh label ", back_sync)
         self.assertNotIn("--label skip-changelog", back_sync)
         self.assertNotIn("--add-label skip-changelog", back_sync)
         release_prepare = (WORKFLOWS / "release-prepare.yml").read_text(encoding="utf-8")
-        self.assertIn(
-            '"--force-with-lease=${release_ref}:${remote_release_sha}"',
-            release_prepare,
-        )
+        self.assertNotIn("--force-with-lease", release_prepare)
+        self.assertIn('"$promotion_base/scripts/security_main_promotion.py"', release_prepare)
+        self.assertIn('authenticated_push origin "HEAD:${release_ref}"', release_prepare)
 
     def test_zero_touch_is_security_only_and_normal_promotion_stays_manual(self) -> None:
         ci = load_yaml(WORKFLOWS / "collection-ci.yml")["jobs"]


### PR DESCRIPTION
## Summary

- verifies exact App-authored Security promotions by content, identity, ancestry, and immutable intake receipt
- replaces force-with-lease back-sync behavior with fetch/verify/reuse-or-push logic
- keeps normal releases human-approved while Security releases remain fail-closed and zero-touch
- isolates release-validation waiting into a read-only job

## Evidence

- exact head: ffa501abfd0a0994668608456b9bcc5d6347f98b
- exact base: 3d0f1d8f79efa55fa6c0330fcac06506771e4ed1
- local unit suite: 279 PASS
- focused promotion/classification/back-sync/workflow suite: 60 PASS
- history-free Copilot/Codex review: PASS/PASS
- exact review patch SHA-256: f11ec97ebb653c9f89b929754882c74e84a63a851d54d514c552bf4458dfa7d0

No force push or branch, ruleset, environment, or admin bypass. Merge only after all protected current-head gates pass as a normal merge commit.