### PR TITLE
fix(vault): guard local state path fallback

### DIFF
--- a/changelogs/fragments/vault-config-state-path-default.yml
+++ b/changelogs/fragments/vault-config-state-path-default.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Guard the Vault deploy flavour while resolving the controller-local
+    Terraform state fallback so an inventory-provided state path remains
+    usable when no deploy flavour is defined.

--- a/roles/vault_config/defaults/main.yml
+++ b/roles/vault_config/defaults/main.yml
@@ -24,7 +24,12 @@ vault_config_tfstate_key_prefix_default: ""
 vault_config_terraform_state_path_local: >-
   {{
     vault_terraform_state_path
-    | default('/tmp/' ~ vault_deploy_flavour ~ '/bootstrap/terraform.tfstate', true)
+    | default(
+        '/tmp/'
+        ~ (vault_deploy_flavour | default('vault', true))
+        ~ '/bootstrap/terraform.tfstate',
+        true
+      )
   }}
 vault_config_terraform_state_dir_local: "{{ vault_config_terraform_state_path_local | dirname }}"
 

--- a/tests/unit/roles/test_vault_config_terragrunt_runtime.py
+++ b/tests/unit/roles/test_vault_config_terragrunt_runtime.py
@@ -27,3 +27,9 @@ def test_vault_config_forwards_guarded_terragrunt_runtime_inputs():
         "vault_config_terragrunt_init_upgrade",
     ):
         assert variable in assertions
+
+
+def test_vault_config_local_state_fallback_guards_deploy_flavour():
+    defaults_text = (ROOT / "roles/vault_config/defaults/main.yml").read_text(encoding="utf-8")
+
+    assert "vault_deploy_flavour | default('vault', true)" in defaults_text


### PR DESCRIPTION
Summary:
- Guard the optional Vault deploy flavour while resolving the controller-local Terraform state fallback.
- Preserve an inventory-provided state path when no deploy flavour is defined.
- Add regression coverage and a changelog entry.

Verification:
- Unit regression tests: 2 passed.
- Ansible 2.18 role-default smoke test without vault_deploy_flavour: passed.
- Whitespace validation: passed.

This fixes the pre-change failure encountered by the authorized Wunderbox Vault PKI apply. No PKI state was modified by the failed run.