### PR TITLE
fix(security): redact base64url JWT suffixes

### DIFF
--- a/molecule/shared/incus/helpers/sanitize_evidence.py
+++ b/molecule/shared/incus/helpers/sanitize_evidence.py
@@ -32,8 +32,9 @@ PROSE_SECRET = re.compile(
 )
 BEARER_TOKEN = re.compile(r"(?i)(\bBearer\s+)[A-Za-z0-9._~+/=-]+")
 JWT = re.compile(
-    r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\."
-    r"[A-Za-z0-9_-]{8,}\b",
+    r"(?<![A-Za-z0-9_-])"
+    r"eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"
+    r"(?![A-Za-z0-9_-])",
 )
 URL_CREDENTIAL = re.compile(
     r"(?i)(\b[a-z][a-z0-9+.-]*://[^\s/:@]+:)[^\s/@]+(@)",

--- a/molecule/shared/keycloak/acceptance/trace_sanitizer.py
+++ b/molecule/shared/keycloak/acceptance/trace_sanitizer.py
@@ -17,9 +17,13 @@ SENSITIVE_KEY = re.compile(
     r"(?i)(authorization|cookie|credential|header|password|post.?data|request.?body|"
     r"response.?body|secret|storage|token|value|text)"
 )
-# A JWT uses base64url, where "_" is a valid final character.  A ``\b``
-# boundary would miss that case because underscore is a word character.
-JWT = re.compile(r"(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}(?![A-Za-z0-9_-])")
+# JWT segments use base64url, including both "_" and "-".  ``\b`` uses
+# Python's narrower ``\w`` definition, so it can miss a terminal "-".
+JWT = re.compile(
+    r"(?<![A-Za-z0-9_-])"
+    r"eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}"
+    r"(?![A-Za-z0-9_-])"
+)
 AUTHORIZATION = re.compile(r"(?i)\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}")
 COOKIE_ASSIGNMENT = re.compile(r"(?i)\b(?:cookie|set-cookie)\s*[:=][^\r\n,}]+")
 HTTP_URL = re.compile(r"https?://[^\s\"'<>]+")

--- a/molecule/shared/keycloak/acceptance/trace_sanitizer.py
+++ b/molecule/shared/keycloak/acceptance/trace_sanitizer.py
@@ -19,9 +19,7 @@ SENSITIVE_KEY = re.compile(
 )
 # A JWT uses base64url, where "_" is a valid final character.  A ``\b``
 # boundary would miss that case because underscore is a word character.
-JWT = re.compile(
-    r"(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}(?![A-Za-z0-9_-])"
-)
+JWT = re.compile(r"(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}(?![A-Za-z0-9_-])")
 AUTHORIZATION = re.compile(r"(?i)\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}")
 COOKIE_ASSIGNMENT = re.compile(r"(?i)\b(?:cookie|set-cookie)\s*[:=][^\r\n,}]+")
 HTTP_URL = re.compile(r"https?://[^\s\"'<>]+")

--- a/molecule/shared/keycloak/acceptance/trace_sanitizer.py
+++ b/molecule/shared/keycloak/acceptance/trace_sanitizer.py
@@ -17,7 +17,11 @@ SENSITIVE_KEY = re.compile(
     r"(?i)(authorization|cookie|credential|header|password|post.?data|request.?body|"
     r"response.?body|secret|storage|token|value|text)"
 )
-JWT = re.compile(r"\beyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\b")
+# A JWT uses base64url, where "_" is a valid final character.  A ``\b``
+# boundary would miss that case because underscore is a word character.
+JWT = re.compile(
+    r"(?<![A-Za-z0-9_-])eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}(?![A-Za-z0-9_-])"
+)
 AUTHORIZATION = re.compile(r"(?i)\b(?:bearer|basic)\s+[A-Za-z0-9._~+/=-]{8,}")
 COOKIE_ASSIGNMENT = re.compile(r"(?i)\b(?:cookie|set-cookie)\s*[:=][^\r\n,}]+")
 HTTP_URL = re.compile(r"https?://[^\s\"'<>]+")

--- a/scripts/quality_evidence.py
+++ b/scripts/quality_evidence.py
@@ -118,7 +118,11 @@ SECRET_ASSIGNMENT_RE = re.compile(
 )
 BEARER_RE = re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{8,}")
 BASIC_AUTH_RE = re.compile(r"(?i)\bbasic\s+[a-z0-9+/]{4,}={0,2}")
-JWT_RE = re.compile(r"\beyJ[a-zA-Z0-9_-]{5,}\.[a-zA-Z0-9_-]{5,}\.[a-zA-Z0-9_-]{5,}\b")
+JWT_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])"
+    r"eyJ[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}\.[A-Za-z0-9_-]{5,}"
+    r"(?![A-Za-z0-9_-])"
+)
 API_KEY_RE = re.compile(
     r"(?i)\b(?:gh[pousr]_[a-z0-9]{20,}|github_pat_[a-z0-9_]{20,}|"
     r"(?:AKIA|ASIA)[A-Z0-9]{16}|xox[baprs]-[a-z0-9-]{10,}|sk-[a-z0-9_-]{20,})\b"

--- a/tests/unit/test_keycloak_evidence_producers.py
+++ b/tests/unit/test_keycloak_evidence_producers.py
@@ -363,10 +363,10 @@ class KeycloakEvidenceProducerTests(unittest.TestCase):
         sanitizer = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(sanitizer)
         typed_value = secrets.token_urlsafe(24)
-        token = "eyJheaderpayload.fixturepayload.signaturepayload-"
+        synthetic_jwt = "eyJheaderpayload.fixturepayload.signaturepayload-"
         authorization_code = secrets.token_urlsafe(24)
         private_cookie = secrets.token_urlsafe(24)
-        self.assertIsNotNone(sanitizer.JWT.fullmatch(token))
+        self.assertIsNotNone(sanitizer.JWT.fullmatch(synthetic_jwt))
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             source = root / "raw.zip"
@@ -385,18 +385,24 @@ class KeycloakEvidenceProducerTests(unittest.TestCase):
                                     "headers": {"Cookie": f"oidc_acceptance_sid={private_cookie}"},
                                 }
                             ),
-                            json.dumps({"type": "after", "token": token, "message": f"Bearer {token}"}),
+                            json.dumps(
+                                {
+                                    "type": "after",
+                                    "token": synthetic_jwt,
+                                    "message": f"Bearer {synthetic_jwt}",
+                                }
+                            ),
                         )
                     ),
                 )
                 archive.writestr("trace.network", f"Cookie: oidc_acceptance_sid={private_cookie}")
-                archive.writestr("resources/body", token)
+                archive.writestr("resources/body", synthetic_jwt)
                 archive.writestr("trace.stacks", json.dumps({"files": ["test_acceptance.py"]}))
 
             with zipfile.ZipFile(source) as archive:
                 raw_trace = archive.read("trace.trace").decode("utf-8")
             self.assertIn(typed_value, raw_trace)
-            self.assertIn(token, raw_trace)
+            self.assertIn(synthetic_jwt, raw_trace)
             self.assertIn(authorization_code, raw_trace)
             self.assertIn(private_cookie, raw_trace)
 
@@ -408,7 +414,7 @@ class KeycloakEvidenceProducerTests(unittest.TestCase):
             self.assertIn("locator.fill", rendered)
             self.assertIn("https://id.example/callback", rendered)
             self.assertIn("[REDACTED-JWT]", rendered)
-            for forbidden in (typed_value, token, authorization_code, private_cookie, "?code="):
+            for forbidden in (typed_value, synthetic_jwt, authorization_code, private_cookie, "?code="):
                 self.assertNotIn(forbidden, rendered)
 
 

--- a/tests/unit/test_keycloak_evidence_producers.py
+++ b/tests/unit/test_keycloak_evidence_producers.py
@@ -363,7 +363,7 @@ class KeycloakEvidenceProducerTests(unittest.TestCase):
         sanitizer = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(sanitizer)
         typed_value = secrets.token_urlsafe(24)
-        token = f"eyJ{secrets.token_urlsafe(12)}.{secrets.token_urlsafe(12)}.{secrets.token_urlsafe(18)}"
+        token = f"eyJ{secrets.token_urlsafe(12)}.{secrets.token_urlsafe(12)}.{secrets.token_urlsafe(18)}_"
         authorization_code = secrets.token_urlsafe(24)
         private_cookie = secrets.token_urlsafe(24)
         self.assertIsNotNone(sanitizer.JWT.fullmatch(token))

--- a/tests/unit/test_keycloak_evidence_producers.py
+++ b/tests/unit/test_keycloak_evidence_producers.py
@@ -363,7 +363,7 @@ class KeycloakEvidenceProducerTests(unittest.TestCase):
         sanitizer = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(sanitizer)
         typed_value = secrets.token_urlsafe(24)
-        token = f"eyJ{secrets.token_urlsafe(12)}.{secrets.token_urlsafe(12)}.{secrets.token_urlsafe(18)}_"
+        token = "eyJheaderpayload.fixturepayload.signaturepayload-"
         authorization_code = secrets.token_urlsafe(24)
         private_cookie = secrets.token_urlsafe(24)
         self.assertIsNotNone(sanitizer.JWT.fullmatch(token))

--- a/tests/unit/test_quality_evidence.py
+++ b/tests/unit/test_quality_evidence.py
@@ -1502,13 +1502,13 @@ class QualityEvidenceTests(unittest.TestCase):
         self.assertIn("X-API-Key: [REDACTED]", redacted_headers)
 
     def test_redacts_jwt_with_base64url_terminal_dash(self) -> None:
-        token = "eyJheaderpayload.fixturepayload.signaturepayload-"
-        source = f"diagnostic token {token}."
+        synthetic_jwt = "eyJheaderpayload.fixturepayload.signaturepayload-"
+        source = f"diagnostic token {synthetic_jwt}."
 
-        self.assertIsNotNone(evidence.JWT_RE.fullmatch(token))
+        self.assertIsNotNone(evidence.JWT_RE.fullmatch(synthetic_jwt))
         rendered = evidence.redact_text(source)
 
-        self.assertNotIn(token, rendered)
+        self.assertNotIn(synthetic_jwt, rendered)
         self.assertIn("[REDACTED JWT]", rendered)
 
     def test_unknown_junit_commit_is_ineligible(self) -> None:

--- a/tests/unit/test_quality_evidence.py
+++ b/tests/unit/test_quality_evidence.py
@@ -1501,6 +1501,16 @@ class QualityEvidenceTests(unittest.TestCase):
         self.assertNotIn(synthetic_header_value, redacted_headers)
         self.assertIn("X-API-Key: [REDACTED]", redacted_headers)
 
+    def test_redacts_jwt_with_base64url_terminal_dash(self) -> None:
+        token = "eyJheaderpayload.fixturepayload.signaturepayload-"
+        source = f"diagnostic token {token}."
+
+        self.assertIsNotNone(evidence.JWT_RE.fullmatch(token))
+        rendered = evidence.redact_text(source)
+
+        self.assertNotIn(token, rendered)
+        self.assertIn("[REDACTED JWT]", rendered)
+
     def test_unknown_junit_commit_is_ineligible(self) -> None:
         self._registry()
         self._junit(commit="unknown")

--- a/tests/unit/test_sanitize_evidence.py
+++ b/tests/unit/test_sanitize_evidence.py
@@ -123,13 +123,13 @@ class SanitizeEvidenceTests(unittest.TestCase):
         self.assertGreaterEqual(result.count("[REDACTED]"), 3)
 
     def test_redacts_jwt_with_base64url_terminal_dash(self) -> None:
-        token = "eyJheaderpayload.fixturepayload.signaturepayload-"
-        source = f"diagnostic token {token}."
+        synthetic_jwt = "eyJheaderpayload.fixturepayload.signaturepayload-"
+        source = f"diagnostic token {synthetic_jwt}."
 
-        self.assertIsNotNone(SANITIZER.JWT.fullmatch(token))
+        self.assertIsNotNone(SANITIZER.JWT.fullmatch(synthetic_jwt))
         result = SANITIZER.sanitize(source, [])
 
-        self.assertNotIn(token, result)
+        self.assertNotIn(synthetic_jwt, result)
         self.assertIn("[REDACTED JWT]", result)
 
     def test_redacts_long_escaped_quoted_values_without_backtracking(self) -> None:

--- a/tests/unit/test_sanitize_evidence.py
+++ b/tests/unit/test_sanitize_evidence.py
@@ -122,6 +122,16 @@ class SanitizeEvidenceTests(unittest.TestCase):
         self.assertNotIn(environment_fixture, result)
         self.assertGreaterEqual(result.count("[REDACTED]"), 3)
 
+    def test_redacts_jwt_with_base64url_terminal_dash(self) -> None:
+        token = "eyJheaderpayload.fixturepayload.signaturepayload-"
+        source = f"diagnostic token {token}."
+
+        self.assertIsNotNone(SANITIZER.JWT.fullmatch(token))
+        result = SANITIZER.sanitize(source, [])
+
+        self.assertNotIn(token, result)
+        self.assertIn("[REDACTED JWT]", result)
+
     def test_redacts_long_escaped_quoted_values_without_backtracking(self) -> None:
         password = (r"\!" * 4096) + secrets.token_urlsafe(24)
         client_secret = (r"\&" * 4096) + secrets.token_urlsafe(24)


### PR DESCRIPTION
## Summary
- recognize JWTs at base64url boundaries, including terminal `_` and `-`
- apply the same matcher to trace, controller, and quality-evidence sanitizers
- make the terminal-base64url regression deterministic

## Verification
- Keycloak evidence-producer, controller-sanitizer, and quality-evidence unit tests
- repository Ruff formatter check
- whitespace validation

This supersedes PR #661 because that branch was based on the pre-merge parent of develop. PR #662 is based on the current `develop` head and receives fresh protected Current-Head gates.