### PR TITLE
fix(security): redact base64url JWT suffixes

### DIFF
--- a/molecule/shared/keycloak/acceptance/trace_sanitizer.py
+++ b/molecule/shared/keycloak/acceptance/trace_sanitizer.py
@@ -17,7 +17,11 @@ SENSITIVE_KEY = re.compile(
     r"(?i)(authorization|cookie|credential|header|password|post.?data|request.?body|"
     r"response.?body|secret|storage|token|value|text)"
 )
-JWT = re.compile(r"\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b")
+# A JWT uses base64url, where "_" is a valid final character.  A ``\b``
+# boundary would miss that case because underscore is a word character.
+JWT = re.compile(
+    r"(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}(?![A-Za-z0-9_-])"
+)
 AUTHORIZATION = re.compile(r"(?i)\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}")
 COOKIE_ASSIGNMENT = re.compile(r"(?i)\b(?:cookie|set-cookie)\s*[:=][^\r\n,}]+")
 HTTP_URL = re.compile(r"https?://[^\s\"'<>]+")

--- a/tests/unit/test_keycloak_evidence_producers.py
+++ b/tests/unit/test_keycloak_evidence_producers.py
@@ -363,7 +363,7 @@ class KeycloakEvidenceProducerTests(unittest.TestCase):
         sanitizer = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(sanitizer)
         typed_value = secrets.token_urlsafe(24)
-        token = f"eyJ{secrets.token_urlsafe(12)}.{secrets.token_urlsafe(12)}.{secrets.token_urlsafe(18)}"
+        token = f"eyJ{secrets.token_urlsafe(12)}.{secrets.token_urlsafe(12)}.{secrets.token_urlsafe(18)}_"
         authorization_code = secrets.token_urlsafe(24)
         private_cookie = secrets.token_urlsafe(24)
         self.assertIsNotNone(sanitizer.JWT.fullmatch(token))


### PR DESCRIPTION
## Summary
- recognize JWTs ending in the base64url underscore character
- make the regression test deterministic

## Verification
- keycloak evidence producer unit tests
- workflow security unit tests
- whitespace validation

This fixes the exact fail-closed Lint/Sanity failure from MLX-90 security candidate run 31450766930; Fast and Release Evidence were dependent failures.