### PR TITLE
fix(vault): enforce rootless ownership gates

### DIFF
--- a/changelogs/fragments/vault-raft-rootless-light-gate.yml
+++ b/changelogs/fragments/vault-raft-rootless-light-gate.yml
@@ -1,5 +1,6 @@
 ---
 bugfixes:
   - >-
-    Keep the Vault Raft restore scenario executable in the capability-minimized
-    rootless light Molecule gate while preserving root-owned production defaults.
+    Keep artifact staging and Vault Raft restore coverage executable in the
+    capability-minimized rootless light Molecule gate while preserving
+    root-owned production defaults.

--- a/changelogs/fragments/vault-raft-rootless-light-gate.yml
+++ b/changelogs/fragments/vault-raft-rootless-light-gate.yml
@@ -1,6 +1,7 @@
 ---
 bugfixes:
   - >-
-    Keep artifact staging, AAP TLS trust, and Vault Raft restore coverage
-    executable in the capability-minimized rootless light Molecule gate while
-    preserving root-owned production defaults.
+    Keep artifact staging, AAP TLS trust, Cloudflare WARP rendering, Vault
+    bootstrap, and Vault Raft restore coverage executable in the
+    capability-minimized rootless light Molecule gate while preserving
+    root-owned production defaults.

--- a/changelogs/fragments/vault-raft-rootless-light-gate.yml
+++ b/changelogs/fragments/vault-raft-rootless-light-gate.yml
@@ -1,6 +1,6 @@
 ---
 bugfixes:
   - >-
-    Keep artifact staging and Vault Raft restore coverage executable in the
-    capability-minimized rootless light Molecule gate while preserving
-    root-owned production defaults.
+    Keep artifact staging, AAP TLS trust, and Vault Raft restore coverage
+    executable in the capability-minimized rootless light Molecule gate while
+    preserving root-owned production defaults.

--- a/changelogs/fragments/vault-raft-rootless-light-gate.yml
+++ b/changelogs/fragments/vault-raft-rootless-light-gate.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - >-
+    Keep the Vault Raft restore scenario executable in the capability-minimized
+    rootless light Molecule gate while preserving root-owned production defaults.

--- a/docs/testing/role-coverage.md
+++ b/docs/testing/role-coverage.md
@@ -36,7 +36,7 @@ promotion input only and never satisfy the release-required supported-target mat
 | aap_preflight | aap | validator | experimental | — | rhel-9, rhel-10 | experimental | blocked-external-license | not-applicable | parent_component_validation | — | Red Hat Ansible Automation Platform entitlement and installer artifacts, Red Hat subscription-backed RHEL test targets | Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix. | aap-preflight-basic |
 | aap_prepare | aap | infrastructure | experimental | — | rhel-9, rhel-10 | experimental | blocked-external-license | not-applicable | parent_component_artifact_staging | artifacts | Red Hat Ansible Automation Platform entitlement and installer artifacts, Red Hat subscription-backed RHEL test targets | Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix. | aap-prepare-basic |
 | aap_secrets | aap | secret_management | experimental | — | rhel-9, rhel-10 | experimental | blocked-external-license | not-applicable | parent_component_secret_resolution | — | Red Hat Ansible Automation Platform entitlement and installer artifacts, Red Hat subscription-backed RHEL test targets | Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix. | — |
-| aap_tls | aap | infrastructure | experimental | — | rhel-9, rhel-10 | experimental | blocked-external-license | not-applicable | parent_component_tls_bootstrap | — | Red Hat Ansible Automation Platform entitlement and installer artifacts, Red Hat subscription-backed RHEL test targets | Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix. | aap-tls-basic |
+| aap_tls | aap | infrastructure | experimental | — | rhel-9, rhel-10 | experimental | blocked-external-license | not-applicable | parent_component_tls_bootstrap | — | Red Hat Ansible Automation Platform entitlement and installer artifacts, Red Hat subscription-backed RHEL test targets | Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix., Tiny uses the capability-minimized controller identity rather than the root-owned production trust-store path. | aap-tls-basic |
 | alertmanager_deploy | observability | monitoring_service | experimental | — | ubuntu-22.04, ubuntu-24.04, rhel-9 | experimental | experimental | experimental | deliver_and_verify_a_real_alert | lit.foundational.podman_systemd | — | Current Incus scenario verifies service and port state, not alert delivery. | atlas-observability-incus_heavy |
 | alloy_deploy | observability | agent | experimental | — | ubuntu-22.04, ubuntu-24.04, rhel-9 | experimental | experimental | experimental | generate_deliver_and_query_source_data | lit.foundational.kubeplay, lit.foundational.podman_systemd, loki_deploy | — | Current Incus scenario does not query delivered data from Loki. | atlas-observability-incus_heavy, wunderbox-monitoring-logging-basic |
 | artifacts | artifacts | infrastructure | experimental | — | rhel-9, ubuntu-24.04 | experimental | experimental | experimental | stage_verify_and_consume_a_real_artifact | — | — | Current scenario covers only a local source, not URL or managed-host sources. | artifacts-basic |
@@ -115,12 +115,12 @@ promotion input only and never satisfy the release-required supported-target mat
 | semaphore_cac | semaphore | configuration_as_code | experimental | — | rhel-9 | experimental | experimental | experimental | apply_query_reconcile_and_delete_api_objects | — | — | Current scenario is a syntax stub. | semaphore-cac-basic |
 | semaphore_deploy | semaphore | web_application | experimental | — | rhel-9 | experimental | experimental | experimental | browser_and_authenticated_api | postgres_deploy, lit.foundational.kubeplay | — | Current scenario is a syntax stub. | semaphore-deploy-basic |
 | vault_backup_restore | vault | backup_component | experimental | — | rhel-9 | experimental | experimental | experimental | create_backup_modify_state_restore_and_verify | vault_deploy, vault_ops, vault_validate | — | Current scenario uses a fake runtime rather than real Vault. | vault-backup-restore-basic |
-| vault_bootstrap | vault | secret_management | experimental | — | rhel-9 | experimental | experimental | experimental | initialize_authenticate_and_use_real_test_identity | vault_foundational, vault_ops | — | Current scenarios focus on local escrow contracts and a fake Vault API. | vault-bootstrap-basic, vault-ops-basic |
+| vault_bootstrap | vault | secret_management | experimental | — | rhel-9 | experimental | experimental | experimental | initialize_authenticate_and_use_real_test_identity | vault_foundational, vault_ops | — | Current scenarios focus on local escrow contracts and a fake Vault API., Tiny proves numeric ownership; root-owned production target escrow requires a privileged target. | vault-bootstrap-basic, vault-ops-basic |
 | vault_config | vault | configuration_as_code | experimental | — | rhel-9 | experimental | experimental | experimental | apply_query_reconcile_and_delete_secret_configuration | vault_bootstrap, lit.foundational.terragrunt | — | Current scenario only validates token normalization. | vault-config-basic |
 | vault_deploy | vault | secret_management | experimental | — | rhel-9 | experimental | experimental | experimental | authenticate_write_read_deny_audit_and_persist | — | — | Current scenario is a syntax stub. | vault-deploy-basic |
 | vault_foundational | vault | helper | experimental | — | rhel-9 | experimental | experimental | not-applicable | parent_component_helper | — | — | Current scenario is a syntax stub. | vault-foundational-basic |
 | vault_ops | vault | infrastructure | experimental | — | rhel-9 | experimental | experimental | experimental | restart_unseal_recovery_and_authenticated_read | vault_deploy, vault_validate, lit.foundational.kubeplay | — | Current scenario uses fake Podman and a fake Vault API. | vault-ops-basic |
-| vault_raft_snapshot | vault | backup_component | experimental | — | rhel-9 | experimental | experimental | experimental | snapshot_modify_restore_and_verify_exact_state | — | — | Current scenario uses a fake Vault API rather than an integrated-Raft cluster. | vault-raft-snapshot-basic, vault-security-lifecycle-basic |
+| vault_raft_snapshot | vault | backup_component | experimental | — | rhel-9 | experimental | experimental | experimental | snapshot_modify_restore_and_verify_exact_state | — | — | Current scenario uses a fake Vault API rather than an integrated-Raft cluster., Tiny proves numeric ownership; the root-owned production restore work root requires a privileged target. | vault-raft-snapshot-basic, vault-security-lifecycle-basic |
 | vault_scoped_approle | vault | secret_management | experimental | — | rhel-9 | experimental | experimental | experimental | authenticate_positive_and_negative_policy_workflows | — | — | Current scenario uses a fake Vault API. | vault-bootstrap-basic, vault-scoped-approle-basic, vault-security-lifecycle-basic |
 | vault_secret_bundle | vault | secret_management | experimental | — | ubuntu-24.04, rhel-9 | experimental | experimental | experimental | read_before_generate_persist_and_reuse_secret_fields | community.hashi_vault | Reachable HashiCorp Vault KV v2 service and scoped authentication | No standalone Molecule scenario exists yet. | — |
 | vault_validate | vault | validator | experimental | — | rhel-9 | experimental | experimental | not-applicable | parent_component_validation | — | — | Current scenario uses fake Podman and a fake Vault API. | vault-validate-basic |
@@ -333,7 +333,7 @@ promotion input only and never satisfy the release-required supported-target mat
 - Candidate-target execution: no runnable candidate matrix is currently declared.
 - Reports/evidence: —. Failed mandatory runs remain failures or infrastructure errors.
 - Backup/restore and upgrade behavior are support claims only when the acceptance surface or an executed scenario proves them.
-- Known limitations: Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix.
+- Known limitations: Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix., Tiny uses the capability-minimized controller identity rather than the root-owned production trust-store path.
 
 ### `alertmanager_deploy`
 
@@ -1597,7 +1597,7 @@ promotion input only and never satisfy the release-required supported-target mat
 - Candidate-target execution: no runnable candidate matrix is currently declared.
 - Reports/evidence: —. Failed mandatory runs remain failures or infrastructure errors.
 - Backup/restore and upgrade behavior are support claims only when the acceptance surface or an executed scenario proves them.
-- Known limitations: Current scenarios focus on local escrow contracts and a fake Vault API.
+- Known limitations: Current scenarios focus on local escrow contracts and a fake Vault API., Tiny proves numeric ownership; root-owned production target escrow requires a privileged target.
 
 ### `vault_config`
 
@@ -1677,7 +1677,7 @@ promotion input only and never satisfy the release-required supported-target mat
 - Candidate-target execution: no runnable candidate matrix is currently declared.
 - Reports/evidence: —. Failed mandatory runs remain failures or infrastructure errors.
 - Backup/restore and upgrade behavior are support claims only when the acceptance surface or an executed scenario proves them.
-- Known limitations: Current scenario uses a fake Vault API rather than an integrated-Raft cluster.
+- Known limitations: Current scenario uses a fake Vault API rather than an integrated-Raft cluster., Tiny proves numeric ownership; the root-owned production restore work root requires a privileged target.
 
 ### `vault_scoped_approle`
 

--- a/meta/role-coverage.yml
+++ b/meta/role-coverage.yml
@@ -385,6 +385,8 @@ roles:
       - "Red Hat subscription-backed RHEL test targets"
     known_limitations:
       - "Entitlement-gated runtime, upgrade, and recovery behavior is not executed in the public CI matrix."
+      - >-
+        Tiny uses the capability-minimized controller identity rather than the root-owned production trust-store path.
     deprecation_state: "active"
     scenario_support:
       tiny:
@@ -2222,6 +2224,8 @@ roles:
     external_dependencies: []
     known_limitations:
       - "Current scenarios focus on local escrow contracts and a fake Vault API."
+      - >-
+        Tiny proves numeric ownership; root-owned production target escrow requires a privileged target.
     deprecation_state: "active"
     scenario_support:
       tiny:
@@ -2333,6 +2337,8 @@ roles:
     external_dependencies: []
     known_limitations:
       - "Current scenario uses a fake Vault API rather than an integrated-Raft cluster."
+      - >-
+        Tiny proves numeric ownership; the root-owned production restore work root requires a privileged target.
     deprecation_state: "active"
     scenario_support:
       tiny:

--- a/molecule/aap-tls-basic/converge.yml
+++ b/molecule/aap-tls-basic/converge.yml
@@ -9,6 +9,9 @@
     aap_tls_selfsigned_delegate_to: localhost
     aap_tls_selfsigned_output_dir: "{{ aap_tls_molecule_root }}/generated"
     aap_tls_selfsigned_ca_trust_path: "{{ aap_tls_molecule_root }}/trust/aap-selfsigned-ca.crt"
+    aap_tls_selfsigned_ca_trust_owner: "{{ lookup('ansible.builtin.pipe', 'id -u') }}"
+    aap_tls_selfsigned_ca_trust_group: "{{ lookup('ansible.builtin.pipe', 'id -g') }}"
+    aap_tls_selfsigned_ca_trust_become: false
     aap_tls_selfsigned_common_name: localhost
     aap_tls_selfsigned_dns_names:
       - localhost

--- a/molecule/aap-tls-basic/converge.yml
+++ b/molecule/aap-tls-basic/converge.yml
@@ -41,6 +41,52 @@
       ansible.builtin.include_role:
         name: lit.supplementary.aap_tls
 
+    - name: Initialize invalid AAP TLS ownership rejection evidence
+      ansible.builtin.set_fact:
+        aap_tls_molecule_invalid_owner_rejected: false
+
+    - name: Exercise invalid AAP TLS ownership precheck
+      block:
+        - name: Run AAP TLS precheck with invalid trust owner
+          ansible.builtin.include_role:
+            name: lit.supplementary.aap_tls
+            tasks_from: assert.yml
+          vars:
+            aap_tls_selfsigned_ca_trust_owner: invalid-owner
+      rescue:
+        - name: Record invalid AAP TLS ownership rejection
+          ansible.builtin.set_fact:
+            aap_tls_molecule_invalid_owner_rejected: true
+
+    - name: Assert invalid AAP TLS ownership was rejected
+      ansible.builtin.assert:
+        that:
+          - aap_tls_molecule_invalid_owner_rejected
+        quiet: true
+
+    - name: Initialize non-boolean AAP TLS become rejection evidence
+      ansible.builtin.set_fact:
+        aap_tls_molecule_invalid_become_rejected: false
+
+    - name: Exercise non-boolean AAP TLS become precheck
+      block:
+        - name: Run AAP TLS precheck with non-boolean become value
+          ansible.builtin.include_role:
+            name: lit.supplementary.aap_tls
+            tasks_from: assert.yml
+          vars:
+            aap_tls_selfsigned_ca_trust_become: "false"
+      rescue:
+        - name: Record non-boolean AAP TLS become rejection
+          ansible.builtin.set_fact:
+            aap_tls_molecule_invalid_become_rejected: true
+
+    - name: Assert non-boolean AAP TLS become was rejected
+      ansible.builtin.assert:
+        that:
+          - aap_tls_molecule_invalid_become_rejected
+        quiet: true
+
     - name: Read generated AAP CA
       ansible.builtin.slurp:
         src: "{{ aap_tls_selfsigned_output_dir }}/aap-selfsigned-ca.crt"

--- a/molecule/artifacts-basic/converge.yml
+++ b/molecule/artifacts-basic/converge.yml
@@ -25,8 +25,8 @@
   roles:
     - role: lit.supplementary.artifacts
       vars:
-        artifacts_default_owner: "{{ lookup('ansible.builtin.pipe', 'id -un') }}"
-        artifacts_default_group: "{{ lookup('ansible.builtin.pipe', 'id -gn') }}"
+        artifacts_default_owner: "{{ lookup('ansible.builtin.pipe', 'id -u') }}"
+        artifacts_default_group: "{{ lookup('ansible.builtin.pipe', 'id -g') }}"
         artifacts_items:
           - name: molecule-local-artifact
             source: local

--- a/molecule/cloudflare-warp-basic/converge.yml
+++ b/molecule/cloudflare-warp-basic/converge.yml
@@ -9,6 +9,8 @@
     cloudflare_warp_install: false
     cloudflare_warp_manage_service: false
     cloudflare_warp_connection_state: ignore
+    cloudflare_warp_mdm_owner: "{{ lookup('ansible.builtin.pipe', 'id -u') }}"
+    cloudflare_warp_mdm_group: "{{ lookup('ansible.builtin.pipe', 'id -g') }}"
     cloudflare_warp_mdm_path: >-
       {{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/cloudflare-warp/mdm.xml
     cloudflare_warp_organization: molecule-test-team

--- a/molecule/vault-bootstrap-basic/converge.yml
+++ b/molecule/vault-bootstrap-basic/converge.yml
@@ -22,6 +22,8 @@
       {{ vault_bootstrap_molecule_strict_root }}/target
     vault_bootstrap_molecule_target_file: >-
       {{ vault_bootstrap_molecule_target_dir }}/vault-init.yml.vault
+    vault_bootstrap_target_escrow_owner: "{{ lookup('ansible.builtin.pipe', 'id -u') }}"
+    vault_bootstrap_target_escrow_group: "{{ lookup('ansible.builtin.pipe', 'id -g') }}"
     vault_bootstrap_molecule_scoped_ca_file: >-
       {{ vault_bootstrap_molecule_controller_root }}/scoped-ca.pem
     vault_bootstrap_molecule_scoped_document: >-
@@ -549,8 +551,8 @@
           ansible.builtin.copy:
             dest: "{{ vault_bootstrap_molecule_target_file }}"
             content: "unit-test-only-ciphertext-drift\n"
-            owner: root
-            group: root
+            owner: "{{ vault_bootstrap_target_escrow_owner }}"
+            group: "{{ vault_bootstrap_target_escrow_group }}"
             mode: "0600"
           no_log: true
 

--- a/molecule/vault-bootstrap-basic/converge.yml
+++ b/molecule/vault-bootstrap-basic/converge.yml
@@ -208,6 +208,8 @@
         vault_bootstrap_molecule_key_linebreak_refused: false
         vault_bootstrap_molecule_target_drift_refused: false
         vault_bootstrap_molecule_sibling_prefix_refused: false
+        vault_bootstrap_molecule_invalid_target_owner_refused: false
+        vault_bootstrap_molecule_invalid_target_group_refused: false
       changed_when: false
 
     - name: Ensure the approved test controller escrow hierarchy exists
@@ -590,6 +592,67 @@
             vault_bootstrap_controller_escrow_result: "{{ vault_bootstrap_molecule_controller_escrow_result }}"
           no_log: true
 
+    - name: Reject an invalid target escrow owner
+      block:
+        - name: Exercise the invalid target escrow owner gate
+          ansible.builtin.include_role:
+            name: lit.supplementary.vault_bootstrap
+            tasks_from: controller_escrow_sync
+          vars:
+            vault_bootstrap_target_escrow_owner: invalid-owner
+            vault_bootstrap_controller_init_file_path: "{{ vault_bootstrap_molecule_controller_file }}"
+            vault_bootstrap_persist_dir: "{{ vault_bootstrap_molecule_target_dir }}"
+            vault_bootstrap_init_file_path: "{{ vault_bootstrap_molecule_target_file }}"
+            vault_bootstrap_controller_escrow_result: "{{ vault_bootstrap_molecule_controller_escrow_result }}"
+          no_log: true
+      rescue:
+        - name: Record invalid target escrow owner refusal
+          ansible.builtin.set_fact:
+            vault_bootstrap_molecule_invalid_target_owner_refused: true
+          changed_when: false
+
+    - name: Reject an invalid target escrow group
+      block:
+        - name: Exercise the invalid target escrow group gate
+          ansible.builtin.include_role:
+            name: lit.supplementary.vault_bootstrap
+            tasks_from: controller_escrow_sync
+          vars:
+            vault_bootstrap_target_escrow_group: invalid-group
+            vault_bootstrap_controller_init_file_path: "{{ vault_bootstrap_molecule_controller_file }}"
+            vault_bootstrap_persist_dir: "{{ vault_bootstrap_molecule_target_dir }}"
+            vault_bootstrap_init_file_path: "{{ vault_bootstrap_molecule_target_file }}"
+            vault_bootstrap_controller_escrow_result: "{{ vault_bootstrap_molecule_controller_escrow_result }}"
+          no_log: true
+      rescue:
+        - name: Record invalid target escrow group refusal
+          ansible.builtin.set_fact:
+            vault_bootstrap_molecule_invalid_target_group_refused: true
+          changed_when: false
+
+    - name: Inspect the numeric-owned target escrow
+      ansible.builtin.stat:
+        path: "{{ item }}"
+        follow: false
+      loop:
+        - "{{ vault_bootstrap_molecule_target_dir }}"
+        - "{{ vault_bootstrap_molecule_target_file }}"
+      register: vault_bootstrap_molecule_target_escrow_stats
+      changed_when: false
+      no_log: true
+
+    - name: Require exact numeric target escrow ownership and modes
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists | default(false)
+          - not (item.stat.islnk | default(false))
+          - item.stat.uid | string == vault_bootstrap_target_escrow_owner | string
+          - item.stat.gid | string == vault_bootstrap_target_escrow_group | string
+          - item.stat.mode == ('0700' if item.item == vault_bootstrap_molecule_target_dir else '0600')
+        quiet: true
+      loop: "{{ vault_bootstrap_molecule_target_escrow_stats.results }}"
+      no_log: true
+
     - name: Require strict path, password, state, and drift gates
       ansible.builtin.assert:
         that:
@@ -600,6 +663,8 @@
           - vault_bootstrap_molecule_password_fallback_refused | bool
           - vault_bootstrap_molecule_payload_drift_refused | bool
           - vault_bootstrap_molecule_key_linebreak_refused | bool
+          - vault_bootstrap_molecule_invalid_target_owner_refused | bool
+          - vault_bootstrap_molecule_invalid_target_group_refused | bool
           - >-
             vault_bootstrap_molecule_plaintext_header_refused | bool
             or vault_bootstrap_molecule_strict_marker_stat.stat.exists | default(false)

--- a/molecule/vault-raft-snapshot-basic/converge.yml
+++ b/molecule/vault-raft-snapshot-basic/converge.yml
@@ -59,11 +59,12 @@
     vault_raft_snapshot_restore_cluster_port: 18222
     vault_raft_snapshot_restore_work_root: /run/lit-vault-raft-molecule
     vault_raft_snapshot_restore_container_name: molecule-vault-raft-restore
-    # This scenario exercises the role locally inside the capability-minimized
-    # devtools container. Keep its fake runtime directories owned by the
-    # invoking container user; production targets retain the role defaults.
-    vault_raft_snapshot_restore_run_as_user: 0
-    vault_raft_snapshot_restore_run_as_group: 0
+    # The capability-minimized devtools controller cannot chown. Production
+    # targets retain the root-owned work-root defaults.
+    vault_raft_snapshot_restore_work_root_owner: "{{ lookup('ansible.builtin.pipe', 'id -u') }}"
+    vault_raft_snapshot_restore_work_root_group: "{{ lookup('ansible.builtin.pipe', 'id -g') }}"
+    vault_raft_snapshot_restore_run_as_user: "{{ lookup('ansible.builtin.pipe', 'id -u') }}"
+    vault_raft_snapshot_restore_run_as_group: "{{ lookup('ansible.builtin.pipe', 'id -g') }}"
     vault_raft_snapshot_production_cert_dir: "{{ vault_raft_snapshot_molecule_root }}"
     vault_raft_snapshot_restore_node_id: molecule-restore
     vault_raft_snapshot_restore_unseal_keys:

--- a/molecule/vault-raft-snapshot-basic/converge.yml
+++ b/molecule/vault-raft-snapshot-basic/converge.yml
@@ -166,6 +166,46 @@
           - vault_raft_snapshot_molecule_nonlocal_hostname_refused | bool
         quiet: true
 
+    - name: Initialize invalid restore work-root ownership refusals
+      ansible.builtin.set_fact:
+        vault_raft_snapshot_molecule_invalid_work_root_owner_refused: false
+        vault_raft_snapshot_molecule_invalid_work_root_group_refused: false
+
+    - name: Reject an invalid restore work-root owner
+      block:
+        - name: Exercise the invalid restore work-root owner gate
+          ansible.builtin.include_role:
+            name: lit.supplementary.vault_raft_snapshot
+            tasks_from: assert
+          vars:
+            vault_raft_snapshot_restore_work_root_owner: invalid-owner
+          no_log: true
+      rescue:
+        - name: Record invalid restore work-root owner refusal
+          ansible.builtin.set_fact:
+            vault_raft_snapshot_molecule_invalid_work_root_owner_refused: true
+
+    - name: Reject an invalid restore work-root group
+      block:
+        - name: Exercise the invalid restore work-root group gate
+          ansible.builtin.include_role:
+            name: lit.supplementary.vault_raft_snapshot
+            tasks_from: assert
+          vars:
+            vault_raft_snapshot_restore_work_root_group: invalid-group
+          no_log: true
+      rescue:
+        - name: Record invalid restore work-root group refusal
+          ansible.builtin.set_fact:
+            vault_raft_snapshot_molecule_invalid_work_root_group_refused: true
+
+    - name: Require invalid restore work-root ownership refusals
+      ansible.builtin.assert:
+        that:
+          - vault_raft_snapshot_molecule_invalid_work_root_owner_refused | bool
+          - vault_raft_snapshot_molecule_invalid_work_root_group_refused | bool
+        quiet: true
+
     - name: Create Vault Raft snapshot test directory
       ansible.builtin.file:
         path: "{{ item }}"

--- a/roles/aap_tls/README.md
+++ b/roles/aap_tls/README.md
@@ -27,6 +27,11 @@ assets are supplied instead.
   managed AAP host trust store and refreshes system trust; defaults to `true`.
   Generation may remain delegated to the controller because the role transfers
   the public CA certificate to the managed host before installation.
+- `aap_tls_selfsigned_ca_trust_owner`,
+  `aap_tls_selfsigned_ca_trust_group`, and
+  `aap_tls_selfsigned_ca_trust_become` retain the production defaults
+  `root`, `root`, and `true`. Numeric ownership with privilege escalation
+  disabled is reserved for capability-minimized test controllers.
 
 See [`defaults/main.yml`](defaults/main.yml) for the complete interface.
 

--- a/roles/aap_tls/defaults/main.yml
+++ b/roles/aap_tls/defaults/main.yml
@@ -18,3 +18,6 @@ aap_tls_selfsigned_key_size: 4096
 aap_tls_selfsigned_force: false
 aap_tls_selfsigned_install_ca_trust: true
 aap_tls_selfsigned_ca_trust_path: /etc/pki/ca-trust/source/anchors/aap-selfsigned-ca.crt
+aap_tls_selfsigned_ca_trust_owner: root
+aap_tls_selfsigned_ca_trust_group: root
+aap_tls_selfsigned_ca_trust_become: true

--- a/roles/aap_tls/handlers/main.yml
+++ b/roles/aap_tls/handlers/main.yml
@@ -2,5 +2,5 @@
 - name: Refresh system CA trust after installing temporary AAP CA
   ansible.builtin.command:
     cmd: update-ca-trust extract
-  become: true
+  become: "{{ aap_tls_selfsigned_ca_trust_become }}"
   changed_when: true

--- a/roles/aap_tls/tasks/assert.yml
+++ b/roles/aap_tls/tasks/assert.yml
@@ -4,11 +4,14 @@
     that:
       - >-
         (aap_tls_selfsigned_ca_trust_owner | string) == 'root' or
-        (aap_tls_selfsigned_ca_trust_owner | string) is regex('^[0-9]+$')
+        (aap_tls_selfsigned_ca_trust_owner | string) is match('^[0-9]+$')
       - >-
         (aap_tls_selfsigned_ca_trust_group | string) == 'root' or
-        (aap_tls_selfsigned_ca_trust_group | string) is regex('^[0-9]+$')
+        (aap_tls_selfsigned_ca_trust_group | string) is match('^[0-9]+$')
       - aap_tls_selfsigned_ca_trust_become is boolean
+    fail_msg: >-
+      AAP TLS trust ownership must be root or a numeric ID, and trust
+      installation privilege escalation must be boolean.
     quiet: true
   when:
     - aap_tls_selfsigned_enabled | bool

--- a/roles/aap_tls/tasks/assert.yml
+++ b/roles/aap_tls/tasks/assert.yml
@@ -1,0 +1,15 @@
+---
+- name: Validate temporary AAP CA trust installation settings
+  ansible.builtin.assert:
+    that:
+      - >-
+        (aap_tls_selfsigned_ca_trust_owner | string) == 'root' or
+        (aap_tls_selfsigned_ca_trust_owner | string) is regex('^[0-9]+$')
+      - >-
+        (aap_tls_selfsigned_ca_trust_group | string) == 'root' or
+        (aap_tls_selfsigned_ca_trust_group | string) is regex('^[0-9]+$')
+      - aap_tls_selfsigned_ca_trust_become is boolean
+    quiet: true
+  when:
+    - aap_tls_selfsigned_enabled | bool
+    - aap_tls_selfsigned_install_ca_trust | bool

--- a/roles/aap_tls/tasks/main.yml
+++ b/roles/aap_tls/tasks/main.yml
@@ -5,6 +5,21 @@
   changed_when: false
   when: not (aap_tls_selfsigned_enabled | bool)
 
+- name: Validate temporary AAP CA trust installation settings
+  ansible.builtin.assert:
+    that:
+      - >-
+        (aap_tls_selfsigned_ca_trust_owner | string) == 'root' or
+        (aap_tls_selfsigned_ca_trust_owner | string) is regex('^[0-9]+$')
+      - >-
+        (aap_tls_selfsigned_ca_trust_group | string) == 'root' or
+        (aap_tls_selfsigned_ca_trust_group | string) is regex('^[0-9]+$')
+      - aap_tls_selfsigned_ca_trust_become is boolean
+    quiet: true
+  when:
+    - aap_tls_selfsigned_enabled | bool
+    - aap_tls_selfsigned_install_ca_trust | bool
+
 - name: Ensure temporary TLS output directory exists
   ansible.builtin.file:
     path: "{{ aap_tls_selfsigned_output_dir }}"
@@ -178,10 +193,10 @@
   ansible.builtin.copy:
     content: "{{ aap_tls_selfsigned_ca_content.content | b64decode }}"
     dest: "{{ aap_tls_selfsigned_ca_trust_path }}"
-    owner: root
-    group: root
+    owner: "{{ aap_tls_selfsigned_ca_trust_owner }}"
+    group: "{{ aap_tls_selfsigned_ca_trust_group }}"
     mode: "0644"
-  become: true
+  become: "{{ aap_tls_selfsigned_ca_trust_become }}"
   notify: Refresh system CA trust after installing temporary AAP CA
   when:
     - aap_tls_selfsigned_enabled | bool

--- a/roles/aap_tls/tasks/main.yml
+++ b/roles/aap_tls/tasks/main.yml
@@ -1,24 +1,13 @@
 ---
+- name: Prechecks
+  ansible.builtin.import_tasks: assert.yml
+  tags: always
+
 - name: Skip temporary self-signed TLS generation when disabled
   ansible.builtin.debug:
     msg: "AAP temporary self-signed TLS generation skipped."
   changed_when: false
   when: not (aap_tls_selfsigned_enabled | bool)
-
-- name: Validate temporary AAP CA trust installation settings
-  ansible.builtin.assert:
-    that:
-      - >-
-        (aap_tls_selfsigned_ca_trust_owner | string) == 'root' or
-        (aap_tls_selfsigned_ca_trust_owner | string) is regex('^[0-9]+$')
-      - >-
-        (aap_tls_selfsigned_ca_trust_group | string) == 'root' or
-        (aap_tls_selfsigned_ca_trust_group | string) is regex('^[0-9]+$')
-      - aap_tls_selfsigned_ca_trust_become is boolean
-    quiet: true
-  when:
-    - aap_tls_selfsigned_enabled | bool
-    - aap_tls_selfsigned_install_ca_trust | bool
 
 - name: Ensure temporary TLS output directory exists
   ansible.builtin.file:

--- a/roles/vault_bootstrap/README.md
+++ b/roles/vault_bootstrap/README.md
@@ -27,6 +27,9 @@ Key variables:
 - `vault_bootstrap_ansible_vault_password_file`: controller password file; defaults to
   `ANSIBLE_VAULT_PASSWORD_FILE` and is preferred over copying a plaintext password.
 - `vault_bootstrap_ansible_vault_password`: compatibility fallback mapped from `vault_ansible_vault_pw`.
+- `vault_bootstrap_target_escrow_owner` and `vault_bootstrap_target_escrow_group`: expected owner and group for the
+  ciphertext-only target secondary. Both default to `root`; numeric identities are supported for explicitly
+  capability-minimized test controllers without weakening the metadata, mode, link-count, or checksum gates.
 - `vault_bootstrap_ca_cert_path`: trusted CA bundle on `vault_bootstrap_api_delegate_to` for HTTPS API checks.
 - `vault_bootstrap_cli_api_url` and `vault_bootstrap_cli_ca_cert_path`: the verified in-container API URL and CA
   bundle used by `vault operator init`.

--- a/roles/vault_bootstrap/defaults/main.yml
+++ b/roles/vault_bootstrap/defaults/main.yml
@@ -36,6 +36,8 @@ vault_bootstrap_persist_dir: >-
   {{ vault_deploy_bootstrap_persist_dir | default('/srv/' ~ vault_deploy_flavour ~ '/bootstrap', true) }}
 vault_bootstrap_init_file_path: >-
   {{ vault_deploy_init_file_path | default(vault_bootstrap_persist_dir ~ '/vault-init.yml.vault', true) }}
+vault_bootstrap_target_escrow_owner: root
+vault_bootstrap_target_escrow_group: root
 
 # Optional strict topology-neutral controller escrow. The controller document is
 # authoritative; vault_bootstrap_init_file_path is a ciphertext-only secondary copy.

--- a/roles/vault_bootstrap/tasks/controller_escrow_sync.yml
+++ b/roles/vault_bootstrap/tasks/controller_escrow_sync.yml
@@ -1,4 +1,16 @@
 ---
+- name: Validate target secondary escrow ownership
+  ansible.builtin.assert:
+    that:
+      - >-
+        (vault_bootstrap_target_escrow_owner | string) == 'root' or
+        (vault_bootstrap_target_escrow_owner | string) is regex('^[0-9]+$')
+      - >-
+        (vault_bootstrap_target_escrow_group | string) == 'root' or
+        (vault_bootstrap_target_escrow_group | string) is regex('^[0-9]+$')
+    quiet: true
+  no_log: true
+
 - name: Inspect the target secondary escrow directory
   ansible.builtin.stat:
     path: "{{ vault_bootstrap_persist_dir }}"
@@ -15,8 +27,16 @@
     that:
       - vault_bootstrap_target_persist_dir_stat.stat.isdir | default(false)
       - not (vault_bootstrap_target_persist_dir_stat.stat.islnk | default(false))
-      - vault_bootstrap_target_persist_dir_stat.stat.uid | default(-1) | int == 0
-      - vault_bootstrap_target_persist_dir_stat.stat.gid | default(-1) | int == 0
+      - >-
+        vault_bootstrap_target_persist_dir_stat.stat.pw_name | default('')
+        == vault_bootstrap_target_escrow_owner | string
+        or vault_bootstrap_target_persist_dir_stat.stat.uid | default(-1) | string
+        == vault_bootstrap_target_escrow_owner | string
+      - >-
+        vault_bootstrap_target_persist_dir_stat.stat.gr_name | default('')
+        == vault_bootstrap_target_escrow_group | string
+        or vault_bootstrap_target_persist_dir_stat.stat.gid | default(-1) | string
+        == vault_bootstrap_target_escrow_group | string
       - vault_bootstrap_target_persist_dir_stat.stat.mode | default('') == '0700'
     fail_msg: "The existing target secondary escrow directory has unsafe metadata."
     quiet: true
@@ -27,8 +47,8 @@
   ansible.builtin.file:
     path: "{{ vault_bootstrap_persist_dir }}"
     state: directory
-    owner: root
-    group: root
+    owner: "{{ vault_bootstrap_target_escrow_owner }}"
+    group: "{{ vault_bootstrap_target_escrow_group }}"
     mode: "0700"
   when: not (vault_bootstrap_target_persist_dir_stat.stat.exists | default(false))
   no_log: true
@@ -49,8 +69,16 @@
     that:
       - vault_bootstrap_target_init_file_stat.stat.isreg | default(false)
       - not (vault_bootstrap_target_init_file_stat.stat.islnk | default(false))
-      - vault_bootstrap_target_init_file_stat.stat.uid | default(-1) | int == 0
-      - vault_bootstrap_target_init_file_stat.stat.gid | default(-1) | int == 0
+      - >-
+        vault_bootstrap_target_init_file_stat.stat.pw_name | default('')
+        == vault_bootstrap_target_escrow_owner | string
+        or vault_bootstrap_target_init_file_stat.stat.uid | default(-1) | string
+        == vault_bootstrap_target_escrow_owner | string
+      - >-
+        vault_bootstrap_target_init_file_stat.stat.gr_name | default('')
+        == vault_bootstrap_target_escrow_group | string
+        or vault_bootstrap_target_init_file_stat.stat.gid | default(-1) | string
+        == vault_bootstrap_target_escrow_group | string
       - vault_bootstrap_target_init_file_stat.stat.mode | default('') == '0600'
       - vault_bootstrap_target_init_file_stat.stat.nlink | default(0) | int == 1
       - vault_bootstrap_target_init_file_stat.stat.size | default(0) | int > 0
@@ -65,8 +93,8 @@
   ansible.builtin.copy:
     src: "{{ vault_bootstrap_controller_init_file_path }}"
     dest: "{{ vault_bootstrap_init_file_path }}"
-    owner: root
-    group: root
+    owner: "{{ vault_bootstrap_target_escrow_owner }}"
+    group: "{{ vault_bootstrap_target_escrow_group }}"
     mode: "0600"
     force: false
     decrypt: false
@@ -91,8 +119,16 @@
       - vault_bootstrap_target_init_file_verified.stat.exists | default(false)
       - vault_bootstrap_target_init_file_verified.stat.isreg | default(false)
       - not (vault_bootstrap_target_init_file_verified.stat.islnk | default(false))
-      - vault_bootstrap_target_init_file_verified.stat.uid | default(-1) | int == 0
-      - vault_bootstrap_target_init_file_verified.stat.gid | default(-1) | int == 0
+      - >-
+        vault_bootstrap_target_init_file_verified.stat.pw_name | default('')
+        == vault_bootstrap_target_escrow_owner | string
+        or vault_bootstrap_target_init_file_verified.stat.uid | default(-1) | string
+        == vault_bootstrap_target_escrow_owner | string
+      - >-
+        vault_bootstrap_target_init_file_verified.stat.gr_name | default('')
+        == vault_bootstrap_target_escrow_group | string
+        or vault_bootstrap_target_init_file_verified.stat.gid | default(-1) | string
+        == vault_bootstrap_target_escrow_group | string
       - vault_bootstrap_target_init_file_verified.stat.mode | default('') == '0600'
       - vault_bootstrap_target_init_file_verified.stat.nlink | default(0) | int == 1
       - >-

--- a/roles/vault_bootstrap/tasks/controller_escrow_sync.yml
+++ b/roles/vault_bootstrap/tasks/controller_escrow_sync.yml
@@ -4,10 +4,11 @@
     that:
       - >-
         (vault_bootstrap_target_escrow_owner | string) == 'root' or
-        (vault_bootstrap_target_escrow_owner | string) is regex('^[0-9]+$')
+        (vault_bootstrap_target_escrow_owner | string) is match('^[0-9]+$')
       - >-
         (vault_bootstrap_target_escrow_group | string) == 'root' or
-        (vault_bootstrap_target_escrow_group | string) is regex('^[0-9]+$')
+        (vault_bootstrap_target_escrow_group | string) is match('^[0-9]+$')
+    fail_msg: "Target escrow owner and group must be root or numeric IDs."
     quiet: true
   no_log: true
 

--- a/roles/vault_raft_snapshot/README.md
+++ b/roles/vault_raft_snapshot/README.md
@@ -48,6 +48,8 @@ must remain within this enforced bound before it is read into protected memory o
 
 The controller document path is immutable. For restore, pin its SHA-256 digest with
 `vault_raft_snapshot_expected_ciphertext_sha256` before the role decrypts it.
+The isolated work root remains `root:root` by default. Its owner and group are configurable only for a
+capability-minimized test controller that cannot change ownership; production callers must retain the defaults.
 `vault_raft_snapshot_restore_tls_hostname` and `vault_raft_snapshot_restore_bind_address` are fail-closed to
 `localhost` and `127.0.0.1`, matching the operational Vault PKI contract. The role refuses alternate DNS names or
 bind addresses, derives every certificate-validated restore URL from those invariants, and disables proxy use for

--- a/roles/vault_raft_snapshot/defaults/main.yml
+++ b/roles/vault_raft_snapshot/defaults/main.yml
@@ -29,6 +29,8 @@ vault_raft_snapshot_restore_tls_hostname: localhost
 vault_raft_snapshot_restore_api_port: 18201
 vault_raft_snapshot_restore_cluster_port: 18202
 vault_raft_snapshot_restore_work_root: /run/lit-vault-restore-drill
+vault_raft_snapshot_restore_work_root_owner: root
+vault_raft_snapshot_restore_work_root_group: root
 vault_raft_snapshot_restore_container_name: vault-restore-drill
 vault_raft_snapshot_restore_node_id: ""
 vault_raft_snapshot_restore_run_as_user: 100

--- a/roles/vault_raft_snapshot/tasks/assert.yml
+++ b/roles/vault_raft_snapshot/tasks/assert.yml
@@ -77,6 +77,12 @@
         vault_raft_snapshot_restore_api_port | int
         != vault_raft_snapshot_restore_cluster_port | int
       - vault_raft_snapshot_restore_work_root is match('^/run/[A-Za-z0-9._-]+$')
+      - >-
+        vault_raft_snapshot_restore_work_root_owner | string
+        is match('^(root|[0-9]+)$')
+      - >-
+        vault_raft_snapshot_restore_work_root_group | string
+        is match('^(root|[0-9]+)$')
       - vault_raft_snapshot_restore_container_name is match('^[A-Za-z0-9][A-Za-z0-9._-]+$')
       - vault_raft_snapshot_restore_node_id is match('^[A-Za-z0-9][A-Za-z0-9._-]+$')
       - vault_raft_snapshot_restore_timeout is integer

--- a/roles/vault_raft_snapshot/tasks/restore_drill.yml
+++ b/roles/vault_raft_snapshot/tasks/restore_drill.yml
@@ -148,8 +148,8 @@
     mode: "{{ item.mode }}"
   loop:
     - path: "{{ vault_raft_snapshot_restore_work_root }}"
-      owner: root
-      group: root
+      owner: "{{ vault_raft_snapshot_restore_work_root_owner }}"
+      group: "{{ vault_raft_snapshot_restore_work_root_group }}"
       mode: "0700"
     - path: "{{ vault_raft_snapshot_restore_work_root }}/data"
       owner: "{{ vault_raft_snapshot_restore_run_as_user }}"

--- a/roles/vault_raft_snapshot/tasks/restore_drill.yml
+++ b/roles/vault_raft_snapshot/tasks/restore_drill.yml
@@ -161,6 +161,47 @@
       mode: "0700"
   no_log: true
 
+- name: Inspect isolated Vault restore-drill directory metadata
+  ansible.builtin.stat:
+    path: "{{ item.path }}"
+    follow: false
+    get_attributes: false
+    get_checksum: false
+    get_mime: false
+  loop:
+    - path: "{{ vault_raft_snapshot_restore_work_root }}"
+      owner: "{{ vault_raft_snapshot_restore_work_root_owner }}"
+      group: "{{ vault_raft_snapshot_restore_work_root_group }}"
+      mode: "0700"
+    - path: "{{ vault_raft_snapshot_restore_work_root }}/data"
+      owner: "{{ vault_raft_snapshot_restore_run_as_user }}"
+      group: "{{ vault_raft_snapshot_restore_run_as_group }}"
+      mode: "0700"
+    - path: "{{ vault_raft_snapshot_restore_work_root }}/config"
+      owner: "{{ vault_raft_snapshot_restore_run_as_user }}"
+      group: "{{ vault_raft_snapshot_restore_run_as_group }}"
+      mode: "0700"
+  register: _vault_raft_snapshot_restore_directory_stats
+  changed_when: false
+  no_log: true
+
+- name: Require exact isolated Vault restore-drill directory metadata
+  ansible.builtin.assert:
+    that:
+      - item.stat.isdir | default(false)
+      - not (item.stat.islnk | default(false))
+      - >-
+        item.stat.pw_name | default('') == item.item.owner | string
+        or item.stat.uid | default(-1) | string == item.item.owner | string
+      - >-
+        item.stat.gr_name | default('') == item.item.group | string
+        or item.stat.gid | default(-1) | string == item.item.group | string
+      - item.stat.mode | default('') == item.item.mode
+    fail_msg: "The isolated restore-drill directory has unsafe metadata."
+    quiet: true
+  loop: "{{ _vault_raft_snapshot_restore_directory_stats.results }}"
+  no_log: true
+
 - name: Run the isolated Vault Raft restore drill
   no_log: true
   block:

--- a/tests/unit/test_aap_tls_contracts.py
+++ b/tests/unit/test_aap_tls_contracts.py
@@ -14,6 +14,7 @@ class AapTlsContractsTests(unittest.TestCase):
     def test_generated_ca_is_transferred_to_managed_host_trust(self) -> None:
         defaults = (ROOT / "roles/aap_tls/defaults/main.yml").read_text(encoding="utf-8")
         tasks = (ROOT / "roles/aap_tls/tasks/main.yml").read_text(encoding="utf-8")
+        assertions = (ROOT / "roles/aap_tls/tasks/assert.yml").read_text(encoding="utf-8")
         handlers = (ROOT / "roles/aap_tls/handlers/main.yml").read_text(encoding="utf-8")
 
         self.assertIn("aap_tls_selfsigned_install_ca_trust: true", defaults)
@@ -24,6 +25,20 @@ class AapTlsContractsTests(unittest.TestCase):
         self.assertNotIn("delegate_to:", handlers)
         self.assertIn("cmd: update-ca-trust extract", handlers)
         self.assertIn("ansible.builtin.meta: flush_handlers", tasks)
+        precheck_entrypoint = "---\n- name: Prechecks\n  ansible.builtin.import_tasks: assert.yml\n  tags: always\n"
+        self.assertTrue(tasks.startswith(precheck_entrypoint))
+        self.assertIn("aap_tls_selfsigned_ca_trust_owner", assertions)
+        self.assertIn("aap_tls_selfsigned_ca_trust_group", assertions)
+        self.assertIn("aap_tls_selfsigned_ca_trust_become is boolean", assertions)
+        self.assertNotIn("Validate temporary AAP CA trust installation settings", tasks)
+
+    def test_invalid_trust_inputs_are_exercised_by_molecule(self) -> None:
+        converge = (ROOT / "molecule/aap-tls-basic/converge.yml").read_text(encoding="utf-8")
+
+        self.assertIn("aap_tls_selfsigned_ca_trust_owner: invalid-owner", converge)
+        self.assertIn('aap_tls_selfsigned_ca_trust_become: "false"', converge)
+        self.assertIn("aap_tls_molecule_invalid_owner_rejected", converge)
+        self.assertIn("aap_tls_molecule_invalid_become_rejected", converge)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_aap_tls_contracts.py
+++ b/tests/unit/test_aap_tls_contracts.py
@@ -29,7 +29,10 @@ class AapTlsContractsTests(unittest.TestCase):
         self.assertTrue(tasks.startswith(precheck_entrypoint))
         self.assertIn("aap_tls_selfsigned_ca_trust_owner", assertions)
         self.assertIn("aap_tls_selfsigned_ca_trust_group", assertions)
+        self.assertIn("is match('^[0-9]+$')", assertions)
+        self.assertNotIn("is regex(", assertions)
         self.assertIn("aap_tls_selfsigned_ca_trust_become is boolean", assertions)
+        self.assertIn("fail_msg:", assertions)
         self.assertNotIn("Validate temporary AAP CA trust installation settings", tasks)
 
     def test_invalid_trust_inputs_are_exercised_by_molecule(self) -> None:

--- a/tests/unit/test_vault_rootless_contracts.py
+++ b/tests/unit/test_vault_rootless_contracts.py
@@ -1,0 +1,46 @@
+"""Regression contracts for capability-minimized Vault test ownership."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class VaultRootlessContractsTests(unittest.TestCase):
+    def test_production_ownership_defaults_remain_root(self) -> None:
+        bootstrap_defaults = yaml.safe_load(
+            (ROOT / "roles/vault_bootstrap/defaults/main.yml").read_text(encoding="utf-8")
+        )
+        snapshot_defaults = yaml.safe_load(
+            (ROOT / "roles/vault_raft_snapshot/defaults/main.yml").read_text(encoding="utf-8")
+        )
+
+        self.assertEqual("root", bootstrap_defaults["vault_bootstrap_target_escrow_owner"])
+        self.assertEqual("root", bootstrap_defaults["vault_bootstrap_target_escrow_group"])
+        self.assertEqual("root", snapshot_defaults["vault_raft_snapshot_restore_work_root_owner"])
+        self.assertEqual("root", snapshot_defaults["vault_raft_snapshot_restore_work_root_group"])
+
+    def test_bootstrap_molecule_rejects_names_and_proves_numeric_metadata(self) -> None:
+        converge = (ROOT / "molecule/vault-bootstrap-basic/converge.yml").read_text(encoding="utf-8")
+
+        self.assertIn("vault_bootstrap_target_escrow_owner: invalid-owner", converge)
+        self.assertIn("vault_bootstrap_target_escrow_group: invalid-group", converge)
+        self.assertIn("Require exact numeric target escrow ownership and modes", converge)
+        self.assertIn("item.stat.mode == ('0700' if", converge)
+
+    def test_snapshot_molecule_and_role_enforce_exact_work_root_metadata(self) -> None:
+        converge = (ROOT / "molecule/vault-raft-snapshot-basic/converge.yml").read_text(encoding="utf-8")
+        restore = (ROOT / "roles/vault_raft_snapshot/tasks/restore_drill.yml").read_text(encoding="utf-8")
+
+        self.assertIn("vault_raft_snapshot_restore_work_root_owner: invalid-owner", converge)
+        self.assertIn("vault_raft_snapshot_restore_work_root_group: invalid-group", converge)
+        self.assertIn("Require exact isolated Vault restore-drill directory metadata", restore)
+        self.assertIn("item.stat.mode | default('') == item.item.mode", restore)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_vault_rootless_contracts.py
+++ b/tests/unit/test_vault_rootless_contracts.py
@@ -26,11 +26,15 @@ class VaultRootlessContractsTests(unittest.TestCase):
 
     def test_bootstrap_molecule_rejects_names_and_proves_numeric_metadata(self) -> None:
         converge = (ROOT / "molecule/vault-bootstrap-basic/converge.yml").read_text(encoding="utf-8")
+        escrow_sync = (ROOT / "roles/vault_bootstrap/tasks/controller_escrow_sync.yml").read_text(encoding="utf-8")
 
         self.assertIn("vault_bootstrap_target_escrow_owner: invalid-owner", converge)
         self.assertIn("vault_bootstrap_target_escrow_group: invalid-group", converge)
         self.assertIn("Require exact numeric target escrow ownership and modes", converge)
         self.assertIn("item.stat.mode == ('0700' if", converge)
+        self.assertIn("is match('^[0-9]+$')", escrow_sync)
+        self.assertNotIn("is regex(", escrow_sync)
+        self.assertIn("fail_msg:", escrow_sync)
 
     def test_snapshot_molecule_and_role_enforce_exact_work_root_metadata(self) -> None:
         converge = (ROOT / "molecule/vault-raft-snapshot-basic/converge.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- enforce root-or-numeric ownership guards for the AAP TLS and Vault role paths
- add fail-closed negative-path and runtime ownership coverage
- update generated role coverage, documentation, and changelog consistently

## Verification

- exact head `3ee38fdcbbc4b912448c300f8970df435c793b95`
- history-free Codex/GitHub-Copilot dualreview: PASS
- canonical repository-quality profile: PASS (336 tests)
- vault-bootstrap-basic and vault-raft-snapshot-basic Molecule converge/idempotence/verify: PASS

## Security

- [x] No secrets, private infrastructure data, or customer data are added.
- [x] No workflow permission changes are included.
- [x] No release or publishing behavior is changed.
