### PR TITLE
fix(vault): forward guarded Terragrunt migrations

### DIFF
--- a/changelogs/fragments/vault-config-strict-terragrunt-import.yml
+++ b/changelogs/fragments/vault-config-strict-terragrunt-import.yml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - >-
+    vault_config - forward strict Terragrunt import handling through the
+    temporary runtime-variable boundary so failed state adoption stops apply.
+  - >-
+    vault_config - forward explicit state-only module upgrade migrations to the
+    Terragrunt runner while keeping target-side state as the source of truth.

--- a/roles/vault_config/defaults/main.yml
+++ b/roles/vault_config/defaults/main.yml
@@ -65,6 +65,11 @@ vault_config_tfstate_s3_insecure: "{{ not (vault_config_vault_validate_certs | b
 # Vault config is a dependency for downstream application roles. A failed
 # Terragrunt run must stop the play unless explicitly relaxed for debugging.
 vault_config_fail_on_terragrunt_error: true
+vault_config_terragrunt_import_strict: false
+vault_config_terragrunt_state_moves: []
+vault_config_terragrunt_state_removals: []
+vault_config_terragrunt_state_migration_strict: false
+vault_config_terragrunt_init_upgrade: false
 vault_config_vault_hostname: "{{ inventory_hostname }}"
 # Run Vault API calls from the same controller/EE delegate used for deployment by default.
 vault_config_api_delegate_to: >-

--- a/roles/vault_config/tasks/assert.yml
+++ b/roles/vault_config/tasks/assert.yml
@@ -12,6 +12,13 @@
       - vault_config_terraform_state_dir_local | default('', true) | trim | length > 0
       - vault_config_api_delegate_to | default('', true) | trim | length > 0
       - vault_config_vault_validate_certs is boolean
+      - vault_config_terragrunt_import_strict is boolean
+      - vault_config_terragrunt_state_moves is sequence
+      - vault_config_terragrunt_state_moves is not string
+      - vault_config_terragrunt_state_removals is sequence
+      - vault_config_terragrunt_state_removals is not string
+      - vault_config_terragrunt_state_migration_strict is boolean
+      - vault_config_terragrunt_init_upgrade is boolean
       - vault_config_api_ca_cert_path is string
       - >-
         vault_config_api_ca_cert_path | length == 0

--- a/roles/vault_config/tasks/config.yml
+++ b/roles/vault_config/tasks/config.yml
@@ -666,16 +666,15 @@
               terragrunt_vault_addr: "{{ vault_config_vault_address }}"
               terragrunt_vault_validate_certs: {{ vault_config_vault_validate_certs | bool | to_json }}
               terragrunt_imports: {{ vault_config_terragrunt_imports | default([], true) | to_json }}
-              terragrunt_import_strict: {{ terragrunt_import_strict | default(false) | bool | to_json }}
+              terragrunt_import_strict: {{ vault_config_terragrunt_import_strict | bool | to_json }}
               terragrunt_state_moves: {{ vault_config_terragrunt_state_moves | default([], true) | to_json }}
               terragrunt_state_removals: {{ vault_config_terragrunt_state_removals | default([], true) | to_json }}
               terragrunt_state_migration_strict: {{
-                terragrunt_state_migration_strict
-                | default(false)
+                vault_config_terragrunt_state_migration_strict
                 | bool
                 | to_json
               }}
-              terragrunt_init_upgrade: {{ terragrunt_init_upgrade | default(false) | bool | to_json }}
+              terragrunt_init_upgrade: {{ vault_config_terragrunt_init_upgrade | bool | to_json }}
               terragrunt_delegate_to: "localhost"
           delegate_to: localhost
           become: false

--- a/roles/vault_config/tasks/config.yml
+++ b/roles/vault_config/tasks/config.yml
@@ -666,6 +666,16 @@
               terragrunt_vault_addr: "{{ vault_config_vault_address }}"
               terragrunt_vault_validate_certs: {{ vault_config_vault_validate_certs | bool | to_json }}
               terragrunt_imports: {{ vault_config_terragrunt_imports | default([], true) | to_json }}
+              terragrunt_import_strict: {{ terragrunt_import_strict | default(false) | bool | to_json }}
+              terragrunt_state_moves: {{ vault_config_terragrunt_state_moves | default([], true) | to_json }}
+              terragrunt_state_removals: {{ vault_config_terragrunt_state_removals | default([], true) | to_json }}
+              terragrunt_state_migration_strict: {{
+                terragrunt_state_migration_strict
+                | default(false)
+                | bool
+                | to_json
+              }}
+              terragrunt_init_upgrade: {{ terragrunt_init_upgrade | default(false) | bool | to_json }}
               terragrunt_delegate_to: "localhost"
           delegate_to: localhost
           become: false

--- a/tests/unit/roles/test_vault_config_terragrunt_runtime.py
+++ b/tests/unit/roles/test_vault_config_terragrunt_runtime.py
@@ -1,14 +1,19 @@
 from pathlib import Path
 
+import yaml
+
 ROOT = Path(__file__).resolve().parents[3]
 
 
 def test_vault_config_forwards_strict_import_mode():
+    defaults = yaml.safe_load((ROOT / "roles/vault_config/defaults/main.yml").read_text(encoding="utf-8"))
     tasks = (ROOT / "roles/vault_config/tasks/config.yml").read_text(encoding="utf-8")
 
-    assert ("terragrunt_import_strict: {{ terragrunt_import_strict | default(false) | bool | to_json }}") in tasks
+    assert defaults["vault_config_terragrunt_import_strict"] is False
+    assert defaults["vault_config_terragrunt_state_migration_strict"] is False
+    assert defaults["vault_config_terragrunt_init_upgrade"] is False
+    assert "terragrunt_import_strict: {{ vault_config_terragrunt_import_strict" in tasks
     assert "terragrunt_state_moves: {{ vault_config_terragrunt_state_moves" in tasks
     assert "terragrunt_state_removals: {{ vault_config_terragrunt_state_removals" in tasks
-    assert "terragrunt_state_migration_strict: {{" in tasks
-    assert "terragrunt_state_migration_strict\n                | default(false)" in tasks
-    assert "terragrunt_init_upgrade: {{ terragrunt_init_upgrade" in tasks
+    assert "vault_config_terragrunt_state_migration_strict" in tasks
+    assert "terragrunt_init_upgrade: {{ vault_config_terragrunt_init_upgrade" in tasks

--- a/tests/unit/roles/test_vault_config_terragrunt_runtime.py
+++ b/tests/unit/roles/test_vault_config_terragrunt_runtime.py
@@ -5,9 +5,10 @@ import yaml
 ROOT = Path(__file__).resolve().parents[3]
 
 
-def test_vault_config_forwards_strict_import_mode():
+def test_vault_config_forwards_guarded_terragrunt_runtime_inputs():
     defaults = yaml.safe_load((ROOT / "roles/vault_config/defaults/main.yml").read_text(encoding="utf-8"))
     tasks = (ROOT / "roles/vault_config/tasks/config.yml").read_text(encoding="utf-8")
+    assertions = (ROOT / "roles/vault_config/tasks/assert.yml").read_text(encoding="utf-8")
 
     assert defaults["vault_config_terragrunt_import_strict"] is False
     assert defaults["vault_config_terragrunt_state_migration_strict"] is False
@@ -15,5 +16,14 @@ def test_vault_config_forwards_strict_import_mode():
     assert "terragrunt_import_strict: {{ vault_config_terragrunt_import_strict" in tasks
     assert "terragrunt_state_moves: {{ vault_config_terragrunt_state_moves" in tasks
     assert "terragrunt_state_removals: {{ vault_config_terragrunt_state_removals" in tasks
+    assert "terragrunt_state_migration_strict: {{" in tasks
     assert "vault_config_terragrunt_state_migration_strict" in tasks
     assert "terragrunt_init_upgrade: {{ vault_config_terragrunt_init_upgrade" in tasks
+    for variable in (
+        "vault_config_terragrunt_import_strict",
+        "vault_config_terragrunt_state_moves",
+        "vault_config_terragrunt_state_removals",
+        "vault_config_terragrunt_state_migration_strict",
+        "vault_config_terragrunt_init_upgrade",
+    ):
+        assert variable in assertions

--- a/tests/unit/roles/test_vault_config_terragrunt_runtime.py
+++ b/tests/unit/roles/test_vault_config_terragrunt_runtime.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_vault_config_forwards_strict_import_mode():
+    tasks = (ROOT / "roles/vault_config/tasks/config.yml").read_text(encoding="utf-8")
+
+    assert ("terragrunt_import_strict: {{ terragrunt_import_strict | default(false) | bool | to_json }}") in tasks
+    assert "terragrunt_state_moves: {{ vault_config_terragrunt_state_moves" in tasks
+    assert "terragrunt_state_removals: {{ vault_config_terragrunt_state_removals" in tasks
+    assert "terragrunt_state_migration_strict: {{" in tasks
+    assert "terragrunt_state_migration_strict\n                | default(false)" in tasks
+    assert "terragrunt_init_upgrade: {{ terragrunt_init_upgrade" in tasks


### PR DESCRIPTION
Forwards strict imports, explicit state-only moves and removals, and opt-in provider lock upgrade through the Vault configuration runtime boundary. Focused unit test passed. Clean pre-commit passed for all non-Molecule hooks; the relevant vault-config-basic Molecule scenario passed including idempotence. The unrelated full Molecule matrix is not claimed because artifacts-basic cannot resolve host UID 501 in the macOS container environment. Work item LI-139 / Goal 07. Risk high; state collisions and non-preserving removals remain fail closed.