### PR TITLE
feat(nginx): enforce explicit Vault TLS custody

### DIFF
--- a/changelogs/fragments/wunderbox-goal07-management-services.yml
+++ b/changelogs/fragments/wunderbox-goal07-management-services.yml
@@ -5,3 +5,6 @@ minor_changes:
   - Add Vault-backed NetBox Keycloak configuration and inventory-declared Guacamole connection reconciliation.
   - Add optional mTLS transport settings to the Grafana Alloy Loki client.
   - Add explicit CA, namespace, and AppRole mount support to NGINX Vault TLS retrieval.
+  - >-
+    Add an explicit NGINX switch for profiles that must reject local
+    certificate files and enforce Vault-only TLS custody.

--- a/roles/nginx_config/README.md
+++ b/roles/nginx_config/README.md
@@ -28,7 +28,17 @@ Key variables:
 - `nginx_config_vault_kv_path`
 - `nginx_config_vault_pki_path`
 - `nginx_config_vault_pki_role`
+- `nginx_config_vault_issue_missing` (default: `true`; issue and persist missing or mismatched material through Vault PKI)
+- `nginx_config_vault_allow_local_fallback` (compatibility default: `true`; set to `false` for Vault-only custody)
 - `nginx_config_remove_default`
+
+With `nginx_config_tls_source: vault`, certificate material is read from Vault
+KV or issued through Vault PKI and then persisted to Vault KV. Private keys are
+written to the managed host with mode `0600`. Set
+`nginx_config_vault_allow_local_fallback: false` in security profiles that must
+reject local certificate/key files as a source of record. The compatibility
+default remains enabled for existing consumers and must not be relied upon as
+proof of Vault-only custody.
 
 ## Dependencies
 

--- a/roles/nginx_config/README.md
+++ b/roles/nginx_config/README.md
@@ -40,6 +40,11 @@ reject local certificate/key files as a source of record. The compatibility
 default remains enabled for existing consumers and must not be relied upon as
 proof of Vault-only custody.
 
+When `nginx_config_vault_issue_missing: false`, Vault KV must already contain a
+certificate/private-key pair, a CA chain, and matching common-name and
+alternative-name metadata. Local host files do not satisfy that stored-identity
+contract.
+
 ## Dependencies
 
 None.

--- a/roles/nginx_config/defaults/main.yml
+++ b/roles/nginx_config/defaults/main.yml
@@ -23,8 +23,8 @@ nginx_config_vault_namespace: ""
 nginx_config_vault_auth_mount_point: "approle"
 nginx_config_vault_kv_mount: "{{ vault_engine_mount_point | default('stage-2c') }}"
 nginx_config_vault_kv_path: "{{ inventory_hostname }}/nginx/certificate"
-nginx_config_vault_pki_path: "{{ vault_config_vault_pki_path }}"
-nginx_config_vault_pki_role: "{{ vault_config_vault_pki_role }}"
+nginx_config_vault_pki_path: "{{ vault_config_vault_pki_path | default('', true) }}"
+nginx_config_vault_pki_role: "{{ vault_config_vault_pki_role | default('', true) }}"
 nginx_config_vault_issue_missing: true
 # Compatibility default for existing consumers. Security profiles that require
 # Vault-only custody must set this to false explicitly.

--- a/roles/nginx_config/defaults/main.yml
+++ b/roles/nginx_config/defaults/main.yml
@@ -25,6 +25,10 @@ nginx_config_vault_kv_mount: "{{ vault_engine_mount_point | default('stage-2c') 
 nginx_config_vault_kv_path: "{{ inventory_hostname }}/nginx/certificate"
 nginx_config_vault_pki_path: "{{ vault_config_vault_pki_path }}"
 nginx_config_vault_pki_role: "{{ vault_config_vault_pki_role }}"
+nginx_config_vault_issue_missing: true
+# Compatibility default for existing consumers. Security profiles that require
+# Vault-only custody must set this to false explicitly.
+nginx_config_vault_allow_local_fallback: true
 nginx_config_vault_token: "{{ vault_token | default('', true) }}"
 nginx_config_vault_role_id: "{{ ansible_hashi_vault_role_id | default('', true) }}"
 nginx_config_vault_secret_id: "{{ ansible_hashi_vault_secret_id | default('', true) }}"

--- a/roles/nginx_config/tasks/assert.yml
+++ b/roles/nginx_config/tasks/assert.yml
@@ -66,6 +66,7 @@
       private key, chain, and identity metadata already exist in Vault KV.
     quiet: true
   when:
+    - not nginx_deploy_skip_config | bool
     - nginx_config_has_force_https_vhosts | bool
     - nginx_config_tls_source == 'vault'
     - nginx_config_vault_issue_missing | bool

--- a/roles/nginx_config/tasks/assert.yml
+++ b/roles/nginx_config/tasks/assert.yml
@@ -35,8 +35,10 @@
       - nginx_config_vault_validate_certs is boolean
       - nginx_config_vault_kv_mount | default('', true) | trim | length > 0
       - nginx_config_vault_kv_path | default('', true) | trim | length > 0
-      - nginx_config_vault_pki_path | default('', true) | trim | length > 0
-      - nginx_config_vault_pki_role | default('', true) | trim | length > 0
+      - nginx_config_vault_pki_path is string
+      - nginx_config_vault_pki_role is string
+      - nginx_config_vault_issue_missing is boolean
+      - nginx_config_vault_allow_local_fallback is boolean
       - nginx_config_vault_token is string
       - nginx_config_vault_role_id is string
       - nginx_config_vault_secret_id is string
@@ -51,6 +53,22 @@
       - nginx_config_test is boolean
     fail_msg: "nginx_config variables are missing or invalid."
     quiet: true
+  tags: always
+
+- name: Ensure Vault PKI issue inputs are present when enabled
+  ansible.builtin.assert:
+    that:
+      - nginx_config_vault_pki_path | default('', true) | trim | length > 0
+      - nginx_config_vault_pki_role | default('', true) | trim | length > 0
+    fail_msg: >-
+      nginx_config_vault_issue_missing=true requires a non-empty Vault PKI
+      issue path and role. Disable issuance only when a complete certificate,
+      private key, chain, and identity metadata already exist in Vault KV.
+    quiet: true
+  when:
+    - nginx_config_has_force_https_vhosts | bool
+    - nginx_config_tls_source == 'vault'
+    - nginx_config_vault_issue_missing | bool
   tags: always
 
 - name: Ensure Vault TLS inputs are present when source=vault

--- a/roles/nginx_config/tasks/main.yml
+++ b/roles/nginx_config/tasks/main.yml
@@ -560,7 +560,6 @@
       certificate/private-key pair, CA chain, and matching identity metadata.
       Local host files are not accepted as Vault certificate custody.
     quiet: true
-  no_log: "{{ nginx_config_tls_no_log }}"
   when:
     - not nginx_deploy_skip_config | bool
     - nginx_config_has_force_https_vhosts | bool

--- a/roles/nginx_config/tasks/main.yml
+++ b/roles/nginx_config/tasks/main.yml
@@ -411,6 +411,7 @@
     - not nginx_deploy_skip_config | bool
     - nginx_config_has_force_https_vhosts | bool
     - nginx_config_tls_source == 'vault'
+    - nginx_config_vault_allow_local_fallback | bool
     - not (nginx_config_vault_cert_present | default(false) | bool)
     - nginx_config_local_tls_present | default(false) | bool
   tags:
@@ -425,6 +426,7 @@
     - not nginx_deploy_skip_config | bool
     - nginx_config_has_force_https_vhosts | bool
     - nginx_config_tls_source == 'vault'
+    - nginx_config_vault_allow_local_fallback | bool
     - not (nginx_config_vault_cert_present | default(false) | bool)
     - nginx_config_local_tls_present | default(false) | bool
   tags:
@@ -442,6 +444,7 @@
     - not nginx_deploy_skip_config | bool
     - nginx_config_has_force_https_vhosts | bool
     - nginx_config_tls_source == 'vault'
+    - nginx_config_vault_allow_local_fallback | bool
     - not (nginx_config_vault_cert_present | default(false) | bool)
     - nginx_config_local_tls_present | default(false) | bool
   tags:
@@ -485,9 +488,11 @@
     - not nginx_deploy_skip_config | bool
     - nginx_config_has_force_https_vhosts | bool
     - nginx_config_tls_source == 'vault'
+    - nginx_config_vault_issue_missing | bool
     - nginx_config_vault_cert_needs_rotation | default(true) | bool
     - not (
-        (not (nginx_config_vault_cert_present | default(false) | bool))
+        (nginx_config_vault_allow_local_fallback | bool)
+        and (not (nginx_config_vault_cert_present | default(false) | bool))
         and (nginx_config_local_tls_present | default(false) | bool)
       )
     - not ansible_check_mode
@@ -541,6 +546,26 @@
     - not nginx_deploy_skip_config | bool
     - nginx_config_has_force_https_vhosts | bool
     - nginx_config_tls_source == 'vault'
+  tags:
+    - config
+
+- name: Require a complete stored Vault TLS identity when issuance is disabled
+  ansible.builtin.assert:
+    that:
+      - nginx_config_vault_cert_present | default(false) | bool
+      - nginx_config_vault_cert_identity_match | default(false) | bool
+      - nginx_config_vault_cert_ca_chain_stored | default([], true) | length > 0
+    fail_msg: >-
+      Vault PKI issuance is disabled, but Vault KV does not contain a complete
+      certificate/private-key pair, CA chain, and matching identity metadata.
+      Local host files are not accepted as Vault certificate custody.
+    quiet: true
+  no_log: "{{ nginx_config_tls_no_log }}"
+  when:
+    - not nginx_deploy_skip_config | bool
+    - nginx_config_has_force_https_vhosts | bool
+    - nginx_config_tls_source == 'vault'
+    - not (nginx_config_vault_issue_missing | bool)
   tags:
     - config
 
@@ -609,7 +634,14 @@
         nginx_config_vault_generated_cert_data.certificate
           | default(
             nginx_config_vault_cert_data.certificate
-              | default(nginx_config_local_tls_certificate_content | default('', true), true),
+              | default(
+                  (
+                    nginx_config_local_tls_certificate_content | default('', true)
+                    if (nginx_config_vault_allow_local_fallback | bool)
+                    else ''
+                  ),
+                  true
+                ),
             true
           )
       }}
@@ -618,7 +650,14 @@
         nginx_config_vault_generated_cert_data.private_key
           | default(
             nginx_config_vault_cert_data.private_key
-              | default(nginx_config_local_tls_certificate_key_content | default('', true), true),
+              | default(
+                  (
+                    nginx_config_local_tls_certificate_key_content | default('', true)
+                    if (nginx_config_vault_allow_local_fallback | bool)
+                    else ''
+                  ),
+                  true
+                ),
             true
           )
       }}

--- a/tests/unit/test_nginx_vault_tls_contracts.py
+++ b/tests/unit/test_nginx_vault_tls_contracts.py
@@ -1,0 +1,88 @@
+"""Security contracts for NGINX Vault-only TLS custody."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULTS = ROOT / "roles" / "nginx_config" / "defaults" / "main.yml"
+ASSERTS = ROOT / "roles" / "nginx_config" / "tasks" / "assert.yml"
+TASKS = ROOT / "roles" / "nginx_config" / "tasks" / "main.yml"
+
+
+class NginxVaultTlsContractTests(unittest.TestCase):
+    def test_local_tls_fallback_has_explicit_compatibility_switch(self) -> None:
+        defaults = yaml.safe_load(DEFAULTS.read_text(encoding="utf-8"))
+
+        self.assertIs(defaults["nginx_config_vault_allow_local_fallback"], True)
+        self.assertIs(defaults["nginx_config_vault_issue_missing"], True)
+
+    def test_pki_inputs_are_required_only_when_issuance_is_enabled(self) -> None:
+        tasks = yaml.safe_load(ASSERTS.read_text(encoding="utf-8"))
+        task = next(
+            item
+            for item in tasks
+            if item.get("name") == "Ensure Vault PKI issue inputs are present when enabled"
+        )
+
+        self.assertIn("nginx_config_vault_issue_missing | bool", task["when"])
+        assertions = task["ansible.builtin.assert"]["that"]
+        self.assertTrue(any("nginx_config_vault_pki_path" in item for item in assertions))
+        self.assertTrue(any("nginx_config_vault_pki_role" in item for item in assertions))
+
+    def test_host_files_require_explicit_migration_fallback(self) -> None:
+        tasks = yaml.safe_load(TASKS.read_text(encoding="utf-8"))
+        fallback_tasks = [
+            item
+            for item in tasks
+            if item.get("name")
+            in {
+                "Read local TLS certificate fallback",
+                "Read local TLS private key fallback",
+                "Set local TLS fallback content",
+            }
+        ]
+
+        self.assertEqual(len(fallback_tasks), 3)
+        for task in fallback_tasks:
+            with self.subTest(task=task["name"]):
+                self.assertIn(
+                    "nginx_config_vault_allow_local_fallback | bool",
+                    task["when"],
+                )
+
+    def test_stored_vault_identity_is_complete_when_pki_issue_is_disabled(self) -> None:
+        tasks = yaml.safe_load(TASKS.read_text(encoding="utf-8"))
+        task = next(
+            item
+            for item in tasks
+            if item.get("name")
+            == "Require a complete stored Vault TLS identity when issuance is disabled"
+        )
+        assertions = task["ansible.builtin.assert"]["that"]
+
+        self.assertIn(
+            "nginx_config_vault_cert_present | default(false) | bool",
+            assertions,
+        )
+        self.assertIn(
+            "nginx_config_vault_cert_identity_match | default(false) | bool",
+            assertions,
+        )
+        self.assertIn("not (nginx_config_vault_issue_missing | bool)", task["when"])
+
+    def test_private_key_is_installed_with_mode_0600(self) -> None:
+        tasks = yaml.safe_load(TASKS.read_text(encoding="utf-8"))
+        task = next(
+            item for item in tasks if item.get("name") == "Write TLS private key from Vault"
+        )
+
+        self.assertEqual(task["ansible.builtin.copy"]["mode"], "0600")
+        self.assertEqual(task["no_log"], "{{ nginx_config_tls_no_log }}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_nginx_vault_tls_contracts.py
+++ b/tests/unit/test_nginx_vault_tls_contracts.py
@@ -70,6 +70,10 @@ class NginxVaultTlsContractTests(unittest.TestCase):
             "nginx_config_vault_cert_identity_match | default(false) | bool",
             assertions,
         )
+        self.assertIn(
+            "nginx_config_vault_cert_ca_chain_stored | default([], true) | length > 0",
+            assertions,
+        )
         self.assertIn("not (nginx_config_vault_issue_missing | bool)", task["when"])
 
     def test_private_key_is_installed_with_mode_0600(self) -> None:

--- a/tests/unit/test_nginx_vault_tls_contracts.py
+++ b/tests/unit/test_nginx_vault_tls_contracts.py
@@ -23,9 +23,7 @@ class NginxVaultTlsContractTests(unittest.TestCase):
     def test_pki_inputs_are_required_only_when_issuance_is_enabled(self) -> None:
         tasks = yaml.safe_load(ASSERTS.read_text(encoding="utf-8"))
         task = next(
-            item
-            for item in tasks
-            if item.get("name") == "Ensure Vault PKI issue inputs are present when enabled"
+            item for item in tasks if item.get("name") == "Ensure Vault PKI issue inputs are present when enabled"
         )
 
         self.assertIn("nginx_config_vault_issue_missing | bool", task["when"])
@@ -59,8 +57,7 @@ class NginxVaultTlsContractTests(unittest.TestCase):
         task = next(
             item
             for item in tasks
-            if item.get("name")
-            == "Require a complete stored Vault TLS identity when issuance is disabled"
+            if item.get("name") == "Require a complete stored Vault TLS identity when issuance is disabled"
         )
         assertions = task["ansible.builtin.assert"]["that"]
 
@@ -76,9 +73,7 @@ class NginxVaultTlsContractTests(unittest.TestCase):
 
     def test_private_key_is_installed_with_mode_0600(self) -> None:
         tasks = yaml.safe_load(TASKS.read_text(encoding="utf-8"))
-        task = next(
-            item for item in tasks if item.get("name") == "Write TLS private key from Vault"
-        )
+        task = next(item for item in tasks if item.get("name") == "Write TLS private key from Vault")
 
         self.assertEqual(task["ansible.builtin.copy"]["mode"], "0600")
         self.assertEqual(task["no_log"], "{{ nginx_config_tls_no_log }}")

--- a/tests/unit/test_nginx_vault_tls_contracts.py
+++ b/tests/unit/test_nginx_vault_tls_contracts.py
@@ -26,6 +26,7 @@ class NginxVaultTlsContractTests(unittest.TestCase):
             item for item in tasks if item.get("name") == "Ensure Vault PKI issue inputs are present when enabled"
         )
 
+        self.assertIn("not nginx_deploy_skip_config | bool", task["when"])
         self.assertIn("nginx_config_vault_issue_missing | bool", task["when"])
         assertions = task["ansible.builtin.assert"]["that"]
         self.assertTrue(any("nginx_config_vault_pki_path" in item for item in assertions))


### PR DESCRIPTION
## Summary
- make local TLS fallback an explicit compatibility switch
- require complete Vault KV identity when PKI issuance is disabled
- preserve private-key mode 0600 and no_log handling
- add focused Vault TLS custody contract tests

## Verification
- Python unit tests: 5 passed
- yamllint: passed
- ansible-lint/pre-commit hook: passed
- NGINX Molecule syntax, converge, idempotence, verify: passed
- collection smoke and Galaxy verification: passed

The full non-heavy Molecule matrix also exposed an unrelated existing macOS UID mapping failure in artifacts-basic before reaching later scenarios; the targeted NGINX scenario passed independently.

Work item: LI-139