### PR TITLE
fix(push-ready): allow full quality profile runtime

### DIFF
--- a/changelogs/fragments/push-ready-quality-timeout.yml
+++ b/changelogs/fragments/push-ready-quality-timeout.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    Allow the complete fail-closed repository-quality profile up to 3600
+    seconds so its full pre-commit and supplemental rootless Molecule gates can
+    finish without weakening or skipping validation.

--- a/docs/push-ready-optimization.md
+++ b/docs/push-ready-optimization.md
@@ -21,6 +21,12 @@ python3 scripts/lit-push-ready.py push-ready
 python3 scripts/lit-push-ready.py verify
 ```
 
+The single repository-quality check has a 3600-second fail-closed timeout. This
+budget covers the complete isolated pre-commit suite plus the supplemental
+rootless Molecule parity scenario; it does not skip, shorten, or make either
+gate optional. Exceeding the budget still stops evidence creation and prevents
+the governed push.
+
 The evidence records total duration, per-reviewer duration, review bytes,
 executed and repeated checks, cache hits and misses, maximum parallelism, and
 explicit local external-review invocation counts split between Codex and

--- a/scripts/lit-push-ready.py
+++ b/scripts/lit-push-ready.py
@@ -101,7 +101,7 @@ INSTRUCTION_PATH_PATTERN = re.compile(
 MAX_CONFIG_BYTES = 1_000_000
 MAX_REVIEW_BYTES = 5_000_000
 MAX_TIMEOUT_SECONDS = 3_600
-CHECK_TIMEOUT_SECONDS = 1_800
+CHECK_TIMEOUT_SECONDS = 3_600
 AUTHORITATIVE_BASE_REFS = {
     "refs/remotes/origin/develop": "develop",
     "refs/remotes/origin/main": "main",

--- a/tests/unit/test_push_ready_engine.py
+++ b/tests/unit/test_push_ready_engine.py
@@ -25,6 +25,10 @@ def run_git(repository: Path, *args: str, environment: dict[str, str]) -> None:
 
 
 class PushReadyEngineTests(unittest.TestCase):
+    def test_repository_quality_check_has_full_profile_timeout_budget(self) -> None:
+        self.assertEqual(3_600, ENGINE["CHECK_TIMEOUT_SECONDS"])
+        self.assertLessEqual(ENGINE["CHECK_TIMEOUT_SECONDS"], ENGINE["MAX_TIMEOUT_SECONDS"])
+
     def test_trusted_policy_covers_executable_quality_scripts(self) -> None:
         trusted_paths = set(ENGINE["TRUSTED_CHECK_POLICY_PATHS"])
 


### PR DESCRIPTION
## Summary

- raise the single repository-quality check timeout from 1800 to 3600 seconds
- retain the complete pre-commit suite and supplemental rootless Molecule parity gate
- document the fail-closed budget and add focused regression coverage

## Root cause

The complete canonical profile reproducibly passed every repository gate but reached the fixed 1800-second engine
deadline while the final isolated `artifacts-basic` parity gate was installing pinned dependencies. No individual
gate failed.

## Validation

- private history-free Codex/Copilot Trust-root dual review: PASS, no findings
- complete `scripts/lit-ci-profile.sh repository-quality`: PASS
- 29 focused push-ready engine unit tests: PASS
- Ruff, format, Mypy, Markdown, and changelog checks: PASS

The change does not skip, shorten, or make any gate optional. Exceeding 3600 seconds remains fail-closed and prevents
governed evidence and push.
