### PR TITLE
fix(release): bootstrap promotion verifier interface

### DIFF
--- a/.github/workflows/main-promotion-authorization.yml
+++ b/.github/workflows/main-promotion-authorization.yml
@@ -97,13 +97,31 @@ jobs:
           fi
           test -f policy/scripts/main-promotion-authorization.py
           test -f policy/.github/workflows/main-promotion-authorization.yml
+          policy_root_args=()
+          if grep -Fq 'parser.add_argument("--base-root"' \
+            policy/scripts/main-promotion-authorization.py; then
+            policy_root_args=(--base-root policy --head-root candidate)
+          else
+            # Compatibility is limited to the one normal develop promotion
+            # that installs the content-verifying policy into main. Reserved
+            # release/Security heads remain fail-closed until that policy is
+            # part of the immutable event base.
+            jq -e \
+              --arg base "$EVENT_BASE_SHA" \
+              --arg head "$EVENT_HEAD_SHA" \
+              --arg repo "$REPOSITORY" \
+              '(.state == "open") and (.draft == false)
+               and (.base.ref == "main") and (.base.sha == $base)
+               and (.head.ref == "develop") and (.head.sha == $head)
+               and (.head.repo.full_name == $repo)' \
+              live-pull.json >/dev/null
+          fi
           classification="$(python3 policy/scripts/main-promotion-authorization.py \
             --pull live-pull.json \
             --repository "$REPOSITORY" \
             --expected-base "$EVENT_BASE_SHA" \
             --expected-head "$EVENT_HEAD_SHA" \
-            --base-root policy \
-            --head-root candidate \
+            "${policy_root_args[@]}" \
             --classification-only)"
           environment="$(jq -er .environment <<<"$classification")"
           gh api "repos/${REPOSITORY}/environments/${environment}" \
@@ -114,8 +132,7 @@ jobs:
             --repository "$REPOSITORY" \
             --expected-base "$EVENT_BASE_SHA" \
             --expected-head "$EVENT_HEAD_SHA" \
-            --base-root policy \
-            --head-root candidate \
+            "${policy_root_args[@]}" \
             --github-output "$GITHUB_OUTPUT"
           echo 'bootstrap=false' >>"$GITHUB_OUTPUT"
 
@@ -204,14 +221,30 @@ jobs:
             ' live-environment.json >/dev/null
           else
             test "$BOOTSTRAP" = false
+            policy_root_args=()
+            if grep -Fq 'parser.add_argument("--base-root"' \
+              policy/scripts/main-promotion-authorization.py; then
+              policy_root_args=(--base-root policy --head-root candidate)
+            else
+              # Apply the same exact normal-develop compatibility constraint
+              # again after the protected environment approval.
+              jq -e \
+                --arg base "$EVENT_BASE_SHA" \
+                --arg head "$EVENT_HEAD_SHA" \
+                --arg repo "$REPOSITORY" \
+                '(.state == "open") and (.draft == false)
+                 and (.base.ref == "main") and (.base.sha == $base)
+                 and (.head.ref == "develop") and (.head.sha == $head)
+                 and (.head.repo.full_name == $repo)' \
+                live-pull.json >/dev/null
+            fi
             python3 policy/scripts/main-promotion-authorization.py \
               --pull live-pull.json \
               --environment live-environment.json \
               --repository "$REPOSITORY" \
               --expected-base "$EVENT_BASE_SHA" \
               --expected-head "$EVENT_HEAD_SHA" \
-              --base-root policy \
-              --head-root candidate \
+              "${policy_root_args[@]}" \
               --expected-mode "$EXPECTED_MODE"
           fi
           {

--- a/changelogs/fragments/main-promotion-policy-bootstrap.yml
+++ b/changelogs/fragments/main-promotion-policy-bootstrap.yml
@@ -1,0 +1,8 @@
+---
+security_fixes:
+  - >-
+    Keep the protected main-promotion workflow compatible while the immutable
+    event base still has the preceding verifier interface. The compatibility
+    path accepts only the exact normal develop-to-main promotion and keeps
+    release and Security heads fail-closed until content verification is
+    available from main.

--- a/tests/unit/test_main_promotion_merge_gate.py
+++ b/tests/unit/test_main_promotion_merge_gate.py
@@ -66,6 +66,27 @@ class MainPromotionMergeGateTests(unittest.TestCase):
             "${{ steps.classify.outputs.environment }}",
         )
 
+    def test_policy_root_bootstrap_is_limited_to_exact_normal_develop(self) -> None:
+        jobs = load_workflow()["jobs"]
+        for job_name, step_name in (
+            ("classify", "Classify exact live pull request"),
+            ("authorize", "Revalidate exact live state after authorization"),
+        ):
+            with self.subTest(job=job_name):
+                steps = jobs[job_name]["steps"]
+                command = next(step["run"] for step in steps if step["name"] == step_name)
+                self.assertIn(
+                    "grep -Fq 'parser.add_argument(\"--base-root\"'",
+                    command,
+                )
+                self.assertIn(
+                    "policy_root_args=(--base-root policy --head-root candidate)",
+                    command,
+                )
+                self.assertIn('and (.head.ref == "develop")', command)
+                self.assertIn("and (.head.repo.full_name == $repo)", command)
+                self.assertIn('"${policy_root_args[@]}"', command)
+
     def test_final_gate_succeeds_only_when_both_upstreams_succeed(self) -> None:
         command = FINAL_STEP["run"]
         bash = shutil.which("bash")


### PR DESCRIPTION
## Summary

- preserves exact base/head content-root verification whenever the immutable base verifier supports it
- limits legacy-interface compatibility to an exact open, same-repository, non-draft `develop` to `main` promotion
- repeats the same constraint after protected environment approval
- keeps release and Security heads fail-closed until the verifier is installed in `main`

## Authorization

The owner explicitly approved this narrowly scoped protected-main workflow bootstrap correction after being informed that it changes a security-control compatibility path.

## Evidence

- targeted promotion and Security unit suite: 9 PASS
- actionlint: PASS
- Ruff format: PASS
- repository Python unit gate: PASS
- changelog policy: PASS
- yamllint: PASS
- full local pre-commit: all applicable workflow/security/quality gates passed; unrelated existing `artifacts-basic` UID mapping failed locally and Galaxy dependency lookup returned a transient API `results` error

No branch protection, environment protection, admin bypass, force push, direct protected-branch push, or release/Security exception.